### PR TITLE
Refactor fatal logging infrastructure and address review comments

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -119,8 +119,8 @@ static char *CacheSystem_calc_dir(const char *url)
 
 void CacheSystem_init(const char *path, int url_supplied)
 {
-    lprintf(cache_lock_debug, "thread %x: initialise cf_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: initialise cf_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_INIT(&cf_lock, NULL);
 
     if (url_supplied) {
@@ -386,8 +386,8 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
         return -EINVAL;
     }
 
-    lprintf(cache_lock_debug, "thread %x: locking seek_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: locking seek_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&cf->seek_lock);
 
     long byte_read = 0;
@@ -434,8 +434,8 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
 
 end:
 
-    lprintf(cache_lock_debug, "thread %x: unlocking seek_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking seek_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf->seek_lock);
     return byte_read;
 }
@@ -459,8 +459,8 @@ static long Data_write(Cache *cf, const uint8_t *buf, off_t len, off_t offset)
         return 0;
     }
 
-    lprintf(cache_lock_debug, "thread %x: locking seek_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: locking seek_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&cf->seek_lock);
 
     long byte_written = 0;
@@ -489,8 +489,8 @@ static long Data_write(Cache *cf, const uint8_t *buf, off_t len, off_t offset)
     }
 
 end:
-    lprintf(cache_lock_debug, "thread %x: unlocking seek_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking seek_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf->seek_lock);
     return byte_written;
 }
@@ -760,13 +760,14 @@ Cache *Cache_open(const char *fn)
         return NULL;
     }
 
-    lprintf(cache_lock_debug, "thread %x: locking cf_lock;\n", pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: locking cf_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&cf_lock);
 
     if (link->cache_ptr) {
         link->cache_ptr->cache_opened++;
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return link->cache_ptr;
     }
@@ -777,16 +778,16 @@ Cache *Cache_open(const char *fn)
     if (CONFIG.mode == NORMAL || CONFIG.mode == SINGLE) {
         if (Cache_exist(fn)) {
 
-            lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                    pthread_self());
+            lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                    (unsigned long)pthread_self());
             PTHREAD_MUTEX_UNLOCK(&cf_lock);
             return NULL;
         }
     } else if (CONFIG.mode == SONIC) {
         if (Cache_exist(link->sonic.id)) {
 
-            lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                    pthread_self());
+            lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                    (unsigned long)pthread_self());
             PTHREAD_MUTEX_UNLOCK(&cf_lock);
             return NULL;
         }
@@ -823,8 +824,8 @@ Cache *Cache_open(const char *fn)
         lprintf(error, "cannot open metadata file %s.\n", fn);
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -836,8 +837,8 @@ Cache *Cache_open(const char *fn)
         lprintf(error, "metadata error: %s.\n", fn);
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -853,8 +854,8 @@ cf->content_length: %ld, Data_size(fn): %ld.\n",
                 fn, cf->content_length, Data_size(fn));
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -866,8 +867,8 @@ cf->content_length: %ld, Data_size(fn): %ld.\n",
         lprintf(warning, "outdated cache file: %s.\n", fn);
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -876,8 +877,8 @@ cf->content_length: %ld, Data_size(fn): %ld.\n",
         lprintf(error, "cannot open data file %s.\n", fn);
         Cache_free(cf);
 
-        lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return NULL;
     }
@@ -887,24 +888,24 @@ cf->content_length: %ld, Data_size(fn): %ld.\n",
      */
     cf->link->cache_ptr = cf;
 
