### PR TITLE
Pass the --no-info option when calling help2man

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ if (host_machine.system() == 'linux')
 		help2man_opts = [
 			'--name="mount HTTP directory as a virtual filesystem"',
 			'--no-discard-stderr',
+			'--no-info',
 			'--section=1']
 		manfile = custom_target('httpdirfs.1',
 			output: 'httpdirfs.1',


### PR DESCRIPTION
For context, help2man was created by the GNU Project as a tool to provide terse manual pages because it is their style to put detailed information in Texinfo format for the 'info' program.

With this user base in mind, help2man by default includes the following text in the manual page it generates: SEE ALSO
	The full documentation for HTTPDirFS is maintained as a Texinfo manual. If the info and HTTPDirFS programs are properly installed at your site, the command
		info HTTPDirFS
	should give you access to the complete manual.

This project doesn't have a Texinfo manual and this note sent me on a goose chase for a manual that didn't exist. For us there is the --no-info option to omit the blurb.