### PR TITLE
Fix const‑correctness for strchr/strrchr

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -273,7 +273,7 @@ static void LinkTable_uninitialised_fill(LinkTable *linktbl)
  */
 static LinkTable *single_LinkTable_new(const char *url)
 {
-    char *orig_ptr = strrchr(url, '/') + 1;
+    const char *orig_ptr = strrchr(url, '/') + 1;
     char *ptr = curl_easy_unescape(NULL, orig_ptr, 0, NULL);
     LinkTable *linktbl = LinkTable_alloc(url);
     Link *link = Link_new(ptr, LINK_UNINITIALISED_FILE);
@@ -356,7 +356,7 @@ static LinkType linkname_to_LinkType(const char *linkname)
     }
 
     /* The linkname must not contain '/' in the middle. */
-    char *slash = strchr(linkname, '/');
+    const char *slash = strchr(linkname, '/');
     if (slash) {
         int linkname_len = strnlen(linkname, MAX_FILENAME_LEN) - 1;
         if (slash - linkname != linkname_len) {

--- a/src/sonic.c
+++ b/src/sonic.c
@@ -235,7 +235,7 @@ XML_parser_general(void *data, const char *elem, const char **attr)
             /*
              * Skip to the last '/' if it exists
              */
-            char *s = strrchr(attr[i + 1], '/');
+            const char *s = strrchr(attr[i + 1], '/');
             if (s) {
                 strncpy(link->linkname, s + 1, MAX_FILENAME_LEN);
             } else {


### PR DESCRIPTION
Make strchr/strrchr results const (inputs are const, so returned pointers must be const).