### PR TITLE
Two small patches

### DIFF
--- a/src/fuse_local.c
+++ b/src/fuse_local.c
@@ -95,8 +95,8 @@ static int fs_open(const char *path, struct fuse_file_info *fi)
     if (!link) {
         return -ENOENT;
     }
-    if ((fi->flags & 3) != O_RDONLY) {
-        return -EACCES;
+    if ((fi->flags & O_RDWR) != O_RDONLY) {
+        return -EROFS;
     }
     if (CACHE_SYSTEM_INIT) {
         fi->fh = (uint64_t) Cache_open(path);

--- a/src/main.c
+++ b/src/main.c
@@ -169,7 +169,7 @@ void parse_config_file(char ***argv, int *argc)
 static int
 parse_arg_list(int argc, char **argv, char ***fuse_argv, int *fuse_argc)
 {
-    char c;
+    int c;
     int long_index = 0;
     const char *short_opts = "o:hVdfsp:u:P:";
     const struct option long_opts[] = {


### PR DESCRIPTION
One fixes #103 and the other just slightly improves error messages in downstream consumers who mistakenly ask to support writes when `open`ing files.