### PR TITLE
fix: in src/cache in cache.c

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -819,7 +819,7 @@ Cache *Cache_open(const char *fn)
      * Fill in the fs_path
      */
     cf->fs_path = CALLOC(MAX_PATH_LEN + 1, sizeof(char));
-    strncpy(cf->fs_path, fn, MAX_PATH_LEN);
+    snprintf(cf->fs_path, MAX_PATH_LEN + 1, "%s", fn);
 
     /*
      * Set the path for the local cache file, if we are in sonic mode
@@ -1118,7 +1118,13 @@ which doesn't make sense\n", pthread_self(), recv);
 error.\n", recv, cf->blksz);
     }
     send = len;
-    memcpy(output_buf, recv_buf + (offset_start - dl_offset), send);
+    if (offset_start < dl_offset ||
+        (size_t)(offset_start - dl_offset) + (size_t)send > cf->blksz) {
+        lprintf(error, "invalid offset or length for memcpy, aborting copy\n");
+        send = 0;
+    } else {
+        memcpy(output_buf, recv_buf + (offset_start - dl_offset), send);
+    }
     FREE(recv_buf);
 
     lprintf(cache_lock_debug,


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/cache.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/cache.c:1121` |

**Description**: In src/cache.c:1121, memcpy copies 'send' bytes from recv_buf at a computed offset (offset_start - dl_offset) into output_buf. No validation is performed to ensure the computed offset is non-negative, that the source range stays within recv_buf bounds, or that 'send' does not exceed output_buf's allocated capacity. Because offset_start and dl_offset are likely unsigned (size_t), if offset_start < dl_offset the subtraction silently underflows to a very large positive value, causing the memcpy source pointer to point far outside recv_buf. If 'send' exceeds output_buf's size, the destination overflows. Both conditions are reachable via attacker-controlled network responses.

## Changes
- `src/cache.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
