### PR TITLE
Compatibility with FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=1.0.3
 
-CFLAGS+= -g -O2 -Wall -Wextra -D_FILE_OFFSET_BITS=64 -DVERSION=\"$(VERSION)\"
-LDFLAGS+= -lgumbo -lcurl -lfuse -lcrypto
+CFLAGS+= -g -O2 -Wall -Wextra -D_FILE_OFFSET_BITS=64 -DVERSION=\"$(VERSION)\" `pkg-config --cflags-only-I gumbo libcurl fuse`
+LDFLAGS+= -lgumbo -lcurl -lfuse -lcrypto `pkg-config --libs-only-L gumbo libcurl fuse`
 COBJS = main.o network.o fuse_local.o link.o
 
 prefix ?= /usr/local

--- a/src/main.c
+++ b/src/main.c
@@ -5,7 +5,11 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
-#include <linux/limits.h>
+#ifdef __FreeBSD__
+    #include <limits.h>
+#else
+    #include <linux/limits.h>
+#endif
 
 #define ARG_LEN_MAX 64
 


### PR DESCRIPTION
It does add a dependency for pkg-config, but it is the cleanest way of making sure the ldflags and cflags are given the correct lib locations for the platform. 

Likewise with the macro in main.c, it's probably ok to assume linux is the default OS. I'm explicitly checking for freebsd, but perhaps it would be better to check if not linux?