### PR TITLE
Fix argument parsing for fstab and mount.fuse compatibility (Issues #100, #102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ and this project adheres to
   (https://github.com/fangfufu/httpdirfs/pull/203).
 - Fixed issue #193: Support parsing links to intermediate subdirectories
   (https://github.com/fangfufu/httpdirfs/issues/193).
+- Fixed issues #100 and #102: Fixed argument parsing to support options passed
+  after the mountpoint, enabling compatibility with `fstab` and `mount`.
+  (https://github.com/fangfufu/httpdirfs/issues/100,
+  https://github.com/fangfufu/httpdirfs/issues/102).
 - Fixed security vulnerability V-001
   ([4584847](https://github.com/fangfufu/httpdirfs/commit/4584847)).
 

--- a/src/main.c
+++ b/src/main.c
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
     /*
      * parse the combined argument list
      */
+    optind = 1;
     if (parse_arg_list(all_argc, all_argv, &fuse_argv, &fuse_argc)) {
         /*
          * The user basically didn't supply enough arguments, if we reach here
@@ -80,13 +81,22 @@ int main(int argc, char **argv)
         goto fuse_start;
     }
 
+    if (optind + 2 != all_argc) {
+        fprintf(
+            stderr,
+            "Error: You must provide exactly one URL and one mountpoint.\n");
+        print_help(argv[0], 0);
+        exit(EXIT_FAILURE);
+    }
+
     /*--- Add the last remaining argument, which is the mountpoint ---*/
-    add_arg(&fuse_argv, &fuse_argc, argv[argc - 1]);
+    add_arg(&fuse_argv, &fuse_argc, all_argv[optind + 1]);
 
     /*
      * The second last remaining argument is the URL
      */
-    char *base_url = argv[argc - 2];
+    char *base_url = all_argv[optind];
+
     if (strncmp(base_url, "http://", 7) != 0
         && strncmp(base_url, "https://", 8) != 0) {
         fprintf(stderr, "Error: Please supply a valid URL.\n");


### PR DESCRIPTION
This PR fixes issues #100 and #102 where passing options like `-o` after the mountpoint or URL would fail.

The root cause was that `httpdirfs` assumed the URL and mountpoint were always at the end of the argument list (`argv[argc - 2]` and `argv[argc - 1]`). However, utilities like `mount.fuse` often append options after these arguments.

I've updated the logic in `src/main.c` to use `getopt_long`'s `optind` to correctly identify non-option arguments regardless of their position.

### Proposed Changes
- Modified `src/main.c` to use `optind` for URL and mountpoint extraction.
- Added a check to ensure exactly two non-option arguments (URL and mountpoint) are provided.
- Updated `CHANGELOG.md`.

### Verification
Verified by running:
`./builddir/httpdirfs https://cdimage.debian.org/cdimage/ /tmp/httpdirfs_test_mnt -o ro -f`
The filesystem successfully mounted and listed directories even with the out-of-order arguments.

Closes #100
Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed argument parsing to support options passed after the mountpoint, improving compatibility with standard mount and fstab conventions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/206)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->