### PR TITLE
Handle Link_download errors in cache

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -988,6 +988,12 @@ static void *Cache_bgdl(void *arg)
                 "thread %lx received %ld bytes, "
                 "which doesn't make sense\n",
                 (unsigned long)pthread_self(), recv);
+        FREE(recv_buf);
+        lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
+                (unsigned long)pthread_self());
+        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+        SEM_POST(&cf->bgt_sem);
+        pthread_exit(NULL);
     }
 
     if ((recv == cf->blksz)
@@ -1089,6 +1095,11 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
                 "thread %lx received %ld bytes, "
                 "which doesn't make sense\n",
                 (unsigned long)pthread_self(), recv);
+        FREE(recv_buf);
+        lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
+                (unsigned long)pthread_self());
+        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+        return recv;
     }
     /*
      * check if we have received enough data, write it to the disk
@@ -1157,8 +1168,12 @@ long Cache_read(Cache *cf, char *const output_buf, off_t len,
         if (end > start + len) {
             end = start + len;
         }
-        send += Cache_read_segment(cf, output_buf + (start - offset_start),
-                                   end - start, start);
+        long seg_send = Cache_read_segment(
+            cf, output_buf + (start - offset_start), end - start, start);
+        if (seg_send < 0) {
+            return seg_send;
+        }
+        send += seg_send;
     }
     return send;
 }


### PR DESCRIPTION
Resolves #225

If `Link_download` fails (returns a negative value), the cache download and segment reading paths could proceed to evaluate conditions using the invalid negative length, which could lead to undefined behavior or crashes.

This PR addresses the issue by handling the error immediately in both paths:
1. **Background download thread (`Cache_bgdl`)**: Releases `cf->w_lock`, frees the allocated `recv_buf`, posts the `cf->bgt_sem` semaphore, and exits the thread immediately.
2. **Segment reading (`Cache_read_segment`)**: Frees the allocated `recv_buf`, releases the `cf->w_lock` lock, and returns the error code `recv`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed downloads now trigger immediate cleanup and halt background processing, preventing hangs and lingering resources.
  * Read operations abort on segment errors and return the error immediately instead of continuing, ensuring failures are surfaced promptly.
  * Overall stability improved for cache download and read workflows, reducing risk of resource leaks and stalled operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->