### PR TITLE
fix: improve synchronization wrappers and semaphore error handling

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -22,45 +22,57 @@ int log_level_init(void)
 #endif
 }
 
+static void vlog_printf(LogType type, const char *file, const char *func,
+                        int line, const char *format, va_list args)
+{
+    switch (type) {
+    case fatal:
+        fprintf(stderr, "Fatal:");
+        break;
+    case error:
+        fprintf(stderr, "Error:");
+        break;
+    case warning:
+        fprintf(stderr, "Warning:");
+        break;
+    case info:
+        goto print_actual_message;
+    default:
+        fprintf(stderr, "Debug");
+        if (type != debug) {
+            fprintf(stderr, "(%x)", type);
+        }
+        fprintf(stderr, ":");
+        break;
+    }
+
+    fprintf(stderr, "%s:%d:", file, line);
+
+print_actual_message: {
+}
+    fprintf(stderr, "%s: ", func);
+    vfprintf(stderr, format, args);
+}
+
 void log_printf(LogType type, const char *file, const char *func, int line,
                 const char *format, ...)
 {
     if (type & CONFIG.log_type) {
-        switch (type) {
-        case fatal:
-            fprintf(stderr, "Fatal:");
-            break;
-        case error:
-            fprintf(stderr, "Error:");
-            break;
-        case warning:
-            fprintf(stderr, "Warning:");
-            break;
-        case info:
-            goto print_actual_message;
-        default:
-            fprintf(stderr, "Debug");
-            if (type != debug) {
-                fprintf(stderr, "(%x)", type);
-            }
-            fprintf(stderr, ":");
-            break;
-        }
-
-        fprintf(stderr, "%s:%d:", file, line);
-
-    print_actual_message: {
-    }
-        fprintf(stderr, "%s: ", func);
         va_list args;
         va_start(args, format);
-        vfprintf(stderr, format, args);
+        vlog_printf(type, file, func, line, format, args);
         va_end(args);
-
-        if (type == fatal) {
-            exit_failure();
-        }
     }
+}
+
+void fatal_log_printf(const char *file, const char *func, int line,
+                      const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    vlog_printf(fatal, file, func, line, format, args);
+    va_end(args);
+    exit_failure();
 }
 
 void print_version(void)

--- a/src/log.h
+++ b/src/log.h
@@ -33,18 +33,24 @@ int log_level_init(void);
  * \details This is for printing nice log messages
  */
 void log_printf(LogType type, const char *file, const char *func, int line,
-                const char *format, ...);
+                const char *format, ...) __attribute__((format(printf, 5, 6)));
+
+/**
+ * \brief Fatal log printf
+ * \details This is for printing fatal error messages and exiting
+ */
+void fatal_log_printf(const char *file, const char *func, int line,
+                      const char *format, ...) __attribute__((noreturn))
+__attribute__((format(printf, 4, 5)));
 
 /**
  * \brief Log type printf
  * \details This macro automatically prints out the filename and line number
  */
 #define lprintf(type, ...)                                                     \
