### PR TITLE
Improved makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 CC=gcc
-CFLAGS= -g -O2 -Wall -Wextra -lgumbo -lcurl -lfuse -lcrypto \
+CFLAGS+= -g -O2 -Wall -Wextra -lgumbo -lcurl -lfuse -lcrypto \
 	-D_FILE_OFFSET_BITS=64
 OBJ = main.o network.o fuse_local.o link.o
 
 %.o: %.c
-	$(CC) -c -o $@ $< $(CFLAGS)
+	$(CC) -c -o $@ $< $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 httpdirfs: $(OBJ)
-	$(CC) -o $@ $^ $(CFLAGS)
+	$(CC) -o $@ $^ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 install:
 	cp httpdirfs ${HOME}/bin/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ CFLAGS+= -g -O2 -Wall -Wextra -lgumbo -lcurl -lfuse -lcrypto \
 	-D_FILE_OFFSET_BITS=64
 OBJ = main.o network.o fuse_local.o link.o
 
+PREFIX ?= /usr/local
+INSTALL = /usr/bin/install
+INSTALL_OPTS = -m 0755
+
 %.o: %.c
 	$(CC) -c -o $@ $< $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
@@ -10,7 +14,8 @@ httpdirfs: $(OBJ)
 	$(CC) -o $@ $^ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 install:
-	cp httpdirfs ${HOME}/bin/
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) $(INSTALL_OPTS) httpdirfs $(DESTDIR)$(PREFIX)/bin
 
 doc:
 	doxygen Doxyfile


### PR DESCRIPTION
This is required in order for the Makefile to play nice with the Debian build system.

It would also be good to have an uninstall target.