### PR TITLE
fix: Allow links starting with an underscore

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -345,7 +345,7 @@ static LinkType linkname_to_LinkType(const char *linkname)
     /*
      * The link name has to start with alphanumerical character
      */
-    if (!isalnum(linkname[0]) && (linkname[0] != '%')) {
+    if (!isalnum(linkname[0]) && (linkname[0] != '%') && (linkname[0) != '_')) {
         return LINK_INVALID;
     }
 


### PR DESCRIPTION
Some directories contain files whose names start with an underscore (e.g. `_SETUP.BAT`), like here for example:

http://cd.textfiles.com/polishprograms/GRY/SAPER/

This change allows those links to be treated as valid.