### PR TITLE
Update help's default value based on config.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to
   ([3a53c40](https://github.com/fangfufu/httpdirfs/commit/3a53c40))
   (https://github.com/fangfufu/httpdirfs/issues/177).
 
+### Changed
+
+- Update help's default value based on `config.h`
+  (https://github.com/fangfufu/httpdirfs/issues/150).
+
 ## [1.2.8] - 2026-05-10
 
 ### Added

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,7 +1,7 @@
 ## HTTPDirFS Usage
 
 As of commit
-[a134774a823a684828589c9db78cfd0b80bdcbb5](https://github.com/fangfufu/httpdirfs/commit/a134774a823a684828589c9db78cfd0b80bdcbb5),
+[75d31293c791a4249e4bdd93cfa0c43bc1332479](https://github.com/fangfufu/httpdirfs/commit/75d31293c791a4249e4bdd93cfa0c43bc1332479),
 HTTPDirFS supports the following usage flags:
 
     usage: ./httpdirfs [options] URL mountpoint
@@ -46,7 +46,7 @@ HTTPDirFS supports the following usage flags:
             --retry-wait        Set delay in seconds before retrying an HTTP request
                                 after encountering an error. (default: 5)
             --invalid-refresh   Try refreshing invalid links when reading a directory.
-            --user-agent        Set user agent string (default: "HTTPDirFS")
+            --user-agent        Set user agent string (default: "HTTPDirFS-VERSION")
             --no-range-check    Disable the built-in check for the server's support
                                 for HTTP range requests
             --zero-len-is-dir   If a file has a zero length, treat it as a directory

--- a/src/config.c
+++ b/src/config.c
@@ -3,22 +3,6 @@
 #include "log.h"
 #include <stddef.h>
 
-/**
- * \brief The default HTTP 429 (too many requests) wait time
- */
-#define DEFAULT_HTTP_WAIT_SEC 5
-/**
- * \brief Data file block size
- * \details We set it to 1024*1024*8 = 8MiB
- */
-#define DEFAULT_DATA_BLKSZ (8 * 1024 * 1024)
-
-/**
- * \brief Maximum segment block count
- * \details This is set to 128*1024 blocks, which uses 128KB. By default,
- * this allows the user to store (128*1024)*(8*1024*1024) = 1TB of data
- */
-#define DEFAULT_MAX_SEGBC (128 * 1024)
 
 ConfigStruct CONFIG;
 

--- a/src/config.h
+++ b/src/config.h
@@ -29,6 +29,32 @@
 #define DEFAULT_REFRESH_TIMEOUT 3600
 
 /**
+ * \brief The default HTTP 429 (too many requests) wait time
+ */
+#define DEFAULT_HTTP_WAIT_SEC 5
+
+/**
+ * \brief Data file block size in MB
+ */
+#define DEFAULT_DATA_BLKSZ_MB 8
+
+/**
+ * \brief Data file block size
+ * \details We set it to 1024*1024*8 = 8MiB
+ */
+#define DEFAULT_DATA_BLKSZ (DEFAULT_DATA_BLKSZ_MB * 1024 * 1024)
+
+/**
+ * \brief Maximum segment block count
+ * \details This is set to 128*1024 blocks, which uses 128KB. By default,
+ * this allows the user to store (128*1024)*(8*1024*1024) = 1TB of data
+ */
+#define DEFAULT_MAX_SEGBC (128 * 1024)
+
+#define STR(x) #x
+#define XSTR(x) STR(x)
+
+/**
  * \brief Operation modes
  */
 typedef enum {

--- a/src/main.c
+++ b/src/main.c
@@ -440,23 +440,24 @@ HTTPDirFS options:\n\
                             specified with `--cache-location`, if the option is\n\
                             seen first. Then exit in either case.\n\
         --cacert            Certificate authority for the server\n\
-        --dl-seg-size       Set cache download segment size, in MB (default: 8)\n\
+        --dl-seg-size       Set cache download segment size, in MB (default: " XSTR(
+                        DEFAULT_DATA_BLKSZ_MB) ")\n\
                             Note: this setting is ignored if previously\n\
                             cached data is found for the requested file.\n\
         --http-header       Set one or more HTTP headers\n\
         --max-seg-count     Set maximum number of download segments a file\n\
-                            can have. (default: 128*1024)\n\
+                            can have. (default: " XSTR(DEFAULT_MAX_SEGBC) ")\n\
                             With the default setting, the maximum memory usage\n\
                             per file is 128KB. This allows caching files up\n\
                             to 1TB in size using the default segment size.\n\
         --max-conns         Set maximum number of network connections that\n\
-                            libcurl is allowed to make. (default: 10)\n\
+                            libcurl is allowed to make. (default: " XSTR(DEFAULT_NETWORK_MAX_CONNS) ")\n\
         --refresh-timeout   The directories are refreshed after the specified\n\
-                            time, in seconds (default: 3600)\n\
+                            time, in seconds (default: " XSTR(DEFAULT_REFRESH_TIMEOUT) ")\n\
         --retry-wait        Set delay in seconds before retrying an HTTP request\n\
-                            after encountering an error. (default: 5)\n\
+                            after encountering an error. (default: " XSTR(DEFAULT_HTTP_WAIT_SEC) ")\n\
         --invalid-refresh   Try refreshing invalid links when reading a directory.\n\
-        --user-agent        Set user agent string (default: \"HTTPDirFS\")\n\
+        --user-agent        Set user agent string (default: \"" DEFAULT_USER_AGENT "\")\n\
         --no-range-check    Disable the built-in check for the server's support\n\
                             for HTTP range requests\n\
         --zero-len-is-dir   If a file has a zero length, treat it as a directory\n\


### PR DESCRIPTION
This PR addresses issue #150 by dynamically updating the help message's default values based on the macros defined in `src/config.h`.

Changes:
1. Moved `DEFAULT_HTTP_WAIT_SEC`, `DEFAULT_DATA_BLKSZ`, and `DEFAULT_MAX_SEGBC` from `src/config.c` to `src/config.h`.
2. Introduced `DEFAULT_DATA_BLKSZ_MB` for easier display in the help message.
3. Added `STR` and `XSTR` helper macros for stringification.
4. Updated `print_long_help` in `src/main.c` to use these macros.
5. Updated `CHANGELOG.md`.

This ensures that any future changes to the default values in `config.h` will be automatically reflected in the help output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Help text, usage docs, and changelog updated so displayed default option values now reflect compile-time configuration (segment size, max segments, connections, timeouts, retry wait, and user agent).

* **Chores**
  * Default configuration values centralized into a single header to ensure consistent defaults across builds and simplify maintenance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/210)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->