### PR TITLE
Cache system bug fix

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -1,9 +1,14 @@
 #ifndef CACHE_H
 #define CACHE_H
 
-#include "link.h"
-
 #include <pthread.h>
+
+/**
+ * \brief cache data type
+ */
+typedef struct Cache Cache;
+
+#include "link.h"
 
 /**
  * \file cache.h
@@ -19,9 +24,9 @@
 typedef uint8_t Seg;
 
 /**
- * \brief cache in-memory data structure
+ * \brief cache data type in-memory data structure
  */
-typedef struct {
+struct Cache {
     char *path; /**< the path to the file on the web server */
     Link *link; /**< the Link associated with this cache data set */
     long time; /**<the modified time of the file */
@@ -41,7 +46,7 @@ typedef struct {
     int blksz; /**<the block size of the data file */
     long segbc; /**<segment array byte count */
     Seg *seg; /**< the detail of each segment */
-} Cache;
+};
 
 /**
  * \brief whether the cache system is enabled

--- a/src/link.c
+++ b/src/link.c
@@ -15,7 +15,8 @@
 LinkTable *ROOT_LINK_TBL = NULL;
 int ROOT_LINK_OFFSET = 0;
 
-/* ----------------- Static variable ----------------------- */
+/* ----------------- Static variables ----------------------- */
+
 /**
  * \brief LinkTable generation priority lock
  * \details This allows LinkTable generation to be run exclusively. This
@@ -584,16 +585,13 @@ long path_download(const char *path, char *output_buf, size_t size,
 
 #ifdef LINK_LOCK_DEBUG
     fprintf(stderr,
-            "path_download(): thread %lu: locking link_lock;\n",
+            "path_download(): thread %lu: locking and unlocking link_lock;\n",
             pthread_self());
 #endif
+
     pthread_mutex_lock(&link_lock);
-#ifdef LINK_LOCK_DEBUG
-    fprintf(stderr,
-            "path_download(): thread %lu: unlocking link_lock;\n",
-            pthread_self());
-#endif
     pthread_mutex_unlock(&link_lock);
+
     transfer_blocking(curl);
 
     long http_resp;

--- a/src/link.h
+++ b/src/link.h
@@ -5,6 +5,11 @@
 
 #include <curl/curl.h>
 
+/** \brief Link type */
+typedef struct Link Link;
+
+#include "cache.h"
+
 /** \brief the link type */
 typedef enum {
     LINK_HEAD = 'H',
@@ -19,11 +24,8 @@ typedef enum {
  */
 typedef struct LinkTable LinkTable;
 
-/** \brief link data type */
-typedef struct Link Link;
-
 /**
- * \brief Link data structure
+ * \brief Link type data structure
  */
 struct Link {
     char linkname[MAX_FILENAME_LEN+1]; /**< The link name in the last level of
@@ -33,6 +35,8 @@ struct Link {
     size_t content_length; /**< CURLINFO_CONTENT_LENGTH_DOWNLOAD of the file */
     LinkTable *next_table; /**< The next LinkTable level, if it is a LINK_DIR */
     long time; /**< CURLINFO_FILETIME obtained from the server */
+    int cache_opened; /**< How many times associated cache has been opened */
+    Cache *cache_ptr; /**< The pointer associated with the cache file */
 };
 
 struct LinkTable {


### PR DESCRIPTION
- Now keep track of the number of times a file has been opened. The on-disk
cache file no longer gets opened multiple times, if a file is opened multiple
times.