-    lprintf(cache_lock_debug, "thread %x: unlocking cf_lock;\n",
-            pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf_lock);
     return cf;
 }
 
 void Cache_close(Cache *cf)
 {
-    lprintf(cache_lock_debug, "thread %x: locking cf_lock: %s\n",
-            pthread_self(), cf->path);
+    lprintf(cache_lock_debug, "thread %lx: locking cf_lock: %s\n",
+            (unsigned long)pthread_self(), cf->path);
     PTHREAD_MUTEX_LOCK(&cf_lock);
 
     cf->cache_opened--;
 
     if (cf->cache_opened > 0) {
         lprintf(cache_lock_debug,
-                "thread %x: unlocking cf_lock: %s, cache_opened: %d\n",
-                pthread_self(), cf->path, cf->cache_opened);
+                "thread %lx: unlocking cf_lock: %s, cache_opened: %d\n",
+                (unsigned long)pthread_self(), cf->path, cf->cache_opened);
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         return;
     }
@@ -915,8 +916,8 @@ void Cache_close(Cache *cf)
      * running. This will cause a use-after-free error.
      */
     lprintf(cache_lock_debug,
-            "thread %x: waiting for background download to finish for %s\n",
-            pthread_self(), cf->path);
+            "thread %lx: waiting for background download to finish for %s\n",
+            (unsigned long)pthread_self(), cf->path);
     SEM_WAIT(&cf->bgt_sem);
 
     if (Meta_write(cf)) {
@@ -934,8 +935,8 @@ void Cache_close(Cache *cf)
     cf->link->cache_ptr = NULL;
 
     lprintf(cache_lock_debug,
-            "thread %x: unlocking cf_lock, cache closed: %s\n", pthread_self(),
-            cf->path);
+            "thread %lx: unlocking cf_lock, cache closed: %s\n",
+            (unsigned long)pthread_self(), cf->path);
     Cache_free(cf);
     PTHREAD_MUTEX_UNLOCK(&cf_lock);
 }
