### PR TITLE
refactor: enhance FREE macro and fix format specifiers

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "log.h"
 #include "util.h"
+#include <curl/curl.h>
 
 #include <sys/stat.h>
 

--- a/src/link.c
+++ b/src/link.c
@@ -582,7 +582,7 @@ void LinkTable_free(LinkTable *linktbl)
             LinkTable_free(linktbl->links[i]->next_table);
             FREE(linktbl->links[i]);
         }
-        FREE((void *)linktbl->links);
+        FREE(linktbl->links);
         FREE(linktbl);
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -171,12 +171,12 @@ fuse_start:
     for (int i = 0; i < all_argc; i++) {
         FREE(all_argv[i]);
     }
-    FREE((void *)all_argv);
+    FREE(all_argv);
 
     for (int i = 0; i < fuse_argc; i++) {
         FREE(fuse_argv[i]);
     }
-    FREE((void *)fuse_argv);
+    FREE(fuse_argv);
 
     FREE(config_path);
 

--- a/src/util.c
+++ b/src/util.c
@@ -261,7 +261,7 @@ void *CALLOC(size_t nmemb, size_t size)
     return ptr;
 }
 
-void FREE(void *ptr)
+void FREE_wrapper(void *ptr)
 {
     if (ptr) {
         free(ptr);

--- a/src/util.h
+++ b/src/util.h
@@ -119,9 +119,26 @@ char *generate_md5sum(const char *str);
 void *CALLOC(size_t nmemb, size_t size);
 
 /**
- * \brief wrapper for free(), but the pointer is set to NULL afterwards.
+ * \brief Internal wrapper for free().
  */
-void FREE(void *ptr);
+void FREE_wrapper(void *ptr);
+
+/**
+ * \brief Macro wrapper for free() that sets the pointer to NULL afterwards.
+ * \note This macro is safe for pointers to const data (e.g., const char *p)
+ * because it only modifies the pointer variable itself, not the data it points
+ * to. However, it will fail for const-qualified pointer variables (e.g., char *
+ * const p) as it attempts to set the pointer itself to NULL.
+ * \note When used on a function parameter (e.g., FREE(ptr)), it only nullifies
+ * the local copy of the pointer within the function scope. The caller's
+ * original pointer remains unchanged and may become a dangling pointer.
+ */
+#define FREE(ptr)                                                              \
+    do {                                                                       \
+        __extension__ __auto_type __ptr_to_free = &(ptr);                      \
+        FREE_wrapper((void *)*__ptr_to_free);                                  \
+        *__ptr_to_free = NULL;                                                 \
+    } while (0)
 
 /**
  * \brief Convert a string to hex


### PR DESCRIPTION
Update FREE to a macro that nullifies the pointer after freeing, removing the need for manual nullification and explicit (void *) casts. Also fixed numerous format specifier warnings and added proper pointer casts in logging calls to satisfy static analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal memory management and pointer handling throughout the codebase for improved code quality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->