### PR TITLE
Removed non-existent file in the makefile, preventing build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 CFLAGS= -O2 -Wall -Wextra -lgumbo -lcurl -lfuse -D_FILE_OFFSET_BITS=64 \
 -DHTTPDIRFS_INFO
-OBJ = main.o network.o network_multi.o
+OBJ = main.o network.o
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS)


### PR DESCRIPTION
When I tried to build the project myself, I noticed that the build was failing because the makefile was trying to link something that didn't exist. I fixed it and the changes are in the makefile.