@@ -973,17 +974,19 @@ static void *Cache_bgdl(void *arg)
 {
     Cache *cf = (Cache *)arg;
 
-    lprintf(cache_lock_debug, "thread %x: locking w_lock;\n", pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: locking w_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&cf->w_lock);
 
     uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
-    lprintf(debug, "thread %x spawned.\n ", pthread_self());
+    lprintf(debug, "thread %lx spawned.\n ", (unsigned long)pthread_self());
     long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz,
                               cf->next_dl_offset);
     if (recv < 0) {
-        lprintf(error, "thread %x received %ld bytes, \
-which doesn't make sense\n",
-                pthread_self(), recv);
+        lprintf(error,
+                "thread %lx received %ld bytes, "
+                "which doesn't make sense\n",
+                (unsigned long)pthread_self(), recv);
     }
 
     if ((recv == cf->blksz)
@@ -993,14 +996,16 @@ which doesn't make sense\n",
             Seg_set(cf, cf->next_dl_offset, 1);
         }
     } else {
-        lprintf(error, "received %ld rather than %ld, possible network \
-error.\n",
+        lprintf(error,
+                "received %ld rather than %d, possible network "
+                "error.\n",
                 recv, cf->blksz);
     }
 
     FREE(recv_buf);
 
-    lprintf(cache_lock_debug, "thread %x: unlocking w_lock;\n", pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
     SEM_POST(&cf->bgt_sem);
 
@@ -1052,8 +1057,8 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
          * Wait for any other download thread to finish
          */
 
-        lprintf(cache_lock_debug, "thread %ld: locking w_lock;\n",
-                pthread_self());
+        lprintf(cache_lock_debug, "thread %lx: locking w_lock;\n",
+                (unsigned long)pthread_self());
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
 
         if (Seg_exist(cf, dl_offset)) {
@@ -1063,8 +1068,8 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
              */
             send = Data_read(cf, (uint8_t *)output_buf, len, offset_start);
 
-            lprintf(cache_lock_debug, "thread %x: unlocking w_lock;\n",
-                    pthread_self());
+            lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
+                    (unsigned long)pthread_self());
             PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
 
             goto bgdl;
@@ -1076,12 +1081,13 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
      */
 
     uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
-    lprintf(debug, "thread %x: spawned.\n ", pthread_self());
+    lprintf(debug, "thread %lx: spawned.\n ", (unsigned long)pthread_self());
     long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz, dl_offset);
     if (recv < 0) {
-        lprintf(error, "thread %x received %ld bytes, \
-which doesn't make sense\n",
-                pthread_self(), recv);
+        lprintf(error,
+                "thread %lx received %ld bytes, "
+                "which doesn't make sense\n",
+                (unsigned long)pthread_self(), recv);
     }
     /*
      * check if we have received enough data, write it to the disk
@@ -1095,8 +1101,9 @@ which doesn't make sense\n",
             Seg_set(cf, dl_offset, 1);
         }
     } else {
-        lprintf(error, "received %ld rather than %ld, possible network \
-error.\n",
+        lprintf(error,
+                "received %ld rather than %d, possible network "
+                "error.\n",
                 recv, cf->blksz);
     }
     send = len;
@@ -1110,7 +1117,8 @@ error.\n",
     }
     FREE(recv_buf);
 
-    lprintf(cache_lock_debug, "thread %x: unlocking w_lock;\n", pthread_self());
+    lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
 
     /*
@@ -1126,8 +1134,8 @@ bgdl: {
         int ret = sem_trywait(&cf->bgt_sem);
         if (!ret) {
             lprintf(cache_lock_debug,
-                    "parent thread %x: sem_trywait successful\n",
-                    pthread_self());
+                    "parent thread %lx: sem_trywait successful\n",
+                    (unsigned long)pthread_self());
             cf->next_dl_offset = next_dl_offset;
             Cache_bgdl_launcher(cf);
         } else if (errno != EAGAIN) {

--- a/src/link.c
+++ b/src/link.c
@@ -438,7 +438,7 @@ static int linknames_equal(const char *str_a, const char *str_b)
     }
 
 end:
-    lprintf(debug, "linknames comparison: a: %s, b: %s, max_len: %d %s\n",
+    lprintf(debug, "linknames comparison: a: %s, b: %s, max_len: %zu %s\n",
             str_a, str_b, comp_len, identical ? ", identical!" : "");
     return identical;
 }
@@ -592,7 +592,7 @@ void LinkTable_print(LinkTable *linktbl)
     if (CONFIG.log_type & info) {
         int j = 0;
         lprintf(info, "--------------------------------------------\n");
-        lprintf(info, " LinkTable %p for %s\n", linktbl,
+        lprintf(info, " LinkTable %p for %s\n", (void *)linktbl,
                 linktbl->links[0]->f_url);
         lprintf(info, "--------------------------------------------\n");
         for (int i = 0; i < linktbl->num; i++) {
@@ -649,10 +649,10 @@ LinkTable *LinkTable_new(const char *url)
              */
             time_t time_now = time(NULL);
             if (time_now - disk_linktbl->index_time > CONFIG.refresh_timeout) {
-                lprintf(info, "time_now: %d, index_time: %d\n", time_now,
-                        disk_linktbl->index_time);
-                lprintf(info, "diff: %d, limit: %d\n",
-                        time_now - disk_linktbl->index_time,
+                lprintf(info, "time_now: %ld, index_time: %ld\n",
+                        (long)time_now, (long)disk_linktbl->index_time);
+                lprintf(info, "diff: %ld, limit: %d\n",
+                        (long)(time_now - disk_linktbl->index_time),
                         CONFIG.refresh_timeout);
                 LinkTable_free(disk_linktbl);
             } else {
@@ -668,7 +668,7 @@ LinkTable *LinkTable_new(const char *url)
     if (!linktbl) {
         linktbl = LinkTable_alloc(url);
         linktbl->index_time = time(NULL);
-        lprintf(debug, "linktbl->index_time: %d\n", linktbl->index_time);
+        lprintf(debug, "linktbl->index_time: %ld\n", (long)linktbl->index_time);
 
         /*
          * start downloading the base URL
@@ -698,7 +698,7 @@ LinkTable *LinkTable_new(const char *url)
     }
 
     static unsigned long long i = 0;
-    lprintf(debug, "Calling LinkTable_new for the %d time!\n", i);
+    lprintf(debug, "Calling LinkTable_new for the %llu time!\n", i);
     i++;
 
     free(unescaped_path);
@@ -740,7 +740,7 @@ int LinkTable_disk_save(LinkTable *linktbl, const char *dirn)
         return -1;
     }
 
-    lprintf(debug, "linktbl->index_time: %d\n", linktbl->index_time);
+    lprintf(debug, "linktbl->index_time: %ld\n", (long)linktbl->index_time);
     if (fwrite(&linktbl->num, sizeof(int), 1, fp) != 1
         || fwrite(&linktbl->index_time, sizeof(time_t), 1, fp) != 1) {
         lprintf(error, "Failed to save the header of %s!\n", path);
@@ -800,7 +800,7 @@ LinkTable *LinkTable_disk_open(const char *dirn)
         FREE(path);
         return NULL;
     }
-    lprintf(debug, "linktbl->index_time: %d\n", linktbl->index_time);
+    lprintf(debug, "linktbl->index_time: %ld\n", (long)linktbl->index_time);
 
     linktbl->links = (Link **)CALLOC(linktbl->num, sizeof(Link *));
     for (int i = 0; i < linktbl->num; i++) {
@@ -964,7 +964,8 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
 
 Link *path_to_Link(const char *path)
 {
-    lprintf(link_lock_debug, "thread %x: locking link_lock;\n", pthread_self());
+    lprintf(link_lock_debug, "thread %lx: locking link_lock;\n",
+            (unsigned long)pthread_self());
 
     PTHREAD_MUTEX_LOCK(&link_lock);
     char *new_path = strndup(path, MAX_PATH_LEN);
@@ -974,8 +975,8 @@ Link *path_to_Link(const char *path)
     Link *link = path_to_Link_recursive(new_path, ROOT_LINK_TBL);
     FREE(new_path);
 
-    lprintf(link_lock_debug, "thread %x: unlocking link_lock;\n",
-            pthread_self());
+    lprintf(link_lock_debug, "thread %lx: unlocking link_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&link_lock);
     return link;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -22,45 +22,57 @@ int log_level_init(void)
 #endif
 }
 
+static void vlog_printf(LogType type, const char *file, const char *func,
+                        int line, const char *format, va_list args)
+{
+    switch (type) {
+    case fatal:
+        fprintf(stderr, "Fatal:");
+        break;
+    case error:
+        fprintf(stderr, "Error:");
+        break;
+    case warning:
+        fprintf(stderr, "Warning:");
+        break;
+    case info:
+        goto print_actual_message;
+    default:
+        fprintf(stderr, "Debug");
+        if (type != debug) {
+            fprintf(stderr, "(%x)", type);
+        }
+        fprintf(stderr, ":");
+        break;
+    }
+
+    fprintf(stderr, "%s:%d:", file, line);
+
+print_actual_message: {
+}
+    fprintf(stderr, "%s: ", func);
+    vfprintf(stderr, format, args);
+}
+
 void log_printf(LogType type, const char *file, const char *func, int line,
                 const char *format, ...)
 {
     if (type & CONFIG.log_type) {
-        switch (type) {
-        case fatal:
-            fprintf(stderr, "Fatal:");
-            break;
-        case error:
-            fprintf(stderr, "Error:");
-            break;
-        case warning:
-            fprintf(stderr, "Warning:");
-            break;
-        case info:
-            goto print_actual_message;
-        default:
-            fprintf(stderr, "Debug");
-            if (type != debug) {
-                fprintf(stderr, "(%x)", type);
-            }
-            fprintf(stderr, ":");
-            break;
-        }
-
-        fprintf(stderr, "%s:%d:", file, line);
-
-    print_actual_message: {
-    }
-        fprintf(stderr, "%s: ", func);
         va_list args;
         va_start(args, format);
-        vfprintf(stderr, format, args);
+        vlog_printf(type, file, func, line, format, args);
         va_end(args);
-
-        if (type == fatal) {
-            exit_failure();
-        }
     }
+}
+
+void fatal_log_printf(const char *file, const char *func, int line,
+                      const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    vlog_printf(fatal, file, func, line, format, args);
+    va_end(args);
+    exit_failure();
 }
 
 void print_version(void)

--- a/src/log.h
+++ b/src/log.h
@@ -33,7 +33,15 @@ int log_level_init(void);
  * \details This is for printing nice log messages
  */
 void log_printf(LogType type, const char *file, const char *func, int line,
-                const char *format, ...);
+                const char *format, ...) __attribute__((format(printf, 5, 6)));
+
+/**
+ * \brief Fatal log printf
+ * \details This is for printing fatal error messages and exiting
+ */
+void fatal_log_printf(const char *file, const char *func, int line,
+                      const char *format, ...) __attribute__((noreturn))
+__attribute__((format(printf, 4, 5)));
 
 /**
  * \brief Log type printf
@@ -41,9 +49,11 @@ void log_printf(LogType type, const char *file, const char *func, int line,
  */
 #define lprintf(type, ...)                                                     \
     do {                                                                       \
-        log_printf(type, __FILE__, __func__, __LINE__, __VA_ARGS__);           \
-        if ((type) == fatal)                                                   \
-            exit_failure();                                                    \
+        LogType _l_type = (type);                                              \
+        if (_l_type == fatal)                                                  \
+            fatal_log_printf(__FILE__, __func__, __LINE__, __VA_ARGS__);       \
+        else                                                                   \
+            log_printf(_l_type, __FILE__, __func__, __LINE__, __VA_ARGS__);    \
     } while (0)
 
 /**

--- a/src/network.c
+++ b/src/network.c
@@ -163,8 +163,8 @@ static void curl_process_msgs(CURLMsg *curl_msg, int n_running_curl,
  */
 int curl_multi_perform_once(void)
 {
-    lprintf(network_lock_debug, "thread %x: locking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: locking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&transfer_lock);
 
     /*
@@ -192,8 +192,8 @@ int curl_multi_perform_once(void)
         curl_process_msgs(curl_msg, n_running_curl, n_mesgs);
     }
 
-    lprintf(network_lock_debug, "thread %x: unlocking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: unlocking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&transfer_lock);
 
     return n_running_curl;
@@ -257,8 +257,8 @@ void transfer_blocking(CURL *curl)
         lprintf(error, "%s", curl_easy_strerror(ret));
     }
 
-    lprintf(network_lock_debug, "thread %x: locking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: locking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&transfer_lock);
 
     CURLMcode res = curl_multi_add_handle(curl_multi, curl);
@@ -266,8 +266,8 @@ void transfer_blocking(CURL *curl)
         lprintf(error, "%d, %s\n", res, curl_multi_strerror(res));
     }
 
-    lprintf(network_lock_debug, "thread %x: unlocking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: unlocking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&transfer_lock);
 
     while (ts->transferring) {
@@ -277,8 +277,8 @@ void transfer_blocking(CURL *curl)
 
 void transfer_nonblocking(CURL *curl)
 {
-    lprintf(network_lock_debug, "thread %x: locking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: locking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_LOCK(&transfer_lock);
 
     CURLMcode res = curl_multi_add_handle(curl_multi, curl);
@@ -286,8 +286,8 @@ void transfer_nonblocking(CURL *curl)
         lprintf(error, "%s\n", curl_multi_strerror(res));
     }
 
-    lprintf(network_lock_debug, "thread %x: unlocking transfer_lock;\n",
-            pthread_self());
+    lprintf(network_lock_debug, "thread %lx: unlocking transfer_lock;\n",
+            (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&transfer_lock);
 }
 

--- a/src/sonic.c
+++ b/src/sonic.c
@@ -498,7 +498,7 @@ static void XMLCALL XML_parser_id3_root(void *data, const char *elem,
 LinkTable *sonic_LinkTable_new_id3(int depth, const char *id)
 {
     char *url;
-    LinkTable *linktbl;
+    LinkTable *linktbl = NULL;
     switch (depth) {
     /*
      * Root table

--- a/src/util.c
+++ b/src/util.c
@@ -59,8 +59,9 @@ void pthread_mutex_init_wrapper(pthread_mutex_t *x,
                                 const char *file, const char *func, int line,
                                 const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_init: %p, %p, %s\n",
-               pthread_self(), x, attr, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_init: %p, %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, (const void *)attr,
+               x_name);
     pthread_mutexattr_t mutex_attr;
     if (attr == NULL) {
         pthread_mutexattr_init(&mutex_attr);
@@ -69,8 +70,8 @@ void pthread_mutex_init_wrapper(pthread_mutex_t *x,
     }
     int ret = pthread_mutex_init(x, attr);
     if (ret) {
-        log_printf(fatal, file, func, line, "%x pthread_mutex_init: %d, %s\n",
-                   pthread_self(), ret, strerror(ret));
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_init: %d, %s\n",
+                         (unsigned long)pthread_self(), ret, strerror(ret));
     }
     if (attr == &mutex_attr) {
         pthread_mutexattr_destroy(&mutex_attr);
@@ -81,40 +82,40 @@ void pthread_mutex_destroy_wrapper(pthread_mutex_t *x, const char *file,
                                    const char *func, int line,
                                    const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_destroy: %p, %s\n",
-               pthread_self(), x, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_destroy: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, x_name);
     int ret;
     ret = pthread_mutex_destroy(x);
     if (ret) {
-        log_printf(fatal, file, func, line,
-                   "%x pthread_mutex_destroy: %d, %s\n", pthread_self(), ret,
-                   strerror(ret));
+        fatal_log_printf(file, func, line,
+                         "%lx pthread_mutex_destroy: %d, %s\n",
+                         (unsigned long)pthread_self(), ret, strerror(ret));
     }
 }
 
 void pthread_mutex_unlock_wrapper(const char *file, const char *func, int line,
                                   pthread_mutex_t *x, const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_unlock: %p, %s\n",
-               pthread_self(), x, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_unlock: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, x_name);
     int i;
     i = pthread_mutex_unlock(x);
     if (i) {
-        log_printf(fatal, file, func, line, "%x pthread_mutex_unlock: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_unlock: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 
 void pthread_mutex_lock_wrapper(const char *file, const char *func, int line,
                                 pthread_mutex_t *x, const char *x_name)
 {
-    log_printf(debug, file, func, line, "%x pthread_mutex_lock: %p, %s\n",
-               pthread_self(), x, x_name);
+    log_printf(debug, file, func, line, "%lx pthread_mutex_lock: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)x, x_name);
     int i;
     i = pthread_mutex_lock(x);
     if (i) {
-        log_printf(fatal, file, func, line, "%x pthread_mutex_unlock: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        fatal_log_printf(file, func, line, "%lx pthread_mutex_lock: %d, %s\n",
+                         (unsigned long)pthread_self(), i, strerror(i));
     }
 }
 
@@ -122,26 +123,31 @@ void sem_init_wrapper(sem_t *sem, int pshared, unsigned int value,
                       const char *file, const char *func, int line,
                       const char *sem_name)
 {
-    log_printf(debug, file, func, line, "%x sem_init: %p, %d, %u, %s\n",
-               pthread_self(), sem, pshared, value, sem_name);
+    log_printf(debug, file, func, line, "%lx sem_init: %p, %d, %u, %s\n",
+               (unsigned long)pthread_self(), (void *)sem, pshared, value,
+               sem_name);
     int i;
     i = sem_init(sem, pshared, value);
     if (i) {
-        log_printf(fatal, file, func, line, "%x sem_init: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        int saved_errno = errno;
+        fatal_log_printf(file, func, line, "%lx sem_init: %d, %s\n",
+                         (unsigned long)pthread_self(), i,
+                         strerror(saved_errno));
     }
 }
 
 void sem_destroy_wrapper(sem_t *sem, const char *file, const char *func,
                          int line, const char *sem_name)
 {
-    log_printf(debug, file, func, line, "%x sem_destroy: %p, %s\n",
-               pthread_self(), sem, sem_name);
+    log_printf(debug, file, func, line, "%lx sem_destroy: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)sem, sem_name);
     int i;
     i = sem_destroy(sem);
     if (i) {
-        log_printf(fatal, file, func, line, "%x sem_destroy: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        int saved_errno = errno;
+        fatal_log_printf(file, func, line, "%lx sem_destroy: %d, %s\n",
+                         (unsigned long)pthread_self(), i,
+                         strerror(saved_errno));
     }
 }
 
@@ -150,29 +156,33 @@ void sem_wait_wrapper(const char *file, const char *func, int line, sem_t *sem,
 {
     int j;
     if (sem_getvalue(sem, &j)) {
-        log_printf(fatal, file, func, line, "%x sem_getvalue: %s\n",
-                   pthread_self(), strerror(errno));
+        fatal_log_printf(file, func, line, "%lx sem_getvalue: %s\n",
+                         (unsigned long)pthread_self(), strerror(errno));
     }
-    log_printf(debug, file, func, line, "%x sem_wait: %p, %s, value: %d\n",
-               pthread_self(), sem, sem_name, j);
+    log_printf(debug, file, func, line, "%lx sem_wait: %p, %s, value: %d\n",
+               (unsigned long)pthread_self(), (void *)sem, sem_name, j);
     int i;
     i = sem_wait(sem);
     if (i) {
-        log_printf(fatal, file, func, line, "%x sem_wait: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        int saved_errno = errno;
+        fatal_log_printf(file, func, line, "%lx sem_wait: %d, %s\n",
+                         (unsigned long)pthread_self(), i,
+                         strerror(saved_errno));
     }
 }
 
 void sem_post_wrapper(const char *file, const char *func, int line, sem_t *sem,
                       const char *sem_name)
 {
-    log_printf(debug, file, func, line, "%x sem_post: %p, %s\n", pthread_self(),
-               sem, sem_name);
+    log_printf(debug, file, func, line, "%lx sem_post: %p, %s\n",
+               (unsigned long)pthread_self(), (void *)sem, sem_name);
     int i;
     i = sem_post(sem);
     if (i) {
-        log_printf(fatal, file, func, line, "%x sem_post: %d, %s\n",
-                   pthread_self(), i, strerror(i));
+        int saved_errno = errno;
+        fatal_log_printf(file, func, line, "%lx sem_post: %d, %s\n",
+                         (unsigned long)pthread_self(), i,
+                         strerror(saved_errno));
     }
 }
 


### PR DESCRIPTION
This pull request centralizes the fatal logging infrastructure and addresses several review comments to improve code safety, thread-safety, and standards compliance.

### Key Changes:
- **Centralized Fatal Logging**: Introduced `fatal_log_printf()` and updated the `lprintf()` macro to ensure all fatal log paths are clearly marked for static analysis.
- **Ensured Correct Termination**: Restored `exit_failure()` calls for all fatal logging paths to guarantee the program exits on critical errors.
- **Standardized Thread IDs**: Updated logging calls to use `(unsigned long)` cast with `%lx` specifier for `pthread_self()` across the codebase for better portability and to satisfy `clang-tidy`.
- **Refactored `log_printf()`**: Removed redundant fatal handling from the main logging function as it is now exclusively handled by the dedicated fatal path.
- **CI & Pre-commit Compliance**: Fixed various formatting and linting issues identified by `clang-format` and `clang-tidy`.

These changes improve the overall robustness and maintainability of the logging system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure a local variable is initialized to avoid undefined return values.

* **Refactor**
  * Separated fatal error handling from standard logging.
  * Standardized log formatting and thread identification across components.
  * Improved format specifiers and error-message consistency for mutexes and semaphores.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->