### PR TITLE
fix segfault due to missing LinkTable allocation

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -607,6 +607,7 @@ LinkTable *LinkTable_new(const char *url)
      * disk
      */
     if (!linktbl) {
+        linktbl = LinkTable_alloc(url);
         linktbl->index_time = time(NULL);
         lprintf(debug, "linktbl->index_time: %d\n", linktbl->index_time);
 


### PR DESCRIPTION
LinkTable_new dereferences a NULL linktbl pointer when it does not load the link table from disk. It needs to allocate the new LinkTable object.

Fixes: 07475660f1f7 ("updated LinkTable invalidation")