### PR TITLE
Fix hang and crash on 404 directory access (Issue #95)

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -234,33 +234,70 @@ static void LinkTable_uninitialised_fill(LinkTable *linktbl)
     int u;
     char s[STATUS_LEN];
     lprintf(debug, " ... ");
+
+    /*
+     * Start all uninitialized requests once
+     */
+    int total_uninitialized = 0;
+    for (int i = 0; i < linktbl->num; i++) {
+        Link *this_link = linktbl->links[i];
+        if (this_link->type == LINK_UNINITIALISED_FILE
+            || this_link->type == LINK_UNINITIALISED_DIR) {
+            Link_req_file_stat(linktbl->links[i]);
+            total_uninitialized++;
+        }
+    }
+
+    if (total_uninitialized == 0) {
+        lprintf(debug, "Done!\n");
+        return;
+    }
+
+    int n = total_uninitialized;
+    int j = 0;
     do {
         u = 0;
         for (int i = 0; i < linktbl->num; i++) {
             Link *this_link = linktbl->links[i];
             if (this_link->type == LINK_UNINITIALISED_FILE
                 || this_link->type == LINK_UNINITIALISED_DIR) {
-                Link_req_file_stat(linktbl->links[i]);
                 u++;
             }
         }
-        /*
-         * Block until the gaps are filled
-         */
-        int n = curl_multi_perform_once();
-        int i = 0;
-        int j = 0;
-        while ((i = curl_multi_perform_once())) {
+
+        if (u > 0) {
             if (CONFIG.log_type & debug) {
                 if (j) {
                     erase_string(stderr, STATUS_LEN, s);
                 }
-                snprintf(s, STATUS_LEN, "%d / %d", n - i, n);
+                snprintf(s, STATUS_LEN, "%d / %d", n - u, n);
                 fprintf(stderr, "%s", s);
                 j++;
             }
+
+            /*
+             * Block until some handles are processed
+             */
+            int n_running = curl_multi_perform_once();
+
+            /*
+             * If no handles are running but u > 0, we have an error
+             * and we must break to avoid infinite loop.
+             */
+            if (n_running == 0 && u > 0) {
+                lprintf(error, "Some links failed to initialize.\n");
+                for (int i = 0; i < linktbl->num; i++) {
+                    Link *this_link = linktbl->links[i];
+                    if (this_link->type == LINK_UNINITIALISED_FILE
+                        || this_link->type == LINK_UNINITIALISED_DIR) {
+                        this_link->type = LINK_INVALID;
+                    }
+                }
+                break;
+            }
         }
-    } while (u);
+    } while (u > 0);
+
     if (CONFIG.log_type & debug) {
         erase_string(stderr, STATUS_LEN, s);
         fprintf(stderr, "... Done!\n");
@@ -802,6 +839,9 @@ LinkTable *path_to_LinkTable(const char *path)
         tmp_link = &link_cpy;
     } else {
         link = path_to_Link(path);
+        if (!link) {
+            return NULL;
+        }
         tmp_link = link;
     }
 
@@ -837,6 +877,10 @@ LinkTable *path_to_LinkTable(const char *path)
 
 static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
 {
+    if (!linktbl || !path || path[0] == '\0') {
+        return NULL;
+    }
+
     /*
      * skip the leading '/' if it exists
      */
@@ -847,12 +891,15 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
     /*
      * remove the last '/' if it exists
      */
-    char *slash = &(path[strnlen(path, MAX_PATH_LEN) - 1]);
-    if (*slash == '/') {
-        *slash = '\0';
+    size_t path_len = strnlen(path, MAX_PATH_LEN);
+    if (path_len > 0) {
+        char *slash = &(path[path_len - 1]);
+        if (*slash == '/') {
+            *slash = '\0';
+        }
     }
 
-    slash = strchr(path, '/');
+    char *slash = strchr(path, '/');
     if (slash == NULL) {
         /*
          * We cannot find another '/', we have reached the last level

--- a/src/link.c
+++ b/src/link.c
@@ -284,7 +284,7 @@ static void LinkTable_uninitialised_fill(LinkTable *linktbl)
              * If no handles are running but u > 0, we have an error
              * and we must break to avoid infinite loop.
              */
-            if (n_running == 0 && u > 0) {
+            if (n_running == 0) {
                 lprintf(error, "Some links failed to initialize.\n");
                 for (int i = 0; i < linktbl->num; i++) {
                     Link *this_link = linktbl->links[i];

--- a/src/network.c
+++ b/src/network.c
@@ -135,6 +135,14 @@ static void curl_process_msgs(CURLMsg *curl_msg, int n_running_curl,
         } else {
             lprintf(error, "%d - %s <%s>\n", curl_msg->data.result,
                     curl_easy_strerror(curl_msg->data.result), url);
+            /*
+             * If the transfer failed, and we are querying the file size,
+             * we must mark the link as invalid so that the link table
+             * fill function can proceed.
+             */
+            if (ts->type == FILESTAT) {
+                ts->link->type = LINK_INVALID;
+            }
         }
         curl_multi_remove_handle(curl_multi, curl);
         /*

--- a/src/util.c
+++ b/src/util.c
@@ -254,8 +254,6 @@ void FREE(void *ptr)
 {
     if (ptr) {
         free(ptr);
-    } else {
-        lprintf(fatal, "attempted to free NULL ptr!\n");
     }
 }
 


### PR DESCRIPTION
This pull request fixes issue #95 where `httpdirfs` hangs indefinitely when encountering a 404 error on a directory or a network failure during directory initialization.

### Root Cause Diagnosis

The hang was caused by a combination of logic errors in the link initialization process and fragile error handling:

1.  **Infinite Loop in Link Initialization**: `LinkTable_uninitialised_fill` used a `do-while` loop that repeatedly initiated new metadata requests for all links still marked as `UNINITIALISED`. If a request failed due to a network error or a 404, the link remained in the `UNINITIALISED` state, causing the loop to initiate yet another request for the same link in the next iteration. This created an infinite loop that blocked the main FUSE thread and exhausted curl handles.
2.  **Missing Network Error Handling**: `curl_process_msgs` only updated a link's state if the curl request was successful (`result == 0`). If a request failed (e.g., connection reset, timeout), the error was logged, but the link was left in the `UNINITIALISED` state, triggering the infinite loop mentioned above.
3.  **NULL Pointer Dereferences**: `path_to_Link_recursive` and `path_to_LinkTable` failed to handle cases where a link or link table could not be resolved (e.g., due to a 404 error). This led to crashes when traversing paths that contained non-existent directories.
4.  **Fragile `FREE` Wrapper**: The custom `FREE` wrapper was configured to crash the application if passed a `NULL` pointer. However, several parts of the codebase (notably `Link_download_full`) explicitly relied on `FREE(NULL)` behavior for cleanup in error paths and first-iteration loop resets.

### Changes Implemented

- **`src/link.c`**:
    - Refactored `LinkTable_uninitialised_fill` to initiate requests exactly once and wait for completion. Added a safety break to ensure the loop terminates even if some links fail to transition state.
    - Added `NULL` checks to `path_to_Link_recursive` and `path_to_LinkTable` to gracefully handle failed path resolutions by returning `NULL` (which FUSE then translates to `ENOENT`).
- **`src/network.c`**:
    - Updated `curl_process_msgs` to mark links as `LINK_INVALID` when a curl-level error occurs during metadata fetching. This allows the initialization process to proceed and report the failure.
- **`src/util.c`**:
    - Modified the `FREE` wrapper to allow `NULL` pointers, matching standard `free()` behavior and improving general system stability.

Verified with a reproduction script simulating 404 directory responses, ensuring `ls` returns `ENOENT` instead of hanging or crashing.