### PR TITLE
Fix issue #190: Implement robust retry logic for downloads

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -1048,9 +1048,8 @@ bug report, please include the following HTTP header information:\n%s\n",
         lprintf(error, "%s", curl_easy_strerror(ret));
     }
     curl_off_t recv = -1;
-    if ((http_resp == HTTP_OK) ||
-            (http_resp == HTTP_PARTIAL_CONTENT) ||
-            (http_resp == HTTP_RANGE_NOT_SATISFIABLE)) {
+    if ((http_resp == HTTP_OK) || (http_resp == HTTP_PARTIAL_CONTENT)
+        || (http_resp == HTTP_RANGE_NOT_SATISFIABLE)) {
         ret = curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD_T, &recv);
         if (ret) {
             lprintf(error, "%s", curl_easy_strerror(ret));
@@ -1094,7 +1093,8 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
         header.curr_size = 0;
         header.data = NULL;
 
-        CURL *curl = Link_download_curl_setup(link, req_size, offset, &header, &ts);
+        CURL *curl
+            = Link_download_curl_setup(link, req_size, offset, &header, &ts);
 
         transfer_blocking(curl);
 
@@ -1110,8 +1110,9 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
             return recv_sz;
         }
 
-        if (recv_sz != (long int) req_size) {
-            lprintf(error, "req_size != recv, req_size: %lu, recv: %ld, retrying...\n",
+        if (recv_sz != (long int)req_size) {
+            lprintf(error,
+                    "req_size != recv, req_size: %lu, recv: %ld, retrying...\n",
                     req_size, recv_sz);
             FREE(ts.data);
             sleep(CONFIG.http_wait_sec);

--- a/src/link.c
+++ b/src/link.c
@@ -968,6 +968,14 @@ TransferStruct Link_download_full(Link *link)
      */
     long http_resp = 0;
     do {
+        /*
+         * Reset the transfer struct for each attempt to avoid accumulating
+         * data from failed/partial attempts.
+         */
+        FREE(ts.data);
+        ts.curr_size = 0;
+        ts.transferring = 1;
+
         transfer_blocking(curl);
         ret = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_resp);
         if (ret) {
@@ -1056,19 +1064,24 @@ bug report, please include the following HTTP header information:\n%s\n",
     if (ret) {
         lprintf(error, "%s", curl_easy_strerror(ret));
     }
-    if ((http_resp != HTTP_OK) &&
-            (http_resp != HTTP_PARTIAL_CONTENT) &&
-            (http_resp != HTTP_RANGE_NOT_SATISFIABLE)) {
+
+    curl_off_t recv = -1;
+    if ((http_resp == HTTP_OK) ||
+            (http_resp == HTTP_PARTIAL_CONTENT) ||
+            (http_resp == HTTP_RANGE_NOT_SATISFIABLE)) {
+        ret = curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD_T, &recv);
+        if (ret) {
+            lprintf(error, "%s", curl_easy_strerror(ret));
+        }
+    } else {
         char *url;
         curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url);
         lprintf(warning, "Could not download %s, HTTP %ld\n", url, http_resp);
-        return -ENOENT;
-    }
-
-    curl_off_t recv;
-    ret = curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD_T, &recv);
-    if (ret) {
-        lprintf(error, "%s", curl_easy_strerror(ret));
+        if (HTTP_temp_failure(http_resp)) {
+            recv = -EAGAIN;
+        } else {
+            recv = -ENOENT;
+        }
     }
 
     curl_easy_cleanup(curl);
@@ -1079,14 +1092,8 @@ bug report, please include the following HTTP header information:\n%s\n",
 long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
 {
     TransferStruct ts;
-    ts.curr_size = 0;
-    ts.data = NULL;
-    ts.type = DATA;
-    ts.transferring = 1;
-
     TransferStruct header;
-    header.curr_size = 0;
-    header.data = NULL;
+    curl_off_t recv_sz;
 
     size_t request_end = offset + req_size;
     if (request_end > link->content_length) {
@@ -1096,16 +1103,42 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
         req_size = link->content_length - offset;
     }
 
-    CURL *curl = Link_download_curl_setup(link, req_size, offset, &header, &ts);
+    do {
+        ts.curr_size = 0;
+        ts.data = NULL;
+        ts.type = DATA;
+        ts.transferring = 1;
 
-    transfer_blocking(curl);
+        header.curr_size = 0;
+        header.data = NULL;
 
-    curl_off_t recv_sz = Link_download_cleanup(curl, &header);
+        CURL *curl = Link_download_curl_setup(link, req_size, offset, &header, &ts);
 
-    if (recv_sz != (long int) req_size) {
-        lprintf(error, "req_size != recv, req_size: %lu, recv: %ld\n",
-                req_size, recv_sz);
-    }
+        transfer_blocking(curl);
+
+        recv_sz = Link_download_cleanup(curl, &header);
+
+        if (recv_sz < 0) {
+            FREE(ts.data);
+            if (recv_sz == -EAGAIN) {
+                lprintf(warning, "HTTP temporary failure, retrying...\n");
+                sleep(CONFIG.http_wait_sec);
+                continue;
+            }
+            return recv_sz;
+        }
+
+        if (recv_sz != (long int) req_size) {
+            lprintf(error, "req_size != recv, req_size: %lu, recv: %ld, retrying...\n",
+                    req_size, recv_sz);
+            FREE(ts.data);
+            sleep(CONFIG.http_wait_sec);
+            continue;
+        }
+
+        /* success */
+        break;
+    } while (1);
 
     memmove(output_buf, ts.data, recv_sz);
     FREE(ts.data);

--- a/src/network.c
+++ b/src/network.c
@@ -112,7 +112,6 @@ curl_process_msgs(CURLMsg *curl_msg, int n_running_curl, int n_mesgs)
 {
     (void) n_running_curl;
     (void) n_mesgs;
-    static volatile int slept = 0;
     if (curl_msg->msg == CURLMSG_DONE) {
         TransferStruct *ts;
         CURL *curl = curl_msg->easy_handle;
@@ -127,26 +126,6 @@ curl_process_msgs(CURLMsg *curl_msg, int n_running_curl, int n_mesgs)
         ret = curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url);
         if (ret) {
             lprintf(error, "%s", curl_easy_strerror(ret));
-        }
-
-        /*
-         * Wait for 5 seconds if we get HTTP 429
-         */
-        long http_resp = 0;
-        ret = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_resp);
-        if (ret) {
-            lprintf(error, "%s", curl_easy_strerror(ret));
-        }
-        if (HTTP_temp_failure(http_resp)) {
-            if (!slept) {
-                lprintf(warning,
-                        "HTTP %ld, sleeping for %d sec\n",
-                        http_resp, CONFIG.http_wait_sec);
-                sleep(CONFIG.http_wait_sec);
-                slept = 1;
-            }
-        } else {
-            slept = 0;
         }
 
         if (!curl_msg->data.result) {

--- a/src/network.c
+++ b/src/network.c
@@ -108,8 +108,8 @@ static void curl_callback_unlock(CURL *handle, curl_lock_data data,
 static void curl_process_msgs(CURLMsg *curl_msg, int n_running_curl,
                               int n_mesgs)
 {
-    (void) n_running_curl;
-    (void) n_mesgs;
+    (void)n_running_curl;
+    (void)n_mesgs;
     if (curl_msg->msg == CURLMSG_DONE) {
         TransferStruct *ts;
         CURL *curl = curl_msg->easy_handle;


### PR DESCRIPTION
This pull request addresses issue #190 where files could appear incomplete or corrupt when encountering HTTP 429 (Rate Limited) errors or network interruptions.

### Technical Analysis

After analyzing the source code in `src/link.c` and `src/network.c`, I identified several root causes for the reported behavior:

1. **Missing Retry Logic in `Link_download`**: The function responsible for reading file content (via range requests) lacked a retry mechanism. Upon encountering an HTTP 429 error or a truncated download, it logged an error but proceeded with whatever partial data it had received.
2. **Improper Error Handling**: If an HTTP error occurred, `Link_download` would still attempt to call `memmove` on the data buffer using the negative error code (e.g., `-ENOENT`) as the size. This could lead to memory corruption or crashes, and certainly resulted in incorrect read returns.
3. **Blocking Network Sleep**: The 429 handling in `network.c` used a blocking `sleep()` while holding the global `transfer_lock`. This effectively froze the entire filesystem's network activity for all threads without actually retrying the failed request.
4. **Cumulative Data Bug**: The retry loop in `Link_download_full` did not reset the transfer buffer between attempts. Since the write callback appends data, a retry after a 429 would prepended the error page's HTML to the actual file content.

### Fixes Applied

- **Robust Retry Loop**: `Link_download` now includes a `do-while` loop that handles both HTTP temporary failures and partial downloads by retrying until the full range is successfully retrieved.
- **Safe Error Paths**: Ensured `Link_download` returns immediately on unrecoverable errors, avoiding invalid memory operations on the output buffer.
- **Buffer Resets**: Updated `Link_download_full` to clear its data buffer before each retry attempt to prevent data corruption.
- **Resource Cleanup**: Fixed a resource leak in `Link_download_cleanup` by ensuring the curl handle is always cleaned up, even on error paths.
- **Decoupled Retries**: Moved the retry delay from the core network processing to individual request handlers, allowing other concurrent transfers to proceed uninterrupted.

These improvements make `httpdirfs` much more resilient to aggressive server-side rate limiting and unstable network connections.