### PR TITLE
Fix: Resolve mountpoint to absolute path to prevent unmount failure on termination

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include "log.h"
 #include "util.h"
 
+#include <errno.h>
 #include <getopt.h>
 #include <stdlib.h>
 #include <string.h>
@@ -91,7 +92,15 @@ int main(int argc, char **argv)
     }
 
     /*--- Add the last remaining argument, which is the mountpoint ---*/
-    add_arg(&fuse_argv, &fuse_argc, all_argv[optind + 1]);
+    char *abs_mountpoint = realpath(all_argv[optind + 1], NULL);
+    if (!abs_mountpoint) {
+        fprintf(stderr, "Error: Invalid mountpoint %s: %s\n",
+                all_argv[optind + 1], strerror(errno));
+        print_help(argv[0], 0);
+        exit(EXIT_FAILURE);
+    }
+    add_arg(&fuse_argv, &fuse_argc, abs_mountpoint);
+    FREE(abs_mountpoint);
 
     /*
      * The second last remaining argument is the URL


### PR DESCRIPTION
Fixes #177.

### Root Cause
When running `httpdirfs` in the background (daemonized), the FUSE library calls `daemon(0, 0)`, which forks the process and changes its current working directory to the system root (`/`). 
If a user specifies a **relative path** for the mountpoint (e.g., `test`), the FUSE teardown routine triggered upon termination (e.g., via `SIGTERM` / `kill`) attempts to execute `fusermount3 -u test`. Since the working directory of the daemon is now `/`, it attempts to unmount `/test`, which fails. 
Additionally, the `auto_unmount` option is subject to the exact same failure mechanism, as the background `fusermount3 --auto-unmount` monitoring process also changes its working directory to `/` upon daemonizing.

This results in the `httpdirfs` process exiting cleanly but leaving a dead, inaccessible mountpoint behind that the user has to manually unmount.

### Fix
This PR ensures that the mountpoint passed via the CLI arguments is explicitly resolved to its **absolute path** (using `realpath()`) before being added to the internal arguments list (`fuse_argv`) passed to FUSE. 

By passing an absolute path to `fuse_main`, `fusermount3 -u <absolute_path>` and `fusermount3 --auto-unmount <absolute_path>` will always be able to target the correct location and successfully unmount the directory during the teardown sequence, regardless of the daemon's current working directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mountpoint paths are now resolved to absolute paths before mounting to avoid ambiguous mounts.
  * Invalid mountpoint inputs now produce a clear error message and display help, preventing startup.
  * Validation tightened to prevent attempting mounts with unresolved or invalid paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/209)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->