### PR TITLE
sonic-id3: fix recursive root listing with artists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Reuse populated LinkTable to prevent memory leaks and redundant I/O
+  ([fba125c](https://github.com/fangfufu/httpdirfs/commit/fba125c)).
+- Fix Sonic ID3 recursive root listing with artists by improving parser
+  robustness ([6ea84ae](https://github.com/fangfufu/httpdirfs/commit/6ea84ae))
+  (https://github.com/fangfufu/httpdirfs/pull/213).
+
 ## [1.2.9] - 2026-05-13
 
 ### Added

--- a/src/link.c
+++ b/src/link.c
@@ -847,6 +847,7 @@ LinkTable *path_to_LinkTable(const char *path)
             return NULL;
         }
         tmp_link = link;
+        next_table = link->next_table;
     }
 
     if (!next_table) {

--- a/src/sonic.c
+++ b/src/sonic.c
@@ -328,6 +328,26 @@ static void sanitise_LinkTable(LinkTable *linktbl)
     }
 }
 
+/*
+ * LinkTable of the <index> element currently being parsed by
+ * XML_parser_id3_root() / XML_parser_id3_root_end(). The previous
+ * "last link added to root" heuristic mis-parents artists when an
+ * <index> produces no link or when elements arrive in an unexpected
+ * order. Track the parent explicitly via an end-element handler.
+ */
+static LinkTable *id3_current_index_table = NULL;
+
+static void XMLCALL XML_parser_id3_root(void *data, const char *elem,
+                                        const char **attr);
+
+static void XMLCALL XML_parser_id3_root_end(void *data, const char *elem)
+{
+    (void)data;
+    if (!strcmp(elem, "index")) {
+        id3_current_index_table = NULL;
+    }
+}
+
 /**
  * \brief parse a XML string in order to fill in the LinkTable
  */
@@ -352,6 +372,11 @@ static LinkTable *sonic_url_to_LinkTable(const char *url,
 
     XML_SetStartElementHandler(parser, handler);
 
+    if (handler == &XML_parser_id3_root) {
+        id3_current_index_table = NULL;
+        XML_SetEndElementHandler(parser, XML_parser_id3_root_end);
+    }
+
     if (XML_Parse(parser, xml.data, xml.curr_size, 1) == XML_STATUS_ERROR) {
         lprintf(error, "Parse error at line %lu: %s\n",
                 XML_GetCurrentLineNumber(parser),
@@ -359,6 +384,7 @@ static LinkTable *sonic_url_to_LinkTable(const char *url,
     }
 
     XML_ParserFree(parser);
+    id3_current_index_table = NULL;
 
     FREE(xml.data);
 
@@ -393,14 +419,6 @@ static void XMLCALL XML_parser_id3_root(void *data, const char *elem,
     }
 
     LinkTable *root_linktbl = (LinkTable *)data;
-    LinkTable *this_linktbl = NULL;
-
-    /*
-     * Set the current linktbl, if we have more than head link.
-     */
-    if (root_linktbl->num > 1) {
-        this_linktbl = root_linktbl->links[root_linktbl->num - 1]->next_table;
-    }
 
     int id_set = 0;
     int linkname_set = 0;
@@ -426,11 +444,16 @@ static void XMLCALL XML_parser_id3_root(void *data, const char *elem,
          */
         if (linkname_set) {
             LinkTable_add(root_linktbl, link);
+            id3_current_index_table = link->next_table;
         } else {
             FREE(link);
         }
         return;
     } else if (!strcmp(elem, "artist")) {
+        if (!id3_current_index_table) {
+            lprintf(warning, "Ignoring <artist> outside of any <index>\n");
+            return;
+        }
         link = CALLOC(1, sizeof(Link));
         link->type = LINK_DIR;
         /*
@@ -456,11 +479,15 @@ static void XMLCALL XML_parser_id3_root(void *data, const char *elem,
          * Clean up if linkname is not set
          */
         if (!linkname_set || !id_set) {
+            if (link->sonic.id) {
+                FREE(link->sonic.id);
+            }
+
             FREE(link);
             return;
         }
 
-        LinkTable_add(this_linktbl, link);
+        LinkTable_add(id3_current_index_table, link);
     }
     /*
      * If we reach here, then this element does not contain directory structural


### PR DESCRIPTION
path_to_LinkTable() overwrites populated next_table causing recursive root listing under letter dirs.

The path_to_LinkTable() issue affects NORMAL and SINGLE modes too in principle (it always re-creates the table), but those modes' constructors (LinkTable_new with disk cache 1) are idempotent enough that users don't notice.
In SONIC ID3 mode, sonic_LinkTable_new_id3(0, NULL) is destructive, which is why this bug surfaces there.

Tested with funkhwale subsonic endpoint.

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ID3 index handling so artist listings no longer get lost or duplicated during navigation.

* **Performance**
  * Reused existing directory tables to avoid redundant reconstruction, reducing unnecessary work and improving listing stability.

* **Documentation**
  * Updated release notes to reflect the fix and related changes.



[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/213)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reuse existing in-memory directory tables to prevent redundant creation, reducing memory leaks and unnecessary I/O when revisiting directories.
  * Improve ID3 index parsing so artist entries are only added to the correct index context, preventing misplaced entries, data loss, and leaked resources during recursive root listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->