### PR TITLE
Refactor: Centralized Logging and Custom Memory Tracking

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -47,7 +47,7 @@ char *CacheSystem_get_cache_dir(void)
 
     const char *xdg_cache_home = getenv("XDG_CACHE_HOME");
     if (xdg_cache_home) {
-        cache_dir = strndup(xdg_cache_home, MAX_PATH_LEN);
+        cache_dir = STRNDUP(xdg_cache_home, MAX_PATH_LEN);
     } else {
         const char *user_home = getenv("HOME");
         if (user_home) {
@@ -58,7 +58,7 @@ char *CacheSystem_get_cache_dir(void)
              * XDG_CACHE_HOME and HOME already are full paths. Not relying
              * on environment PWD since it too may be undefined.
              */
-            const char *cur_dir = realpath("./", NULL);
+            const char *cur_dir = REALPATH("./", NULL);
             if (cur_dir) {
                 cache_dir = path_append(cur_dir, default_cache_subdir);
             } else {
@@ -705,7 +705,7 @@ int Cache_create(const char *path)
     lprintf(debug, "Creating cache files for %s.\n", fn);
 
     Cache *cf = Cache_alloc();
-    cf->path = strndup(fn, MAX_PATH_LEN);
+    cf->path = STRNDUP(fn, MAX_PATH_LEN);
     cf->time = this_link->time;
     cf->content_length = this_link->content_length;
     cf->blksz = CONFIG.data_blksz;
@@ -813,7 +813,7 @@ Cache *Cache_open(const char *fn)
         fn = link->sonic.id;
     }
 
-    cf->path = strndup(fn, MAX_PATH_LEN);
+    cf->path = STRNDUP(fn, MAX_PATH_LEN);
 
     /*
      * Associate the cache structure with a link
@@ -1055,7 +1055,7 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
          * Wait for any other download thread to finish
          */
 
-        lprintf(cache_lock_debug, "thread %ld: locking w_lock;\n",
+        lprintf(cache_lock_debug, "thread %lx: locking w_lock;\n",
                 (unsigned long)pthread_self());
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -119,8 +119,8 @@ static char *CacheSystem_calc_dir(const char *url)
 
 void CacheSystem_init(const char *path, int url_supplied)
 {
-    lprintf(cache_lock_debug, "thread %x: initialise cf_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: initialise cf_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_INIT(&cf_lock, NULL);
 
     if (url_supplied) {
@@ -386,8 +386,8 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
         return -EINVAL;
     }
 
-    lprintf(cache_lock_debug, "thread %x: locking seek_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: locking seek_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&cf->seek_lock);
 
     long byte_read = 0;
@@ -434,8 +434,8 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
 
 end:
 
-    lprintf(cache_lock_debug, "thread %x: unlocking seek_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking seek_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf->seek_lock);
     return byte_read;
 }
@@ -459,8 +459,8 @@ static long Data_write(Cache *cf, const uint8_t *buf, off_t len, off_t offset)
         return 0;
     }
 
-    lprintf(cache_lock_debug, "thread %x: locking seek_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: locking seek_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&cf->seek_lock);
 
     long byte_written = 0;
@@ -489,8 +489,8 @@ static long Data_write(Cache *cf, const uint8_t *buf, off_t len, off_t offset)
     }
 
 end:
-    lprintf(cache_lock_debug, "thread %x: unlocking seek_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking seek_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf->seek_lock);
     return byte_written;
 }
@@ -760,13 +760,14 @@ Cache *Cache_open(const char *fn)
         return NULL;
     }
 
-    lprintf(cache_lock_debug, "thread %x: locking cf_lock;\n", pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: locking cf_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&cf_lock);
 
     if (link->cache_ptr) {
         link->cache_ptr->cache_opened++;
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return link->cache_ptr;
     }
@@ -777,16 +778,16 @@ Cache *Cache_open(const char *fn)
     if (CONFIG.mode == NORMAL || CONFIG.mode == SINGLE) {
         if (Cache_exist(fn)) {
 
-            lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                    pthread_self());
+            lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                    (unsigned long)pthread_self());
             PTHREAD_MUTEX_UNLOCK(&cf_lock);
             return NULL;
         }
     } else if (CONFIG.mode == SONIC) {
         if (Cache_exist(link->sonic.id)) {
 
-            lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                    pthread_self());
+            lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                    (unsigned long)pthread_self());
             PTHREAD_MUTEX_UNLOCK(&cf_lock);
             return NULL;
         }
@@ -823,8 +824,8 @@ Cache *Cache_open(const char *fn)
         lprintf(error, "cannot open metadata file %s.\n", fn);
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -836,8 +837,8 @@ Cache *Cache_open(const char *fn)
         lprintf(error, "metadata error: %s.\n", fn);
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -853,8 +854,8 @@ cf->content_length: %ld, Data_size(fn): %ld.\n",
                 fn, cf->content_length, Data_size(fn));
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -866,8 +867,8 @@ cf->content_length: %ld, Data_size(fn): %ld.\n",
         lprintf(warning, "outdated cache file: %s.\n", fn);
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -876,8 +877,8 @@ cf->content_length: %ld, Data_size(fn): %ld.\n",
         lprintf(error, "cannot open data file %s.\n", fn);
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -887,24 +888,24 @@ cf->content_length: %ld, Data_size(fn): %ld.\n",
      */
     cf->link->cache_ptr = cf;
 
-    lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf_lock);
     return cf;
 }
 
 void Cache_close(Cache *cf)
 {
-    lprintf(cache_lock_debug, "thread %x: locking cf_lock: %s\n",
-            pthread_self(), cf->path);
+    lprintf(cache_lock_debug, "thread %lx: locking cf_lock: %s\n",
+            (unsigned long)pthread_self(), cf->path);
     PTHREAD_MUTEX_LOCK(&cf_lock);
 
     cf->cache_opened--;
 
     if (cf->cache_opened > 0) {
         lprintf(cache_lock_debug,
-                "thread %x: unlocking cf_lock: %s, cache_opened: %d\n",
-                pthread_self(), cf->path, cf->cache_opened);
+                "thread %lx: unlocking cf_lock: %s, cache_opened: %d\n",
+                (unsigned long)pthread_self(), cf->path, cf->cache_opened);
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return;
     }
@@ -915,8 +916,8 @@ void Cache_close(Cache *cf)
      * running. This will cause a use-after-free error.
      */
     lprintf(cache_lock_debug,
-            "thread %x: waiting for background download to finish for %s\n",
-            pthread_self(), cf->path);
+            "thread %lx: waiting for background download to finish for %s\n",
+            (unsigned long)pthread_self(), cf->path);
     SEM_WAIT(&cf->bgt_sem);
 
     if (Meta_write(cf)) {
@@ -934,8 +935,8 @@ void Cache_close(Cache *cf)
     cf->link->cache_ptr = NULL;
 
     lprintf(cache_lock_debug,
-            "thread %x: unlocking cf_lock, cache closed: %s\n", pthread_self(),
-            cf->path);
+            "thread %lx: unlocking cf_lock, cache closed: %s\n",
+            (unsigned long)pthread_self(), cf->path);
     Cache_free(cf);
     PTHREAD_MUTEX_UNLOCK(&cf_lock);
 }
