### PR TITLE
Fix #193: Parse links to intermediate subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ and this project adheres to
 - Fixed issue #190: Implemented robust retry logic for network downloads
   ([08a7987](https://github.com/fangfufu/httpdirfs/commit/08a7987))
   (https://github.com/fangfufu/httpdirfs/pull/203).
+- Fixed issue #193: Support parsing links to intermediate subdirectories
+  (https://github.com/fangfufu/httpdirfs/issues/193).
 - Fixed security vulnerability V-001
   ([4584847](https://github.com/fangfufu/httpdirfs/commit/4584847)).
 

--- a/src/link.c
+++ b/src/link.c
@@ -462,6 +462,15 @@ static void HTML_to_LinkTable(const char *url, GumboNode *node,
         char *relative_url = (char *)href->value;
         make_link_relative(url, relative_url);
 
+        /* Truncate at the first slash to support links to subdirectories */
+        char *slash = strchr(relative_url, '/');
+        if (slash && slash != relative_url) {
+            /* Don't truncate full URIs like http://... */
+            if (*(slash - 1) != ':' && slash[1] != '/') {
+                slash[1] = '\0';
+            }
+        }
+
         /* if it is valid, copy the link onto the heap */
         LinkType type = linkname_to_LinkType(relative_url);
 


### PR DESCRIPTION
Fixes #193

Truncate relative URLs containing intermediate subdirectories (e.g., `href="build/100/i586/"`) at their first slash. This allows httpdirfs to treat the first path component as a valid directory and seamlessly discover the deeper structure during navigation, while still avoiding mutations to full URIs and absolute paths.

Includes CHANGELOG.md update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of links to intermediate subdirectories so nested relative links are correctly recognized and handled (issue #193).

* **Chores**
  * Updated changelog with the above fix under Unreleased → Fixed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/205)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->