-    do {                                                                       \
-        log_printf(type, __FILE__, __func__, __LINE__, __VA_ARGS__);           \
-        if ((type) == fatal)                                                   \
-            exit_failure();                                                    \
-    } while (0)
+    ((type) == fatal                                                           \
+         ? fatal_log_printf(__FILE__, __func__, __LINE__, __VA_ARGS__)         \
+         : log_printf(type, __FILE__, __func__, __LINE__, __VA_ARGS__))
 
 /**
  * \brief Print the version information for HTTPDirFS

--- a/src/util.c
+++ b/src/util.c
@@ -59,8 +59,8 @@ void pthread_mutex_init_wrapper(pthread_mutex_t *x,
                                 const char *file, const char *func, int line,
                                 const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_init: %p, %p, %s\n",
-               pthread_self(), x, attr, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_init: %p, %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, (void *)attr, x_name);
     pthread_mutexattr_t mutex_attr;
     if (attr == NULL) {
         pthread_mutexattr_init(&mutex_attr);
@@ -69,8 +69,8 @@ void pthread_mutex_init_wrapper(pthread_mutex_t *x,
     }
     int ret = pthread_mutex_init(x, attr);
     if (ret) {
-        log_printf(fatal, file, func, line, "%x pthread_mutex_init: %d, %s\n",
-                   pthread_self(), ret, strerror(ret));
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_init: %d, %s\n",
+                         (unsigned long)pthread_self(), ret, strerror(ret));
     }
     if (attr == &mutex_attr) {
         pthread_mutexattr_destroy(&mutex_attr);
@@ -81,40 +81,40 @@ void pthread_mutex_destroy_wrapper(pthread_mutex_t *x, const char *file,
                                    const char *func, int line,
                                    const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_destroy: %p, %s\n",
-               pthread_self(), x, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_destroy: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, x_name);
     int ret;
     ret = pthread_mutex_destroy(x);
     if (ret) {
-        log_printf(fatal, file, func, line,
-                   "%x pthread_mutex_destroy: %d, %s\n", pthread_self(), ret,
-                   strerror(ret));
+        fatal_log_printf(file, func, line,
+                         "%lx pthread_mutex_destroy: %d, %s\n",
+                         (unsigned long)pthread_self(), ret, strerror(ret));
     }
 }
 
 void pthread_mutex_unlock_wrapper(const char *file, const char *func, int line,
                                   pthread_mutex_t *x, const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_unlock: %p, %s\n",
-               pthread_self(), x, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_unlock: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, x_name);
     int i;
     i = pthread_mutex_unlock(x);
     if (i) {
-        log_printf(fatal, file, func, line, "%x pthread_mutex_unlock: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_unlock: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 
 void pthread_mutex_lock_wrapper(const char *file, const char *func, int line,
                                 pthread_mutex_t *x, const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_lock: %p, %s\n",
-               pthread_self(), x, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_lock: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, x_name);
     int i;
     i = pthread_mutex_lock(x);
     if (i) {
-        log_printf(fatal, file, func, line, "%x pthread_mutex_unlock: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_lock: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 
@@ -122,26 +122,29 @@ void sem_init_wrapper(sem_t *sem, int pshared, unsigned int value,
                       const char *file, const char *func, int line,
                       const char *sem_name)
 {
-    log_printf(debug, file, func, line, "%x sem_init: %p, %d, %u, %s\n",
-               pthread_self(), sem, pshared, value, sem_name);
+    log_printf(debug, file, func, line, "%lx sem_init: %p, %d, %u, %s\n",
+               (unsigned long)pthread_self(), (void *)sem, pshared, value,
+               sem_name);
     int i;
     i = sem_init(sem, pshared, value);
-    if (i) {
-        log_printf(fatal, file, func, line, "%x sem_init: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+    if (i == -1) {
+        int err = errno;
+        fatal_log_printf(file, func, line, "%lx sem_init: %d, %s\n",
+                         (unsigned long)pthread_self(), err, strerror(err));
     }
 }
 
 void sem_destroy_wrapper(sem_t *sem, const char *file, const char *func,
                          int line, const char *sem_name)
 {
-    log_printf(debug, file, func, line, "%x sem_destroy: %p, %s\n",
-               pthread_self(), sem, sem_name);
+    log_printf(debug, file, func, line, "%lx sem_destroy: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)sem, sem_name);
     int i;
     i = sem_destroy(sem);
-    if (i) {
-        log_printf(fatal, file, func, line, "%x sem_destroy: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+    if (i == -1) {
+        int err = errno;
+        fatal_log_printf(file, func, line, "%lx sem_destroy: %d, %s\n",
+                         (unsigned long)pthread_self(), err, strerror(err));
     }
 }
 
@@ -150,29 +153,31 @@ void sem_wait_wrapper(const char *file, const char *func, int line, sem_t *sem,
 {
     int j;
     if (sem_getvalue(sem, &j)) {
-        log_printf(fatal, file, func, line, "%x sem_getvalue: %s\n",
-                   pthread_self(), strerror(errno));
+        fatal_log_printf(file, func, line, "%lx sem_getvalue: %s\n",
+                         (unsigned long)pthread_self(), strerror(errno));
     }
-    log_printf(debug, file, func, line, "%x sem_wait: %p, %s, value: %d\n",
-               pthread_self(), sem, sem_name, j);
+    log_printf(debug, file, func, line, "%lx sem_wait: %p, %s, value: %d\n",
+               (unsigned long)pthread_self(), (void *)sem, sem_name, j);
     int i;
     i = sem_wait(sem);
-    if (i) {
-        log_printf(fatal, file, func, line, "%x sem_wait: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+    if (i == -1) {
+        int err = errno;
+        fatal_log_printf(file, func, line, "%lx sem_wait: %d, %s\n",
+                         (unsigned long)pthread_self(), err, strerror(err));
     }
 }
 
 void sem_post_wrapper(const char *file, const char *func, int line, sem_t *sem,
                       const char *sem_name)
 {
-    log_printf(debug, file, func, line, "%x sem_post: %p, %s\n", pthread_self(),
-               sem, sem_name);
+    log_printf(debug, file, func, line, "%lx sem_post: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)sem, sem_name);
     int i;
     i = sem_post(sem);
-    if (i) {
-        log_printf(fatal, file, func, line, "%x sem_post: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+    if (i == -1) {
+        int err = errno;
+        fatal_log_printf(file, func, line, "%lx sem_post: %d, %s\n",
+                         (unsigned long)pthread_self(), err, strerror(err));
     }
 }
 


### PR DESCRIPTION
Update pthread and semaphore wrappers to correctly handle errno,
fix format specifiers for pthread_self(), and use fatal_log_printf
for error reporting. Also fixed a typo in pthread_mutex_lock_wrapper.

This is part 2 of a series of cleanup and refactoring commits.
Depends on #216.