### PR TITLE
Update manual page path on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifeq ($(OS),FreeBSD)
 		$(DESTDIR)$(prefix)/bin/httpdirfs
 	gzip -f -k doc/man/httpdirfs.1
 	install -m 644 doc/man/httpdirfs.1.gz \
-		$(DESTDIR)$(prefix)/man/man1/httpdirfs.1.gz
+		$(DESTDIR)$(prefix)/share/man/man1/httpdirfs.1.gz
 endif
 ifeq ($(OS),Darwin)
 	install -d $(DESTDIR)$(prefix)/bin


### PR DESCRIPTION
$prefix/man is considered deprecated on FreeBSD. It's better to use $prefix/share/man. See https://github.com/freebsd/freebsd-ports/commit/a2ac717048e967e7e5e1ba9ea468de6251fd06f5#diff-aac07aefec754086f5c344e2c233862f6a611c739b5647fd456c1b77d3577c79 for details.