### PR TITLE
Add option to clear cache

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -93,6 +93,11 @@ extern char *META_DIR;
 void CacheSystem_init(const char *path, int url_supplied);
 
 /**
+ * \brief clear the content of the cache directory
+ */
+void CacheSystem_clear(const char *path);
+
+/**
  * \brief Create directories under the cache directory structure, if they do
  * not already exist
  * \return

--- a/src/main.c
+++ b/src/main.c
@@ -203,6 +203,7 @@ parse_arg_list(int argc, char **argv, char ***fuse_argv, int *fuse_argc)
         { "proxy-cacert", required_argument, NULL, 'L' },       /* 24 */
         { "refresh-timeout", required_argument, NULL, 'L' },    /* 25 */
         { "http-header", required_argument, NULL, 'L' },        /* 26 */
+        { "cache-clear", no_argument, NULL, 'L' },     /* 27 */
         { 0, 0, 0, 0 }
     };
     while ((c =
@@ -314,6 +315,13 @@ parse_arg_list(int argc, char **argv, char ***fuse_argv, int *fuse_argc)
                 CONFIG.http_headers =
                     curl_slist_append(CONFIG.http_headers, strdup(optarg));
                 break;
+            case 27:
+                if (CONFIG.cache_dir) {
+                    CacheSystem_clear(CONFIG.cache_dir);
+                } else {
+                    CacheSystem_clear(NULL);
+                }
+                break;
             default:
                 fprintf(stderr, "see httpdirfs -h for usage\n");
                 return 1;
@@ -369,6 +377,7 @@ HTTPDirFS options:\n\
         --cache             Enable cache (default: off)\n\
         --cache-location    Set a custom cache location\n\
                             (default: \"${XDG_CACHE_HOME}/httpdirfs\")\n\
+        --cache-clear       Clear cache directory and exit\n\
         --cacert            Certificate authority for the server\n\
         --dl-seg-size       Set cache download segment size, in MB (default: 8)\n\
                             Note: this setting is ignored if previously\n\


### PR DESCRIPTION
Casually took note of https://github.com/fangfufu/httpdirfs/issues/111#issuecomment-1336558133  

**PR summary**
`--cache-clear` option will clear the cache associated with user-specified URL only.