### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ HTTPDirFS options:
         --retry-wait        Set delay in seconds before retrying an HTTP request
                             after encountering an error. (default: 5)
         --user-agent        Set user agent string (default: "HTTPDirFS")
-        --no-range-check    Disable the build-in check for the server's support
+        --no-range-check    Disable the built-in check for the server's support
                             for HTTP range requests
         --insecure-tls      Disable licurl TLS certificate verification by
                             setting CURLOPT_SSL_VERIFYHOST to 0
@@ -250,7 +250,7 @@ Alternatively, you can specify your own configuration file by using the
 
 ### Log levels
 You can control how much log HTTPDirFS outputs by setting the
-``HTTPDIRFS_LOG_LEVEL`` enviromental variable. For details of the different
+``HTTPDIRFS_LOG_LEVEL`` environmental variable. For details of the different
 types of log that are supported, please refer to
 [log.h](https://github.com/fangfufu/httpdirfs/blob/master/src/log.h) and
 [log.c](https://github.com/fangfufu/httpdirfs/blob/master/src/log.c).

--- a/src/main.c
+++ b/src/main.c
@@ -373,7 +373,7 @@ HTTPDirFS options:\n\
         --retry-wait        Set delay in seconds before retrying an HTTP request\n\
                             after encountering an error. (default: 5)\n\
         --user-agent        Set user agent string (default: \"HTTPDirFS\")\n\
-        --no-range-check    Disable the build-in check for the server's support\n\
+        --no-range-check    Disable the built-in check for the server's support\n\
                             for HTTP range requests\n\
         --insecure-tls      Disable licurl TLS certificate verification by\n\
                             setting CURLOPT_SSL_VERIFYHOST to 0\n\

--- a/src/sonic.c
+++ b/src/sonic.c
@@ -24,7 +24,7 @@ typedef struct {
 static SonicConfigStruct SONIC_CONFIG;
 
 /**
- * \brief initalise Sonic configuration struct
+ * \brief initialise Sonic configuration struct
  */
 void
 sonic_config_init(const char *server, const char *username,

--- a/src/sonic.h
+++ b/src/sonic.h
@@ -8,7 +8,7 @@
 typedef struct {
     /**
      * \brief Sonic id field
-     * \details This is used to store the followings:
+     * \details This is used to store the following:
      *  - Arist ID
      *  - Album ID
      *  - Song ID


### PR DESCRIPTION
Found via `codespell`