### PR TITLE
Add setting to refresh directory contents

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -53,6 +53,8 @@ void Config_init(void)
 
     CONFIG.insecure_tls = 0;
 
+    CONFIG.refresh_timeout = DEFAULT_REFRESH_TIMEOUT;
+
     /*--------------- Cache related ---------------*/
     CONFIG.cache_enabled = 0;
 

--- a/src/config.h
+++ b/src/config.h
@@ -24,6 +24,11 @@
 #define DEFAULT_NETWORK_MAX_CONNS   10
 
 /**
+ * \brief The default refresh_timeout 
+ */
+#define DEFAULT_REFRESH_TIMEOUT  86400 
+
+/**
  * \brief Operation modes
  */
 typedef enum {
@@ -67,6 +72,8 @@ typedef struct {
     int insecure_tls;
     /** \brief Server certificate file */
     char *cafile;
+    /** \brief Refresh directory listing after refresh_timeout seconds*/
+    int refresh_timeout;
     /*--------------- Cache related ---------------*/
     /** \brief Whether cache mode is enabled */
     int cache_enabled;

--- a/src/fuse_local.c
+++ b/src/fuse_local.c
@@ -44,7 +44,7 @@ static int fs_getattr(const char *path, struct stat *stbuf)
         if (!link) {
             return -ENOENT;
         }
-        struct timespec spec;
+        struct timespec spec = {0};
         spec.tv_sec = link->time;
 #if defined(__APPLE__) && defined(__MACH__)
         stbuf->st_mtimespec = spec;
@@ -138,14 +138,11 @@ fs_readdir(const char *path, void *buf, fuse_fill_dir_t dir_add,
     (void) fi;
     LinkTable *linktbl;
 
-    if (!strcmp(path, "/")) {
-        linktbl = ROOT_LINK_TBL;
-    } else {
-        linktbl = path_to_Link_LinkTable_new(path);
-        if (!linktbl) {
-            return -ENOENT;
-        }
+    linktbl = path_to_Link_LinkTable_new(path);
+    if (!linktbl) {
+        return -ENOENT;
     }
+
 
     /*
      * start adding the links

--- a/src/link.h
+++ b/src/link.h
@@ -33,6 +33,7 @@ typedef enum {
  */
 struct LinkTable {
     int num;
+    time_t index_time;
     Link **links;
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -201,6 +201,7 @@ parse_arg_list(int argc, char **argv, char ***fuse_argv, int *fuse_argc)
         { "single-file-mode", required_argument, NULL, 'L' },   /* 22 */
         { "cacert", required_argument, NULL, 'L' },     /* 23 */
         { "proxy-cacert", required_argument, NULL, 'L' },       /* 24 */
+        { "refresh-timeout", required_argument, NULL, 'L' }, /* 25 */
         { 0, 0, 0, 0 }
     };
     while ((c =
@@ -304,6 +305,9 @@ parse_arg_list(int argc, char **argv, char ***fuse_argv, int *fuse_argc)
             case 24:
                 CONFIG.proxy_cafile = strdup(optarg);
                 break;
+            case 25:
+                CONFIG.refresh_timeout = atoi(optarg);
+                break;
             default:
                 fprintf(stderr, "see httpdirfs -h for usage\n");
                 return 1;
@@ -370,6 +374,7 @@ HTTPDirFS options:\n\
                             to 1TB in size using the default segment size.\n\
         --max-conns         Set maximum number of network connections that\n\
                             libcurl is allowed to make. (default: 10)\n\
+        --refresh-timeout X Refresh directories after X seconds\n\
         --retry-wait        Set delay in seconds before retrying an HTTP request\n\
                             after encountering an error. (default: 5)\n\
         --user-agent        Set user agent string (default: \"HTTPDirFS\")\n\


### PR DESCRIPTION
Refresh a directory's contents when fs_readdir is called if it has been more than the number of seconds specified by --refresh_timeout since the directory was last indexed.


----

I haven't tested this with the cache option but thought I'd send along in case it was useful to anyone else. Sometimes it's nice to see new files in a directory without having to restart httpdirfs.