@@ -973,17 +974,18 @@ static void *Cache_bgdl(void *arg)
 {
     Cache *cf = (Cache *)arg;
 
-    lprintf(cache_lock_debug, "thread %x: locking w_lock;\n", pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: locking w_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&cf->w_lock);
 
     uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
-    lprintf(debug, "thread %x spawned.\n ", pthread_self());
+    lprintf(debug, "thread %lx spawned.\n ", (unsigned long)pthread_self());
     long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz,
                               cf->next_dl_offset);
     if (recv < 0) {
-        lprintf(error, "thread %x received %ld bytes, \
+        lprintf(error, "thread %lx received %ld bytes, \
 which doesn't make sense\n",
-                pthread_self(), recv);
+                (unsigned long)pthread_self(), recv);
     }
 
     if ((recv == cf->blksz)
@@ -993,14 +995,15 @@ which doesn't make sense\n",
             Seg_set(cf, cf->next_dl_offset, 1);
         }
     } else {
-        lprintf(error, "received %ld rather than %ld, possible network \
+        lprintf(error, "received %ld rather than %d, possible network \
 error.\n",
                 recv, cf->blksz);
     }
 
     FREE(recv_buf);
 
-    lprintf(cache_lock_debug, "thread %x: unlocking w_lock;\n", pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
     SEM_POST(&cf->bgt_sem);
 
@@ -1053,7 +1056,7 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
          */
 
         lprintf(cache_lock_debug, "thread %ld: locking w_lock;\n",
-                pthread_self());
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
 
         if (Seg_exist(cf, dl_offset)) {
@@ -1063,8 +1066,8 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
              */
             send = Data_read(cf, (uint8_t *)output_buf, len, offset_start);
 
-            lprintf(cache_lock_debug, "thread %x: unlocking w_lock;\n",
-                    pthread_self());
+            lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
+                    (unsigned long)pthread_self());
             PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
 
             goto bgdl;
@@ -1076,12 +1079,12 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
      */
 
     uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
-    lprintf(debug, "thread %x: spawned.\n ", pthread_self());
+    lprintf(debug, "thread %lx: spawned.\n ", (unsigned long)pthread_self());
     long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz, dl_offset);
     if (recv < 0) {
-        lprintf(error, "thread %x received %ld bytes, \
+        lprintf(error, "thread %lx received %ld bytes, \
 which doesn't make sense\n",
-                pthread_self(), recv);
+                (unsigned long)pthread_self(), recv);
     }
     /*
      * check if we have received enough data, write it to the disk
@@ -1095,7 +1098,7 @@ which doesn't make sense\n",
             Seg_set(cf, dl_offset, 1);
         }
     } else {
-        lprintf(error, "received %ld rather than %ld, possible network \
+        lprintf(error, "received %ld rather than %d, possible network \
 error.\n",
                 recv, cf->blksz);
     }
@@ -1110,7 +1113,8 @@ error.\n",
     }
     FREE(recv_buf);
 
-    lprintf(cache_lock_debug, "thread %x: unlocking w_lock;\n", pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
 
     /*
@@ -1126,8 +1130,8 @@ bgdl: {
         int ret = sem_trywait(&cf->bgt_sem);
         if (!ret) {
             lprintf(cache_lock_debug,
-                    "parent thread %x: sem_trywait successful\n",
-                    pthread_self());
+                    "parent thread %lx: sem_trywait successful\n",
+                    (unsigned long)pthread_self());
             cf->next_dl_offset = next_dl_offset;
             Cache_bgdl_launcher(cf);
         } else if (errno != EAGAIN) {

--- a/src/config.c
+++ b/src/config.c
@@ -2,6 +2,8 @@
 
 #include "log.h"
 #include <stddef.h>
+#include <stdlib.h>
+#include "util.h"
 
 
 ConfigStruct CONFIG;
@@ -58,4 +60,5 @@ void Config_init(void)
     CONFIG.sonic_id3 = 0;
 
     CONFIG.sonic_insecure = 0;
+    atexit(mem_cleanup);
 }

--- a/src/link.c
+++ b/src/link.c
@@ -364,10 +364,10 @@ LinkTable *LinkSystem_init(const char *url)
 void LinkTable_add(LinkTable *linktbl, Link *link)
 {
     linktbl->num++;
-    Link **tmp = (Link **)realloc((void *)linktbl->links,
+    Link **tmp = (Link **)REALLOC((void *)linktbl->links,
                                   linktbl->num * sizeof(Link *));
     if (!tmp) {
-        lprintf(fatal, "realloc() failure!\n");
+        lprintf(fatal, "REALLOC() failure!\n");
     }
     linktbl->links = tmp;
     linktbl->links[linktbl->num - 1] = link;
@@ -649,10 +649,10 @@ LinkTable *LinkTable_new(const char *url)
              */
             time_t time_now = time(NULL);
             if (time_now - disk_linktbl->index_time > CONFIG.refresh_timeout) {
-                lprintf(info, "time_now: %ld, index_time: %ld\n", time_now,
-                        disk_linktbl->index_time);
+                lprintf(info, "time_now: %ld, index_time: %ld\n",
+                        (long)time_now, (long)disk_linktbl->index_time);
                 lprintf(info, "diff: %ld, limit: %d\n",
-                        time_now - disk_linktbl->index_time,
+                        (long)(time_now - disk_linktbl->index_time),
                         CONFIG.refresh_timeout);
                 LinkTable_free(disk_linktbl);
             } else {
@@ -668,7 +668,7 @@ LinkTable *LinkTable_new(const char *url)
     if (!linktbl) {
         linktbl = LinkTable_alloc(url);
         linktbl->index_time = time(NULL);
-        lprintf(debug, "linktbl->index_time: %ld\n", linktbl->index_time);
+        lprintf(debug, "linktbl->index_time: %ld\n", (long)linktbl->index_time);
 
         /*
          * start downloading the base URL
@@ -698,7 +698,7 @@ LinkTable *LinkTable_new(const char *url)
     }
 
     static unsigned long long i = 0;
-    lprintf(debug, "Calling LinkTable_new for the %lld time!\n", i);
+    lprintf(debug, "Calling LinkTable_new for the %llu time!\n", i);
     i++;
 
     free(unescaped_path);
@@ -740,7 +740,7 @@ int LinkTable_disk_save(LinkTable *linktbl, const char *dirn)
         return -1;
     }
 
-    lprintf(debug, "linktbl->index_time: %ld\n", linktbl->index_time);
+    lprintf(debug, "linktbl->index_time: %ld\n", (long)linktbl->index_time);
     if (fwrite(&linktbl->num, sizeof(int), 1, fp) != 1
         || fwrite(&linktbl->index_time, sizeof(time_t), 1, fp) != 1) {
         lprintf(error, "Failed to save the header of %s!\n", path);
@@ -800,7 +800,7 @@ LinkTable *LinkTable_disk_open(const char *dirn)
         FREE(path);
         return NULL;
     }
-    lprintf(debug, "linktbl->index_time: %ld\n", linktbl->index_time);
+    lprintf(debug, "linktbl->index_time: %ld\n", (long)linktbl->index_time);
 
     linktbl->links = (Link **)CALLOC(linktbl->num, sizeof(Link *));
     for (int i = 0; i < linktbl->num; i++) {
@@ -968,7 +968,7 @@ Link *path_to_Link(const char *path)
             (unsigned long)pthread_self());
 
     PTHREAD_MUTEX_LOCK(&link_lock);
-    char *new_path = strndup(path, MAX_PATH_LEN);
+    char *new_path = STRNDUP(path, MAX_PATH_LEN);
     if (!new_path) {
         lprintf(fatal, "cannot allocate memory\n");
     }

--- a/src/link.c
+++ b/src/link.c
@@ -582,7 +582,7 @@ void LinkTable_free(LinkTable *linktbl)
             LinkTable_free(linktbl->links[i]->next_table);
             FREE(linktbl->links[i]);
         }
-        FREE((void *)linktbl->links);
+        FREE(linktbl->links);
         FREE(linktbl);
     }
 }

--- a/src/link.c
+++ b/src/link.c
@@ -438,7 +438,7 @@ static int linknames_equal(const char *str_a, const char *str_b)
     }
 
 end:
-    lprintf(debug, "linknames comparison: a: %s, b: %s, max_len: %d %s\n",
+    lprintf(debug, "linknames comparison: a: %s, b: %s, max_len: %zu %s\n",
             str_a, str_b, comp_len, identical ? ", identical!" : "");
     return identical;
 }
@@ -592,7 +592,7 @@ void LinkTable_print(LinkTable *linktbl)
     if (CONFIG.log_type & info) {
         int j = 0;
         lprintf(info, "--------------------------------------------\n");
-        lprintf(info, " LinkTable %p for %s\n", linktbl,
+        lprintf(info, " LinkTable %p for %s\n", (void *)linktbl,
                 linktbl->links[0]->f_url);
         lprintf(info, "--------------------------------------------\n");
         for (int i = 0; i < linktbl->num; i++) {
@@ -649,9 +649,9 @@ LinkTable *LinkTable_new(const char *url)
              */
             time_t time_now = time(NULL);
             if (time_now - disk_linktbl->index_time > CONFIG.refresh_timeout) {
-                lprintf(info, "time_now: %d, index_time: %d\n", time_now,
+                lprintf(info, "time_now: %ld, index_time: %ld\n", time_now,
                         disk_linktbl->index_time);
-                lprintf(info, "diff: %d, limit: %d\n",
+                lprintf(info, "diff: %ld, limit: %d\n",
                         time_now - disk_linktbl->index_time,
                         CONFIG.refresh_timeout);
                 LinkTable_free(disk_linktbl);
@@ -668,7 +668,7 @@ LinkTable *LinkTable_new(const char *url)
     if (!linktbl) {
         linktbl = LinkTable_alloc(url);
         linktbl->index_time = time(NULL);
-        lprintf(debug, "linktbl->index_time: %d\n", linktbl->index_time);
+        lprintf(debug, "linktbl->index_time: %ld\n", linktbl->index_time);
 
         /*
          * start downloading the base URL
@@ -698,7 +698,7 @@ LinkTable *LinkTable_new(const char *url)
     }
 
     static unsigned long long i = 0;
-    lprintf(debug, "Calling LinkTable_new for the %d time!\n", i);
+    lprintf(debug, "Calling LinkTable_new for the %lld time!\n", i);
     i++;
 
     free(unescaped_path);
@@ -740,7 +740,7 @@ int LinkTable_disk_save(LinkTable *linktbl, const char *dirn)
         return -1;
     }
 
-    lprintf(debug, "linktbl->index_time: %d\n", linktbl->index_time);
+    lprintf(debug, "linktbl->index_time: %ld\n", linktbl->index_time);
     if (fwrite(&linktbl->num, sizeof(int), 1, fp) != 1
         || fwrite(&linktbl->index_time, sizeof(time_t), 1, fp) != 1) {
         lprintf(error, "Failed to save the header of %s!\n", path);
@@ -800,7 +800,7 @@ LinkTable *LinkTable_disk_open(const char *dirn)
         FREE(path);
         return NULL;
     }
-    lprintf(debug, "linktbl->index_time: %d\n", linktbl->index_time);
+    lprintf(debug, "linktbl->index_time: %ld\n", linktbl->index_time);
 
     linktbl->links = (Link **)CALLOC(linktbl->num, sizeof(Link *));
     for (int i = 0; i < linktbl->num; i++) {
@@ -964,7 +964,8 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
 
 Link *path_to_Link(const char *path)
 {
-    lprintf(link_lock_debug, "thread %x: locking link_lock;\n", pthread_self());
+    lprintf(link_lock_debug, "thread %lx: locking link_lock;\n",
+            (unsigned long)pthread_self());
 
     PTHREAD_MUTEX_LOCK(&link_lock);
     char *new_path = strndup(path, MAX_PATH_LEN);
@@ -974,8 +975,8 @@ Link *path_to_Link(const char *path)
     Link *link = path_to_Link_recursive(new_path, ROOT_LINK_TBL);
     FREE(new_path);
 
-    lprintf(link_lock_debug, "thread %x: unlocking link_lock;\n",
-            pthread_self());
+    lprintf(link_lock_debug, "thread %lx: unlocking link_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&link_lock);
     return link;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -25,47 +25,43 @@ int log_level_init(void)
 static void vlog_printf(LogType type, const char *file, const char *func,
                         int line, const char *format, va_list args)
 {
-    if (type == fatal || (type & CONFIG.log_type)) {
-        switch (type) {
-        case fatal:
-            fprintf(stderr, "Fatal:");
-            break;
-        case error:
-            fprintf(stderr, "Error:");
-            break;
-        case warning:
-            fprintf(stderr, "Warning:");
-            break;
-        case info:
-            goto print_actual_message;
-        default:
-            fprintf(stderr, "Debug");
-            if (type != debug) {
-                fprintf(stderr, "(%x)", type);
-            }
-            fprintf(stderr, ":");
-            break;
+    switch (type) {
+    case fatal:
+        fprintf(stderr, "Fatal:");
+        break;
+    case error:
+        fprintf(stderr, "Error:");
+        break;
+    case warning:
+        fprintf(stderr, "Warning:");
+        break;
+    case info:
+        goto print_actual_message;
+    default:
+        fprintf(stderr, "Debug");
+        if (type != debug) {
+            fprintf(stderr, "(%x)", type);
         }
-
-        fprintf(stderr, "%s:%d:", file, line);
-
-    print_actual_message: {
+        fprintf(stderr, ":");
+        break;
     }
-        fprintf(stderr, "%s: ", func);
-        vfprintf(stderr, format, args);
-    }
+
+    fprintf(stderr, "%s:%d:", file, line);
+
+print_actual_message: {
+}
+    fprintf(stderr, "%s: ", func);
+    vfprintf(stderr, format, args);
 }
 
 void log_printf(LogType type, const char *file, const char *func, int line,
                 const char *format, ...)
 {
-    va_list args;
-    va_start(args, format);
-    vlog_printf(type, file, func, line, format, args);
-    va_end(args);
-
-    if (type == fatal) {
-        exit_failure();
+    if (type & CONFIG.log_type) {
+        va_list args;
+        va_start(args, format);
+        vlog_printf(type, file, func, line, format, args);
+        va_end(args);
     }
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -22,45 +22,63 @@ int log_level_init(void)
 #endif
 }
 
+static void vlog_printf(LogType type, const char *file, const char *func,
+                        int line, const char *format, va_list args)
+{
+    if (type == fatal || (type & CONFIG.log_type)) {
+        if (type & CONFIG.log_type) {
+            switch (type) {
+            case fatal:
+                fprintf(stderr, "Fatal:");
+                break;
+            case error:
+                fprintf(stderr, "Error:");
+                break;
+            case warning:
+                fprintf(stderr, "Warning:");
+                break;
+            case info:
+                goto print_actual_message;
+            default:
+                fprintf(stderr, "Debug");
+                if (type != debug) {
+                    fprintf(stderr, "(%x)", type);
+                }
+                fprintf(stderr, ":");
+                break;
+            }
+
+            fprintf(stderr, "%s:%d:", file, line);
+
+        print_actual_message: {
+        }
+            fprintf(stderr, "%s: ", func);
+            vfprintf(stderr, format, args);
+        }
+    }
+}
+
 void log_printf(LogType type, const char *file, const char *func, int line,
                 const char *format, ...)
 {
-    if (type & CONFIG.log_type) {
-        switch (type) {
-        case fatal:
-            fprintf(stderr, "Fatal:");
-            break;
-        case error:
-            fprintf(stderr, "Error:");
-            break;
-        case warning:
-            fprintf(stderr, "Warning:");
-            break;
-        case info:
-            goto print_actual_message;
-        default:
-            fprintf(stderr, "Debug");
-            if (type != debug) {
-                fprintf(stderr, "(%x)", type);
-            }
-            fprintf(stderr, ":");
-            break;
-        }
+    va_list args;
+    va_start(args, format);
+    vlog_printf(type, file, func, line, format, args);
+    va_end(args);
 
-        fprintf(stderr, "%s:%d:", file, line);
-
-    print_actual_message: {
+    if (type == fatal) {
+        exit_failure();
     }
-        fprintf(stderr, "%s: ", func);
-        va_list args;
-        va_start(args, format);
-        vfprintf(stderr, format, args);
-        va_end(args);
+}
 
-        if (type == fatal) {
-            exit_failure();
-        }
-    }
+void fatal_log_printf(const char *file, const char *func, int line,
+                      const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    vlog_printf(fatal, file, func, line, format, args);
+    va_end(args);
+    exit_failure();
 }
 
 void print_version(void)

--- a/src/log.c
+++ b/src/log.c
@@ -26,35 +26,33 @@ static void vlog_printf(LogType type, const char *file, const char *func,
                         int line, const char *format, va_list args)
 {
     if (type == fatal || (type & CONFIG.log_type)) {
-        if (type & CONFIG.log_type) {
-            switch (type) {
-            case fatal:
-                fprintf(stderr, "Fatal:");
-                break;
-            case error:
-                fprintf(stderr, "Error:");
-                break;
-            case warning:
-                fprintf(stderr, "Warning:");
-                break;
-            case info:
-                goto print_actual_message;
-            default:
-                fprintf(stderr, "Debug");
-                if (type != debug) {
-                    fprintf(stderr, "(%x)", type);
-                }
-                fprintf(stderr, ":");
-                break;
+        switch (type) {
+        case fatal:
+            fprintf(stderr, "Fatal:");
+            break;
+        case error:
+            fprintf(stderr, "Error:");
+            break;
+        case warning:
+            fprintf(stderr, "Warning:");
+            break;
+        case info:
+            goto print_actual_message;
+        default:
+            fprintf(stderr, "Debug");
+            if (type != debug) {
+                fprintf(stderr, "(%x)", type);
             }
-
-            fprintf(stderr, "%s:%d:", file, line);
-
-        print_actual_message: {
+            fprintf(stderr, ":");
+            break;
         }
-            fprintf(stderr, "%s: ", func);
-            vfprintf(stderr, format, args);
-        }
+
+        fprintf(stderr, "%s:%d:", file, line);
+
+    print_actual_message: {
+    }
+        fprintf(stderr, "%s: ", func);
+        vfprintf(stderr, format, args);
     }
 }
 

--- a/src/log.h
+++ b/src/log.h
@@ -33,18 +33,24 @@ int log_level_init(void);
  * \details This is for printing nice log messages
  */
 void log_printf(LogType type, const char *file, const char *func, int line,
-                const char *format, ...);
+                const char *format, ...) __attribute__((format(printf, 5, 6)));
+
+/**
+ * \brief Fatal log printf
+ * \details This is for printing fatal error messages and exiting
+ */
+void fatal_log_printf(const char *file, const char *func, int line,
+                      const char *format, ...) __attribute__((noreturn))
+__attribute__((format(printf, 4, 5)));
 
 /**
  * \brief Log type printf
  * \details This macro automatically prints out the filename and line number
  */
 #define lprintf(type, ...)                                                     \
-    do {                                                                       \
-        log_printf(type, __FILE__, __func__, __LINE__, __VA_ARGS__);           \
-        if ((type) == fatal)                                                   \
-            exit_failure();                                                    \
-    } while (0)
+    ((type) == fatal                                                           \
+         ? fatal_log_printf(__FILE__, __func__, __LINE__, __VA_ARGS__)         \
+         : log_printf(type, __FILE__, __func__, __LINE__, __VA_ARGS__))
 
 /**
  * \brief Print the version information for HTTPDirFS

--- a/src/main.c
+++ b/src/main.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
     for (int i = 1; i < argc; i++) {
         add_arg(&all_argv, &all_argc, argv[i]);
         if (!strcmp(argv[i], "--config")) {
-            config_path = strdup(argv[i + 1]);
+            config_path = STRDUP(argv[i + 1]);
         }
     }
 
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
     }
 
     /*--- Add the last remaining argument, which is the mountpoint ---*/
-    char *abs_mountpoint = realpath(all_argv[optind + 1], NULL);
+    char *abs_mountpoint = REALPATH(all_argv[optind + 1], NULL);
     if (!abs_mountpoint) {
         fprintf(stderr, "Error: Invalid mountpoint %s: %s\n",
                 all_argv[optind + 1], strerror(errno));
@@ -176,14 +176,14 @@ static char *get_XDG_CONFIG_HOME(void)
 
     const char *xdg_config_home = getenv("XDG_CONFIG_HOME");
     if (xdg_config_home) {
-        config_dir = strndup(xdg_config_home, MAX_PATH_LEN);
+        config_dir = STRNDUP(xdg_config_home, MAX_PATH_LEN);
     } else {
         const char *user_home = getenv("HOME");
         if (user_home) {
             config_dir = path_append(user_home, default_config_subdir);
         } else {
             lprintf(warning, "$HOME is unset\n");
-            const char *cur_dir = realpath("./", NULL);
+            const char *cur_dir = REALPATH("./", NULL);
             if (cur_dir) {
                 config_dir = path_append(cur_dir, default_config_subdir);
             } else {
@@ -219,22 +219,22 @@ void parse_config_file(char ***argv, int *argc)
                 char *space;
                 space = strchr(buf, ' ');
                 if (!space) {
-                    *argv = (char **)realloc((void *)*argv,
+                    *argv = (char **)REALLOC((void *)*argv,
                                              *argc * sizeof(char *));
-                    (*argv)[*argc - 1] = strndup(buf, buf_len);
+                    (*argv)[*argc - 1] = STRNDUP(buf, buf_len);
                 } else {
                     (*argc)++;
-                    *argv = (char **)realloc((void *)*argv,
+                    *argv = (char **)REALLOC((void *)*argv,
                                              *argc * sizeof(char *));
                     /*
                      * Only copy up to the space character
                      */
-                    (*argv)[*argc - 2] = strndup(buf, space - buf);
+                    (*argv)[*argc - 2] = STRNDUP(buf, space - buf);
                     /*
                      * Starts copying after the space
                      */
                     (*argv)[*argc - 1]
-                        = strndup(space + 1, buf_len - (space + 1 - buf));
+                        = STRNDUP(space + 1, buf_len - (space + 1 - buf));
                 }
             }
         }
@@ -313,13 +313,13 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
             add_arg(fuse_argv, fuse_argc, "-s");
             break;
         case 'u':
-            CONFIG.http_username = strdup(optarg);
+            CONFIG.http_username = STRDUP(optarg);
             break;
         case 'p':
-            CONFIG.http_password = strdup(optarg);
+            CONFIG.http_password = STRDUP(optarg);
             break;
         case 'P':
-            CONFIG.proxy = strdup(optarg);
+            CONFIG.proxy = STRDUP(optarg);
             break;
         case 'L':
             /*
@@ -327,10 +327,10 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
              */
             switch (long_index) {
             case 6:
-                CONFIG.proxy_username = strdup(optarg);
+                CONFIG.proxy_username = STRDUP(optarg);
                 break;
             case 7:
-                CONFIG.proxy_password = strdup(optarg);
+                CONFIG.proxy_password = STRDUP(optarg);
                 break;
             case 8:
                 CONFIG.cache_enabled = 1;
@@ -345,19 +345,19 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
                 CONFIG.max_conns = (int)strtol(optarg, NULL, 10);
                 break;
             case 12:
-                CONFIG.user_agent = strdup(optarg);
+                CONFIG.user_agent = STRDUP(optarg);
                 break;
             case 13:
                 CONFIG.http_wait_sec = (int)strtol(optarg, NULL, 10);
                 break;
             case 14:
-                CONFIG.cache_dir = strdup(optarg);
+                CONFIG.cache_dir = STRDUP(optarg);
                 break;
             case 15:
-                CONFIG.sonic_username = strdup(optarg);
+                CONFIG.sonic_username = STRDUP(optarg);
                 break;
             case 16:
-                CONFIG.sonic_password = strdup(optarg);
+                CONFIG.sonic_password = STRDUP(optarg);
                 break;
             case 17:
                 CONFIG.sonic_id3 = 1;
@@ -380,10 +380,10 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
                 CONFIG.mode = SINGLE;
                 break;
             case 23:
-                CONFIG.cafile = strdup(optarg);
+                CONFIG.cafile = STRDUP(optarg);
                 break;
             case 24:
-                CONFIG.proxy_cafile = strdup(optarg);
+                CONFIG.proxy_cafile = STRDUP(optarg);
                 break;
             case 25:
                 CONFIG.refresh_timeout = (int)strtol(optarg, NULL, 10);
@@ -422,9 +422,9 @@ void add_arg(char ***fuse_argv_ptr, int *fuse_argc, char *opt_string)
 {
     (*fuse_argc)++;
     *fuse_argv_ptr
-        = (char **)realloc((void *)*fuse_argv_ptr, *fuse_argc * sizeof(char *));
+        = (char **)REALLOC((void *)*fuse_argv_ptr, *fuse_argc * sizeof(char *));
     char **fuse_argv = *fuse_argv_ptr;
-    fuse_argv[*fuse_argc - 1] = strdup(opt_string);
+    fuse_argv[*fuse_argc - 1] = STRDUP(opt_string);
 }
 
 static void print_help(char *program_name, int long_help)

--- a/src/main.c
+++ b/src/main.c
@@ -63,7 +63,13 @@ int main(int argc, char **argv)
     for (int i = 1; i < argc; i++) {
         add_arg(&all_argv, &all_argc, argv[i]);
         if (!strcmp(argv[i], "--config")) {
+            if (i + 1 >= argc) {
+                lprintf(fatal, "--config requires a path\n");
+            }
+            FREE(config_path);
             config_path = STRDUP(argv[i + 1]);
+            add_arg(&all_argv, &all_argc, argv[i + 1]);
+            i++;
         }
     }
 
@@ -157,12 +163,12 @@ fuse_start:
     for (int i = 0; i < all_argc; i++) {
         FREE(all_argv[i]);
     }
-    FREE((void *)all_argv);
+    FREE(all_argv);
 
     for (int i = 0; i < fuse_argc; i++) {
         FREE(fuse_argv[i]);
     }
-    FREE((void *)fuse_argv);
+    FREE(fuse_argv);
 
     FREE(config_path);
 
@@ -240,7 +246,9 @@ void parse_config_file(char ***argv, int *argc)
         }
         fclose(config);
     }
-    FREE(full_path);
+    if (full_path != config_path) {
+        FREE(full_path);
+    }
 }
 
 static int parse_arg_list(int argc, char **argv, char ***fuse_argv,

--- a/src/memcache.c
+++ b/src/memcache.c
@@ -12,12 +12,12 @@ size_t write_memory_callback(void *recv_data, size_t size, size_t nmemb,
     size_t recv_size = size * nmemb;
     TransferStruct *ts = (TransferStruct *)userp;
 
-    char *tmp = realloc(ts->data, ts->curr_size + recv_size + 1);
+    char *tmp = REALLOC(ts->data, ts->curr_size + recv_size + 1);
     if (!tmp) {
         /*
          * out of memory!
          */
-        lprintf(fatal, "realloc failure!\n");
+        lprintf(fatal, "REALLOC failure!\n");
     }
     ts->data = tmp;
 

--- a/src/network.c
+++ b/src/network.c
@@ -163,8 +163,8 @@ static void curl_process_msgs(CURLMsg *curl_msg, int n_running_curl,
  */
 int curl_multi_perform_once(void)
 {
-    lprintf(network_lock_debug, "thread %x: locking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: locking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&transfer_lock);
 
     /*
@@ -192,8 +192,8 @@ int curl_multi_perform_once(void)
         curl_process_msgs(curl_msg, n_running_curl, n_mesgs);
     }
 
-    lprintf(network_lock_debug, "thread %x: unlocking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: unlocking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&transfer_lock);
 
     return n_running_curl;
@@ -257,8 +257,8 @@ void transfer_blocking(CURL *curl)
         lprintf(error, "%s", curl_easy_strerror(ret));
     }
 
-    lprintf(network_lock_debug, "thread %x: locking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: locking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&transfer_lock);
 
     CURLMcode res = curl_multi_add_handle(curl_multi, curl);
@@ -266,8 +266,8 @@ void transfer_blocking(CURL *curl)
         lprintf(error, "%d, %s\n", res, curl_multi_strerror(res));
     }
 
-    lprintf(network_lock_debug, "thread %x: unlocking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: unlocking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&transfer_lock);
 
     while (ts->transferring) {
@@ -277,8 +277,8 @@ void transfer_blocking(CURL *curl)
 
 void transfer_nonblocking(CURL *curl)
 {
-    lprintf(network_lock_debug, "thread %x: locking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: locking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&transfer_lock);
 
     CURLMcode res = curl_multi_add_handle(curl_multi, curl);
@@ -286,8 +286,8 @@ void transfer_nonblocking(CURL *curl)
         lprintf(error, "%s\n", curl_multi_strerror(res));
     }
 
-    lprintf(network_lock_debug, "thread %x: unlocking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: unlocking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&transfer_lock);
 }
 

--- a/src/sonic.c
+++ b/src/sonic.c
@@ -29,7 +29,7 @@ static SonicConfigStruct SONIC_CONFIG;
 void sonic_config_init(const char *server, const char *username,
                        const char *password)
 {
-    SONIC_CONFIG.server = strndup(server, MAX_PATH_LEN);
+    SONIC_CONFIG.server = STRNDUP(server, MAX_PATH_LEN);
     /*
      * Correct for the extra '/'
      */
@@ -37,8 +37,8 @@ void sonic_config_init(const char *server, const char *username,
     if (SONIC_CONFIG.server[server_url_len] == '/') {
         SONIC_CONFIG.server[server_url_len] = '\0';
     }
-    SONIC_CONFIG.username = strndup(username, MAX_FILENAME_LEN);
-    SONIC_CONFIG.password = strndup(password, MAX_FILENAME_LEN);
+    SONIC_CONFIG.username = STRNDUP(username, MAX_FILENAME_LEN);
+    SONIC_CONFIG.password = STRNDUP(password, MAX_FILENAME_LEN);
     SONIC_CONFIG.client = DEFAULT_USER_AGENT;
 
     if (!CONFIG.sonic_insecure) {

--- a/src/util.c
+++ b/src/util.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "log.h"
 
+#include <curl/curl.h>
 #include <openssl/evp.h>
 #include <uuid/uuid.h>
 
@@ -28,6 +29,9 @@
  * \details This is basically the length of a UUID
  */
 #define SALT_LEN 36
+
+static MemNode *mem_head = NULL;
+static pthread_mutex_t mem_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 char *path_append(const char *path, const char *filename)
 {
@@ -87,8 +91,8 @@ void pthread_mutex_destroy_wrapper(pthread_mutex_t *x, const char *file,
     ret = pthread_mutex_destroy(x);
     if (ret) {
         fatal_log_printf(file, func, line,
-                         "%lx pthread_mutex_destroy: %d, %s\n",
-                         (unsigned long)pthread_self(), ret, strerror(ret));
+                         "%lx pthread_mutex_destroy: %d, %s\n", pthread_self(),
+                         ret, strerror(ret));
     }
 }
 
@@ -242,19 +246,188 @@ char *generate_md5sum(const char *str)
     return out;
 }
 
-void *CALLOC(size_t nmemb, size_t size)
+void *CALLOC_wrapper(size_t nmemb, size_t size, const char *file,
+                     const char *func, int line)
 {
     void *ptr = calloc(nmemb, size);
     if (!ptr) {
-        lprintf(fatal, "%s!\n", strerror(errno));
+        fatal_log_printf(file, func, line, "%s!\n", strerror(errno));
+    }
+
+    log_printf(debug, file, func, line, "CALLOC: %p, %zu bytes\n", ptr,
+               nmemb * size);
+
+    MemNode *node = calloc(1, sizeof(MemNode));
+    if (!node) {
+        fatal_log_printf(file, func, line, "Could not allocate MemNode: %s!\n",
+                         strerror(errno));
+    }
+    node->ptr = ptr;
+    node->size = nmemb * size;
+    node->file = file;
+    node->func = func;
+    node->line = line;
+
+    pthread_mutex_lock(&mem_mutex);
+    node->next = mem_head;
+    mem_head = node;
+    pthread_mutex_unlock(&mem_mutex);
+
+    return ptr;
+}
+
+char *STRDUP_wrapper(const char *s, const char *file, const char *func,
+                     int line)
+{
+    if (!s) {
+        return NULL;
+    }
+    size_t len = strlen(s) + 1;
+    char *ptr = CALLOC_wrapper(len, sizeof(char), file, func, line);
+    if (ptr) {
+        memcpy(ptr, s, len);
     }
     return ptr;
 }
 
-void FREE(void *ptr)
+char *STRNDUP_wrapper(const char *s, size_t n, const char *file,
+                      const char *func, int line)
 {
+    if (!s) {
+        return NULL;
+    }
+    size_t len = strnlen(s, n);
+    char *ptr = CALLOC_wrapper(len + 1, sizeof(char), file, func, line);
     if (ptr) {
-        free(ptr);
+        memcpy(ptr, s, len);
+        ptr[len] = '\0';
+    }
+    return ptr;
+}
+
+void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
+                      const char *func, int line)
+{
+    if (!ptr) {
+        return CALLOC_wrapper(1, size, file, func, line);
+    }
+
+    pthread_mutex_lock(&mem_mutex);
+    MemNode **curr = &mem_head;
+    while (*curr) {
+        if ((*curr)->ptr == ptr) {
+            MemNode *node = *curr;
+            log_printf(debug, file, func, line, "REALLOC: %p, %zu bytes\n", ptr,
+                       size);
+            void *new_ptr = realloc(ptr, size);
+            if (!new_ptr) {
+                pthread_mutex_unlock(&mem_mutex);
+                fatal_log_printf(file, func, line, "realloc failed: %s!\n",
+                                 strerror(errno));
+            }
+            node->ptr = new_ptr;
+            node->size = size;
+            node->file = file;
+            node->func = func;
+            node->line = line;
+            pthread_mutex_unlock(&mem_mutex);
+            log_printf(debug, file, func, line, "REALLOC result: %p\n",
+                       new_ptr);
+            return new_ptr;
+        }
+        curr = &((*curr)->next);
+    }
+    pthread_mutex_unlock(&mem_mutex);
+
+    log_printf(warning, file, func, line, "REALLOC: %p not found in tracker!\n",
+               ptr);
+    void *new_ptr = realloc(ptr, size);
+    if (!new_ptr) {
+        fatal_log_printf(file, func, line, "realloc failed: %s!\n",
+                         strerror(errno));
+    }
+    return new_ptr;
+}
+
+char *REALPATH_wrapper(const char *path, char *resolved_path, const char *file,
+                       const char *func, int line)
+{
+    char *res = realpath(path, resolved_path);
+    if (res && !resolved_path) {
+        log_printf(debug, file, func, line, "REALPATH: %p\n", (void *)res);
+        // We need to track the pointer returned by realpath
+        // But realpath uses malloc internally, so we should untrack it with
+        // free() later. Wait, our FREE_wrapper already handles pointers not in
+        // the tracker by calling free(). But if we want it to be deallocated at
+        // exit, we SHOULD track it.
+
+        MemNode *node = calloc(1, sizeof(MemNode));
+        if (!node) {
+            fatal_log_printf(file, func, line,
+                             "Could not allocate MemNode: %s!\n",
+                             strerror(errno));
+        }
+        node->ptr = res;
+        node->size = 0; // We don't know the size, but realpath returns a
+                        // null-terminated string
+        node->file = file;
+        node->func = func;
+        node->line = line;
+
+        pthread_mutex_lock(&mem_mutex);
+        node->next = mem_head;
+        mem_head = node;
+        pthread_mutex_unlock(&mem_mutex);
+    }
+    return res;
+}
+
+void FREE_wrapper(void *ptr, const char *file, const char *func, int line)
+{
+    if (!ptr) {
+        return;
+    }
+
+    pthread_mutex_lock(&mem_mutex);
+    MemNode **curr = &mem_head;
+    while (*curr) {
+        if ((*curr)->ptr == ptr) {
+            MemNode *to_free = *curr;
+            *curr = to_free->next;
+            free(to_free);
+            goto found;
+        }
+        curr = &((*curr)->next);
+    }
+    pthread_mutex_unlock(&mem_mutex);
+
+    log_printf(warning, file, func, line, "FREE: %p not found in tracker!\n",
+               ptr);
+    free(ptr);
+    return;
+
+found:
+    pthread_mutex_unlock(&mem_mutex);
+    log_printf(debug, file, func, line, "FREE: %p\n", ptr);
+    free(ptr);
+}
+
+void mem_cleanup(void)
+{
+    pthread_mutex_lock(&mem_mutex);
+    MemNode *curr = mem_head;
+    while (curr) {
+        MemNode *next = curr->next;
+        free(curr->ptr);
+        free(curr);
+        curr = next;
+    }
+    mem_head = NULL;
+    pthread_mutex_unlock(&mem_mutex);
+
+    if (CONFIG.http_headers) {
+        curl_slist_free_all(CONFIG.http_headers);
+        CONFIG.http_headers = NULL;
     }
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -59,8 +59,8 @@ void pthread_mutex_init_wrapper(pthread_mutex_t *x,
                                 const char *file, const char *func, int line,
                                 const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_init: %p, %p, %s\n",
-               pthread_self(), x, attr, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_init: %p, %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, (void *)attr, x_name);
     pthread_mutexattr_t mutex_attr;
     if (attr == NULL) {
         pthread_mutexattr_init(&mutex_attr);
@@ -69,8 +69,8 @@ void pthread_mutex_init_wrapper(pthread_mutex_t *x,
     }
     int ret = pthread_mutex_init(x, attr);
     if (ret) {
-        log_printf(fatal, file, func, line, "%x pthread_mutex_init: %d, %s\n",
-                   pthread_self(), ret, strerror(ret));
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_init: %d, %s\n",
+                         (unsigned long)pthread_self(), ret, strerror(ret));
     }
     if (attr == &mutex_attr) {
         pthread_mutexattr_destroy(&mutex_attr);
@@ -81,40 +81,40 @@ void pthread_mutex_destroy_wrapper(pthread_mutex_t *x, const char *file,
                                    const char *func, int line,
                                    const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_destroy: %p, %s\n",
-               pthread_self(), x, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_destroy: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, x_name);
     int ret;
     ret = pthread_mutex_destroy(x);
     if (ret) {
-        log_printf(fatal, file, func, line,
-                   "%x pthread_mutex_destroy: %d, %s\n", pthread_self(), ret,
-                   strerror(ret));
+        fatal_log_printf(file, func, line,
+                         "%lx pthread_mutex_destroy: %d, %s\n",
+                         (unsigned long)pthread_self(), ret, strerror(ret));
     }
 }
 
 void pthread_mutex_unlock_wrapper(const char *file, const char *func, int line,
                                   pthread_mutex_t *x, const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_unlock: %p, %s\n",
-               pthread_self(), x, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_unlock: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, x_name);
     int i;
     i = pthread_mutex_unlock(x);
     if (i) {
-        log_printf(fatal, file, func, line, "%x pthread_mutex_unlock: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_unlock: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 
 void pthread_mutex_lock_wrapper(const char *file, const char *func, int line,
                                 pthread_mutex_t *x, const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_lock: %p, %s\n",
-               pthread_self(), x, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_lock: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, x_name);
     int i;
     i = pthread_mutex_lock(x);
     if (i) {
-        log_printf(fatal, file, func, line, "%x pthread_mutex_unlock: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_unlock: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 
@@ -122,26 +122,27 @@ void sem_init_wrapper(sem_t *sem, int pshared, unsigned int value,
                       const char *file, const char *func, int line,
                       const char *sem_name)
 {
-    log_printf(debug, file, func, line, "%x sem_init: %p, %d, %u, %s\n",
-               pthread_self(), sem, pshared, value, sem_name);
+    log_printf(debug, file, func, line, "%lx sem_init: %p, %d, %u, %s\n",
+               (unsigned long)pthread_self(), (void *)sem, pshared, value,
+               sem_name);
     int i;
     i = sem_init(sem, pshared, value);
     if (i) {
-        log_printf(fatal, file, func, line, "%x sem_init: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx sem_init: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 
 void sem_destroy_wrapper(sem_t *sem, const char *file, const char *func,
                          int line, const char *sem_name)
 {
-    log_printf(debug, file, func, line, "%x sem_destroy: %p, %s\n",
-               pthread_self(), sem, sem_name);
+    log_printf(debug, file, func, line, "%lx sem_destroy: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)sem, sem_name);
     int i;
     i = sem_destroy(sem);
     if (i) {
-        log_printf(fatal, file, func, line, "%x sem_destroy: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx sem_destroy: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 
@@ -150,29 +151,29 @@ void sem_wait_wrapper(const char *file, const char *func, int line, sem_t *sem,
 {
     int j;
     if (sem_getvalue(sem, &j)) {
-        log_printf(fatal, file, func, line, "%x sem_getvalue: %s\n",
-                   pthread_self(), strerror(errno));
+        fatal_log_printf(file, func, line, "%lx sem_getvalue: %s\n",
+                         (unsigned long)pthread_self(), strerror(errno));
     }
-    log_printf(debug, file, func, line, "%x sem_wait: %p, %s, value: %d\n",
-               pthread_self(), sem, sem_name, j);
+    log_printf(debug, file, func, line, "%lx sem_wait: %p, %s, value: %d\n",
+               (unsigned long)pthread_self(), (void *)sem, sem_name, j);
     int i;
     i = sem_wait(sem);
     if (i) {
-        log_printf(fatal, file, func, line, "%x sem_wait: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx sem_wait: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 
 void sem_post_wrapper(const char *file, const char *func, int line, sem_t *sem,
                       const char *sem_name)
 {
-    log_printf(debug, file, func, line, "%x sem_post: %p, %s\n", pthread_self(),
-               sem, sem_name);
+    log_printf(debug, file, func, line, "%lx sem_post: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)sem, sem_name);
     int i;
     i = sem_post(sem);
     if (i) {
-        log_printf(fatal, file, func, line, "%x sem_post: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx sem_post: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -417,7 +417,9 @@ found:
 
 void mem_cleanup(void)
 {
-    pthread_mutex_lock(&mem_mutex);
+    if (pthread_mutex_trylock(&mem_mutex) != 0) {
+        goto cleanup_headers;
+    }
     MemNode *curr = mem_head;
     while (curr) {
         MemNode *next = curr->next;
@@ -428,6 +430,7 @@ void mem_cleanup(void)
     mem_head = NULL;
     pthread_mutex_unlock(&mem_mutex);
 
+cleanup_headers:
     if (CONFIG.http_headers) {
         curl_slist_free_all(CONFIG.http_headers);
         CONFIG.http_headers = NULL;

--- a/src/util.c
+++ b/src/util.c
@@ -91,8 +91,8 @@ void pthread_mutex_destroy_wrapper(pthread_mutex_t *x, const char *file,
     ret = pthread_mutex_destroy(x);
     if (ret) {
         fatal_log_printf(file, func, line,
-                         "%lx pthread_mutex_destroy: %d, %s\n", pthread_self(),
-                         ret, strerror(ret));
+                         "%lx pthread_mutex_destroy: %d, %s\n",
+                         (unsigned long)pthread_self(), ret, strerror(ret));
     }
 }
 
@@ -117,7 +117,7 @@ void pthread_mutex_lock_wrapper(const char *file, const char *func, int line,
     int i;
     i = pthread_mutex_lock(x);
     if (i) {
-        fatal_log_printf(file, func, line, "%lx pthread_mutex_unlock: %d, %s\n",
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_lock: %d, %s\n",
                          (unsigned long)pthread_self(), i, strerror(i));
     }
 }
@@ -131,9 +131,10 @@ void sem_init_wrapper(sem_t *sem, int pshared, unsigned int value,
                sem_name);
     int i;
     i = sem_init(sem, pshared, value);
-    if (i) {
+    if (i == -1) {
+        int err = errno;
         fatal_log_printf(file, func, line, "%lx sem_init: %d, %s\n",
-                         (unsigned long)pthread_self(), i, strerror(i));
+                         (unsigned long)pthread_self(), err, strerror(err));
     }
 }
 
@@ -144,9 +145,10 @@ void sem_destroy_wrapper(sem_t *sem, const char *file, const char *func,
                (unsigned long)pthread_self(), (void *)sem, sem_name);
     int i;
     i = sem_destroy(sem);
-    if (i) {
+    if (i == -1) {
+        int err = errno;
         fatal_log_printf(file, func, line, "%lx sem_destroy: %d, %s\n",
-                         (unsigned long)pthread_self(), i, strerror(i));
+                         (unsigned long)pthread_self(), err, strerror(err));
     }
 }
 
@@ -162,9 +164,10 @@ void sem_wait_wrapper(const char *file, const char *func, int line, sem_t *sem,
                (unsigned long)pthread_self(), (void *)sem, sem_name, j);
     int i;
     i = sem_wait(sem);
-    if (i) {
+    if (i == -1) {
+        int err = errno;
         fatal_log_printf(file, func, line, "%lx sem_wait: %d, %s\n",
-                         (unsigned long)pthread_self(), i, strerror(i));
+                         (unsigned long)pthread_self(), err, strerror(err));
     }
 }
 
@@ -175,9 +178,10 @@ void sem_post_wrapper(const char *file, const char *func, int line, sem_t *sem,
                (unsigned long)pthread_self(), (void *)sem, sem_name);
     int i;
     i = sem_post(sem);
-    if (i) {
+    if (i == -1) {
+        int err = errno;
         fatal_log_printf(file, func, line, "%lx sem_post: %d, %s\n",
-                         (unsigned long)pthread_self(), i, strerror(i));
+                         (unsigned long)pthread_self(), err, strerror(err));
     }
 }
 
@@ -368,8 +372,7 @@ char *REALPATH_wrapper(const char *path, char *resolved_path, const char *file,
                              strerror(errno));
         }
         node->ptr = res;
-        node->size = 0; // We don't know the size, but realpath returns a
-                        // null-terminated string
+        node->size = strlen(res) + 1; // Store actual length of allocated string
         node->file = file;
         node->func = func;
         node->line = line;

--- a/src/util.h
+++ b/src/util.h
@@ -114,14 +114,65 @@ char *generate_salt(void);
 char *generate_md5sum(const char *str);
 
 /**
- * \brief wrapper for calloc(), with error handling
+ * \brief memory allocation tracker node
  */
-void *CALLOC(size_t nmemb, size_t size);
+typedef struct MemNode {
+    void *ptr;
+    size_t size;
+    const char *file;
+    const char *func;
+    int line;
+    struct MemNode *next;
+} MemNode;
+
+/**
+ * \brief wrapper for calloc(), with error handling and memory tracking
+ */
+void *CALLOC_wrapper(size_t nmemb, size_t size, const char *file,
+                     const char *func, int line);
+#define CALLOC(nmemb, size)                                                    \
+    CALLOC_wrapper(nmemb, size, __FILE__, __func__, __LINE__)
 
 /**
  * \brief wrapper for free(), but the pointer is set to NULL afterwards.
  */
-void FREE(void *ptr);
+void FREE_wrapper(void *ptr, const char *file, const char *func, int line);
+#define FREE(ptr) FREE_wrapper(ptr, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for STRDUP(), with memory tracking
+ */
+char *STRDUP_wrapper(const char *s, const char *file, const char *func,
+                     int line);
+#define STRDUP(s) STRDUP_wrapper(s, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for STRNDUP(), with memory tracking
+ */
+char *STRNDUP_wrapper(const char *s, size_t n, const char *file,
+                      const char *func, int line);
+#define STRNDUP(s, n) STRNDUP_wrapper(s, n, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for realloc(), with memory tracking
+ */
+void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
+                      const char *func, int line);
+#define REALLOC(ptr, size)                                                     \
+    REALLOC_wrapper(ptr, size, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for realpath(), with memory tracking
+ */
+char *REALPATH_wrapper(const char *path, char *resolved_path, const char *file,
+                       const char *func, int line);
+#define REALPATH(path, resolved_path)                                          \
+    REALPATH_wrapper(path, resolved_path, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief cleanup all allocated memory
+ */
+void mem_cleanup(void);
 
 /**
  * \brief Convert a string to hex

--- a/src/util.h
+++ b/src/util.h
@@ -137,7 +137,11 @@ void *CALLOC_wrapper(size_t nmemb, size_t size, const char *file,
  * \brief wrapper for free(), but the pointer is set to NULL afterwards.
  */
 void FREE_wrapper(void *ptr, const char *file, const char *func, int line);
-#define FREE(ptr) FREE_wrapper(ptr, __FILE__, __func__, __LINE__)
+#define FREE(ptr)                                                              \
+    do {                                                                       \
+        FREE_wrapper((void *)(ptr), __FILE__, __func__, __LINE__);             \
+        (ptr) = NULL;                                                          \
+    } while (0)
 
 /**
  * \brief wrapper for STRDUP(), with memory tracking


### PR DESCRIPTION
### Description
This PR introduces two major improvements to the codebase: a centralized fatal error logging system and a custom memory tracking infrastructure.

### Rationale

#### 1. Centralized Fatal Logging
Previously, fatal errors required a manual call to `exit_failure()` immediately following a `log_printf(fatal, ...)` call. This pattern was repetitive and caused static analysis tools like `clang-tidy` to report unreachable code or potential control flow issues because the compiler didn't know `log_printf` could terminate the program.
- **Solution**: Introduced `fatal_log_printf` with `__attribute__((noreturn))`.
- **Benefits**: Cleaner code, better compiler optimizations, and satisfied static analysis requirements.

#### 2. Custom Memory Tracking
To improve resource management and simplify debugging of memory leaks, a tracking layer was added over standard allocation functions.
- **Solution**: Implemented a global allocation list (`MemNode`) and wrapped standard functions (`calloc`, `free`, `strdup`, etc.).
- **Benefits**: Automatic cleanup on exit via `atexit(mem_cleanup)`, and precise tracking of allocation sources (file, function, line).

### Changes
- **log.c/h**: Centralized fatal exit logic and updated `lprintf` macro.
- **util.c/h**: Implemented `MemNode` list and allocation wrappers.
- **config.c**: Registered `mem_cleanup` on process termination.
- **Global**: Standardized thread ID logging format and fixed various format string warnings across `link.c`, `cache.c`, and `util.c`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory cleanup at exit to reduce leaks.
  * Standardized logging formats to fix misreported thread IDs, numeric values, and error messages.

* **Refactor**
  * Centralized logging with clearer severity handling and a dedicated fatal path.
  * Reworked allocation helpers to track/manage dynamic memory with safer alloc/free wrappers (no public APIs changed).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->