### PR TITLE
feat: implement thread-safe custom memory tracking system

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -48,7 +48,7 @@ char *CacheSystem_get_cache_dir(void)
 
     const char *xdg_cache_home = getenv("XDG_CACHE_HOME");
     if (xdg_cache_home) {
-        cache_dir = strndup(xdg_cache_home, MAX_PATH_LEN);
+        cache_dir = STRNDUP(xdg_cache_home, MAX_PATH_LEN);
     } else {
         const char *user_home = getenv("HOME");
         if (user_home) {
@@ -59,7 +59,7 @@ char *CacheSystem_get_cache_dir(void)
              * XDG_CACHE_HOME and HOME already are full paths. Not relying
              * on environment PWD since it too may be undefined.
              */
-            const char *cur_dir = realpath("./", NULL);
+            const char *cur_dir = REALPATH("./", NULL);
             if (cur_dir) {
                 cache_dir = path_append(cur_dir, default_cache_subdir);
             } else {
@@ -706,7 +706,7 @@ int Cache_create(const char *path)
     lprintf(debug, "Creating cache files for %s.\n", fn);
 
     Cache *cf = Cache_alloc();
-    cf->path = strndup(fn, MAX_PATH_LEN);
+    cf->path = STRNDUP(fn, MAX_PATH_LEN);
     cf->time = this_link->time;
     cf->content_length = this_link->content_length;
     cf->blksz = CONFIG.data_blksz;
@@ -814,7 +814,7 @@ Cache *Cache_open(const char *fn)
         fn = link->sonic.id;
     }
 
-    cf->path = strndup(fn, MAX_PATH_LEN);
+    cf->path = STRNDUP(fn, MAX_PATH_LEN);
 
     /*
      * Associate the cache structure with a link

--- a/src/config.c
+++ b/src/config.c
@@ -1,7 +1,9 @@
 #include "config.h"
 
 #include "log.h"
+#include "util.h"
 #include <stddef.h>
+#include <stdlib.h>
 
 
 ConfigStruct CONFIG;
@@ -58,4 +60,5 @@ void Config_init(void)
     CONFIG.sonic_id3 = 0;
 
     CONFIG.sonic_insecure = 0;
+    atexit(mem_cleanup);
 }

--- a/src/link.c
+++ b/src/link.c
@@ -364,10 +364,10 @@ LinkTable *LinkSystem_init(const char *url)
 void LinkTable_add(LinkTable *linktbl, Link *link)
 {
     linktbl->num++;
-    Link **tmp = (Link **)realloc((void *)linktbl->links,
+    Link **tmp = (Link **)REALLOC((void *)linktbl->links,
                                   linktbl->num * sizeof(Link *));
     if (!tmp) {
-        lprintf(fatal, "realloc() failure!\n");
+        lprintf(fatal, "REALLOC() failure!\n");
     }
     linktbl->links = tmp;
     linktbl->links[linktbl->num - 1] = link;
@@ -968,7 +968,7 @@ Link *path_to_Link(const char *path)
             (unsigned long)pthread_self());
 
     PTHREAD_MUTEX_LOCK(&link_lock);
-    char *new_path = strndup(path, MAX_PATH_LEN);
+    char *new_path = STRNDUP(path, MAX_PATH_LEN);
     if (!new_path) {
         lprintf(fatal, "cannot allocate memory\n");
     }

--- a/src/main.c
+++ b/src/main.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
     }
 
     /*--- Add the last remaining argument, which is the mountpoint ---*/
-    char *abs_mountpoint = realpath(all_argv[optind + 1], NULL);
+    char *abs_mountpoint = REALPATH(all_argv[optind + 1], NULL);
     if (!abs_mountpoint) {
         fprintf(stderr, "Error: Invalid mountpoint %s: %s\n",
                 all_argv[optind + 1], strerror(errno));
@@ -197,7 +197,7 @@ static char *get_XDG_CONFIG_HOME(void)
             config_dir = path_append(user_home, default_config_subdir);
         } else {
             lprintf(warning, "$HOME is unset\n");
-            const char *cur_dir = realpath("./", NULL);
+            const char *cur_dir = REALPATH("./", NULL);
             if (cur_dir) {
                 config_dir = path_append(cur_dir, default_config_subdir);
             } else {
@@ -446,10 +446,9 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
  */
 void add_arg(char ***fuse_argv_ptr, int *fuse_argc, char *opt_string)
 {
-    char **tmp = (char **)realloc((void *)*fuse_argv_ptr,
+    char **tmp = (char **)REALLOC((void *)*fuse_argv_ptr,
                                   ((size_t)*fuse_argc + 1) * sizeof(char *));
     if (!tmp) {
-        lprintf(fatal, "realloc failed: %s\n", strerror(errno));
         return;
     }
     *fuse_argv_ptr = tmp;

--- a/src/memcache.c
+++ b/src/memcache.c
@@ -12,12 +12,12 @@ size_t write_memory_callback(void *recv_data, size_t size, size_t nmemb,
     size_t recv_size = size * nmemb;
     TransferStruct *ts = (TransferStruct *)userp;
 
-    char *tmp = realloc(ts->data, ts->curr_size + recv_size + 1);
+    char *tmp = REALLOC(ts->data, ts->curr_size + recv_size + 1);
     if (!tmp) {
         /*
          * out of memory!
          */
-        lprintf(fatal, "realloc failure!\n");
+        lprintf(fatal, "REALLOC failure!\n");
     }
     ts->data = tmp;
 

--- a/src/sonic.c
+++ b/src/sonic.c
@@ -29,7 +29,7 @@ static SonicConfigStruct SONIC_CONFIG;
 void sonic_config_init(const char *server, const char *username,
                        const char *password)
 {
-    SONIC_CONFIG.server = strndup(server, MAX_PATH_LEN);
+    SONIC_CONFIG.server = STRNDUP(server, MAX_PATH_LEN);
     /*
      * Correct for the extra '/'
      */
@@ -37,8 +37,8 @@ void sonic_config_init(const char *server, const char *username,
     if (SONIC_CONFIG.server[server_url_len] == '/') {
         SONIC_CONFIG.server[server_url_len] = '\0';
     }
-    SONIC_CONFIG.username = strndup(username, MAX_FILENAME_LEN);
-    SONIC_CONFIG.password = strndup(password, MAX_FILENAME_LEN);
+    SONIC_CONFIG.username = STRNDUP(username, MAX_FILENAME_LEN);
+    SONIC_CONFIG.password = STRNDUP(password, MAX_FILENAME_LEN);
     SONIC_CONFIG.client = DEFAULT_USER_AGENT;
 
     if (!CONFIG.sonic_insecure) {

--- a/src/util.c
+++ b/src/util.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "log.h"
 
+#include <curl/curl.h>
 #include <openssl/evp.h>
 #include <uuid/uuid.h>
 
@@ -28,6 +29,9 @@
  * \details This is basically the length of a UUID
  */
 #define SALT_LEN 36
+
+static MemNode *mem_head = NULL;
+static pthread_mutex_t mem_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 char *path_append(const char *path, const char *filename)
 {
@@ -252,19 +256,190 @@ char *generate_md5sum(const char *str)
     return out;
 }
 
-void *CALLOC(size_t nmemb, size_t size)
+void *CALLOC_wrapper(size_t nmemb, size_t size, const char *file,
+                     const char *func, int line)
 {
     void *ptr = calloc(nmemb, size);
     if (!ptr) {
-        lprintf(fatal, "%s!\n", strerror(errno));
+        fatal_log_printf(file, func, line, "%s!\n", strerror(errno));
+    }
+
+    log_printf(debug, file, func, line, "CALLOC: %p, %zu bytes\n", ptr,
+               nmemb * size);
+
+    MemNode *node = calloc(1, sizeof(MemNode));
+    if (!node) {
+        fatal_log_printf(file, func, line, "Could not allocate MemNode: %s!\n",
+                         strerror(errno));
+    }
+    node->ptr = ptr;
+    node->size = nmemb * size;
+    node->file = file;
+    node->func = func;
+    node->line = line;
+
+    pthread_mutex_lock(&mem_mutex);
+    node->next = mem_head;
+    mem_head = node;
+    pthread_mutex_unlock(&mem_mutex);
+
+    return ptr;
+}
+
+char *STRDUP_wrapper(const char *s, const char *file, const char *func,
+                     int line)
+{
+    if (!s) {
+        return NULL;
+    }
+    size_t len = strlen(s) + 1;
+    char *ptr = CALLOC_wrapper(len, sizeof(char), file, func, line);
+    if (ptr) {
+        memcpy(ptr, s, len);
     }
     return ptr;
 }
 
-void FREE_wrapper(void *ptr)
+char *STRNDUP_wrapper(const char *s, size_t n, const char *file,
+                      const char *func, int line)
 {
+    if (!s) {
+        return NULL;
+    }
+    size_t len = strnlen(s, n);
+    char *ptr = CALLOC_wrapper(len + 1, sizeof(char), file, func, line);
     if (ptr) {
-        free(ptr);
+        memcpy(ptr, s, len);
+        ptr[len] = '\0';
+    }
+    return ptr;
+}
+
+void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
+                      const char *func, int line)
+{
+    if (!ptr) {
+        return CALLOC_wrapper(1, size, file, func, line);
+    }
+
+    pthread_mutex_lock(&mem_mutex);
+    MemNode **curr = &mem_head;
+    while (*curr) {
+        if ((*curr)->ptr == ptr) {
+            MemNode *node = *curr;
+            log_printf(debug, file, func, line, "REALLOC: %p, %zu bytes\n", ptr,
+                       size);
+            void *new_ptr = realloc(ptr, size);
+            if (!new_ptr) {
+                pthread_mutex_unlock(&mem_mutex);
+                fatal_log_printf(file, func, line, "realloc failed: %s!\n",
+                                 strerror(errno));
+            }
+            node->ptr = new_ptr;
+            node->size = size;
+            node->file = file;
+            node->func = func;
+            node->line = line;
+            pthread_mutex_unlock(&mem_mutex);
+            log_printf(debug, file, func, line, "REALLOC result: %p\n",
+                       new_ptr);
+            return new_ptr;
+        }
+        curr = &((*curr)->next);
+    }
+    pthread_mutex_unlock(&mem_mutex);
+
+    log_printf(warning, file, func, line, "REALLOC: %p not found in tracker!\n",
+               ptr);
+    void *new_ptr = realloc(ptr, size);
+    if (!new_ptr) {
+        fatal_log_printf(file, func, line, "realloc failed: %s!\n",
+                         strerror(errno));
+    }
+    return new_ptr;
+}
+
+char *REALPATH_wrapper(const char *path, char *resolved_path, const char *file,
+                       const char *func, int line)
+{
+    char *res = realpath(path, resolved_path);
+    if (res && !resolved_path) {
+        log_printf(debug, file, func, line, "REALPATH: %p\n", (void *)res);
+        // We need to track the pointer returned by realpath
+        // But realpath uses malloc internally, so we should untrack it with
+        // free() later. Wait, our FREE_wrapper already handles pointers not in
+        // the tracker by calling free(). But if we want it to be deallocated at
+        // exit, we SHOULD track it.
+
+        MemNode *node = calloc(1, sizeof(MemNode));
+        if (!node) {
+            fatal_log_printf(file, func, line,
+                             "Could not allocate MemNode: %s!\n",
+                             strerror(errno));
+        }
+        node->ptr = res;
+        node->size = strlen(res) + 1; // Store actual length of allocated string
+        node->file = file;
+        node->func = func;
+        node->line = line;
+
+        pthread_mutex_lock(&mem_mutex);
+        node->next = mem_head;
+        mem_head = node;
+        pthread_mutex_unlock(&mem_mutex);
+    }
+    return res;
+}
+
+void FREE_wrapper(void *ptr, const char *file, const char *func, int line)
+{
+    if (!ptr) {
+        return;
+    }
+
+    pthread_mutex_lock(&mem_mutex);
+    MemNode **curr = &mem_head;
+    while (*curr) {
+        if ((*curr)->ptr == ptr) {
+            MemNode *to_free = *curr;
+            *curr = to_free->next;
+            free(to_free);
+            goto found;
+        }
+        curr = &((*curr)->next);
+    }
+    pthread_mutex_unlock(&mem_mutex);
+
+    log_printf(warning, file, func, line, "FREE: %p not found in tracker!\n",
+               ptr);
+    free(ptr);
+    return;
+
+found:
+    pthread_mutex_unlock(&mem_mutex);
+    log_printf(debug, file, func, line, "FREE: %p\n", ptr);
+    free(ptr);
+}
+
+void mem_cleanup(void)
+{
+    if (pthread_mutex_trylock(&mem_mutex) != 0) {
+        goto cleanup_headers;
+    }
+    MemNode *curr = mem_head;
+    while (curr) {
+        MemNode *next = curr->next;
+        free(curr->ptr);
+        free(curr);
+        curr = next;
+    }
+    mem_head = NULL;
+    pthread_mutex_unlock(&mem_mutex);
+
+cleanup_headers:
+    if (CONFIG.http_headers) {
+        curl_slist_free_all(CONFIG.http_headers);
+        CONFIG.http_headers = NULL;
     }
 }
 
@@ -275,22 +450,4 @@ char *str_to_hex(char *s)
         sprintf(h, "%x", *c);
     }
     return hex;
-}
-
-char *STRDUP(const char *s)
-{
-    char *ptr = strdup(s);
-    if (!ptr) {
-        lprintf(fatal, "%s!\n", strerror(errno));
-    }
-    return ptr;
-}
-
-char *STRNDUP(const char *s, size_t n)
-{
-    char *ptr = strndup(s, n);
-    if (!ptr) {
-        lprintf(fatal, "%s!\n", strerror(errno));
-    }
-    return ptr;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -114,14 +114,29 @@ char *generate_salt(void);
 char *generate_md5sum(const char *str);
 
 /**
- * \brief wrapper for calloc(), with error handling
+ * \brief memory allocation tracker node
  */
-void *CALLOC(size_t nmemb, size_t size);
+typedef struct MemNode {
+    void *ptr;
+    size_t size;
+    const char *file;
+    const char *func;
+    int line;
+    struct MemNode *next;
+} MemNode;
+
+/**
+ * \brief wrapper for calloc(), with error handling and memory tracking
+ */
+void *CALLOC_wrapper(size_t nmemb, size_t size, const char *file,
+                     const char *func, int line);
+#define CALLOC(nmemb, size)                                                    \
+    CALLOC_wrapper(nmemb, size, __FILE__, __func__, __LINE__)
 
 /**
  * \brief Internal wrapper for free().
  */
-void FREE_wrapper(void *ptr);
+void FREE_wrapper(void *ptr, const char *file, const char *func, int line);
 
 /**
  * \brief Macro wrapper for free() that sets the pointer to NULL afterwards.
@@ -136,24 +151,49 @@ void FREE_wrapper(void *ptr);
 #define FREE(ptr)                                                              \
     do {                                                                       \
         __extension__ __auto_type __ptr_to_free = &(ptr);                      \
-        FREE_wrapper((void *)*__ptr_to_free);                                  \
+        FREE_wrapper((void *)*__ptr_to_free, __FILE__, __func__, __LINE__);    \
         *__ptr_to_free = NULL;                                                 \
     } while (0)
+
+/**
+ * \brief wrapper for STRDUP(), with memory tracking
+ */
+char *STRDUP_wrapper(const char *s, const char *file, const char *func,
+                     int line);
+#define STRDUP(s) STRDUP_wrapper(s, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for STRNDUP(), with memory tracking
+ */
+char *STRNDUP_wrapper(const char *s, size_t n, const char *file,
+                      const char *func, int line);
+#define STRNDUP(s, n) STRNDUP_wrapper(s, n, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for realloc(), with memory tracking
+ */
+void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
+                      const char *func, int line);
+#define REALLOC(ptr, size)                                                     \
+    REALLOC_wrapper(ptr, size, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for realpath(), with memory tracking
+ */
+char *REALPATH_wrapper(const char *path, char *resolved_path, const char *file,
+                       const char *func, int line);
+#define REALPATH(path, resolved_path)                                          \
+    REALPATH_wrapper(path, resolved_path, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief cleanup all allocated memory
+ */
+void mem_cleanup(void);
 
 /**
  * \brief Convert a string to hex
  */
 char *str_to_hex(char *s);
-
-/**
- * \brief wrapper for strdup(), with error handling
- */
-char *STRDUP(const char *s);
-
-/**
- * \brief wrapper for strndup(), with error handling
- */
-char *STRNDUP(const char *s, size_t n);
 
 /**
  * \brief initialise the configuration data structure


### PR DESCRIPTION
This pull request introduces a custom thread-safe memory tracking system to monitor allocations, prevent leaks, and automate cleanup upon program termination.

### Rationale
By tracking dynamically allocated memory with a unified system, we can verify allocation reliability, easily log debug/warning traces for memory operations, and ensure all tracked memory (including internal curl lists) is freed cleanly at exit.

### Key Changes
1. **Thread-Safe Memory Tracker Infrastructure**:
   - Implements a thread-safe `MemNode` tracker and `mem_mutex` lock in `src/util.c` and `src/util.h`.
   - Adds wrappers for `calloc`, `realloc`, `free`, `realpath`, `strdup`, and `strndup` to safely log and track allocations.
   - Defines capitalized macros (`CALLOC`, `FREE`, `STRDUP`, `STRNDUP`, `REALLOC`, `REALPATH`) that delegate to their respective wrappers.
2. **Automatic Cleanup**:
   - Registers a `mem_cleanup` callback inside `Config_init` using `atexit` to automatically clean up all tracked memory on program exit.
3. **Core Refactoring**:
   - Updates memory allocation and duplication calls across `src/cache.c`, `src/link.c`, `src/main.c`, `src/memcache.c`, and `src/sonic.c` to use the tracked macros.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Upgraded memory management with allocation tracking and safer deallocation to reduce leaks and improve stability.
  * Added automatic cleanup on process shutdown to reclaim tracked resources.
  * Replaced direct system allocation/resolution calls with tracked, location-aware wrappers for more robust error reporting and safer path handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->