### PR TITLE
feat: add debug memory tracker and harden allocations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
 -   repo: local
     hooks:
     -   id: clang-format
-        name: clang-format (formatted files must be manual re-staged)
+        name: clang-format
         entry: clang-format -i
         language: system
         files: \.(c|h)$

--- a/src/cache.c
+++ b/src/cache.c
@@ -48,7 +48,7 @@ char *CacheSystem_get_cache_dir(void)
 
     const char *xdg_cache_home = getenv("XDG_CACHE_HOME");
     if (xdg_cache_home) {
-        cache_dir = strndup(xdg_cache_home, PATH_MAX);
+        cache_dir = STRNDUP(xdg_cache_home, PATH_MAX);
     } else {
         const char *user_home = getenv("HOME");
         if (user_home) {
@@ -59,9 +59,10 @@ char *CacheSystem_get_cache_dir(void)
              * XDG_CACHE_HOME and HOME already are full paths. Not relying
              * on environment PWD since it too may be undefined.
              */
-            const char *cur_dir = realpath("./", NULL);
+            char *cur_dir = REALPATH("./", NULL);
             if (cur_dir) {
                 cache_dir = path_append(cur_dir, default_cache_subdir);
+                FREE(cur_dir);
             } else {
                 lprintf(fatal, "Could not create cache directory\n");
             }
@@ -216,8 +217,6 @@ static int Meta_read(Cache *cf)
         return EIO;
     }
 
-    int nmemb = 0;
-
     if (1 != fread(&cf->time, sizeof(long), 1, fp)
         || 1 != fread(&cf->content_length, sizeof(off_t), 1, fp)
         || 1 != fread(&cf->blksz, sizeof(int), 1, fp)
@@ -238,16 +237,36 @@ static int Meta_read(Cache *cf)
         lprintf(warning, "Warning: cf->blksz != CONFIG.data_blksz\n");
     }
 
-    if (cf->segbc > CONFIG.max_segbc) {
-        lprintf(error, "Error: segbc: %ld\n", cf->segbc);
-        return EFBIG;
+    if (cf->content_length <= 0 || cf->blksz <= 0) {
+        lprintf(error, "Error: invalid metadata sizes\n");
+        return EBADMSG;
+    }
+
+    if (cf->content_length > INT64_MAX - cf->blksz) {
+        lprintf(error, "Error: segbc upper bound overflow\n");
+        return EBADMSG;
+    }
+
+    off_t max_segbc = cf->content_length / cf->blksz;
+
+    if ((cf->content_length % cf->blksz) != 0) {
+        max_segbc += 1;
+    }
+
+    if (max_segbc > INT_MAX) {
+        max_segbc = INT_MAX;
+    }
+
+    if (cf->segbc <= 0 || cf->segbc > max_segbc) {
+        lprintf(error, "Error: invalid segbc size: %ld\n", cf->segbc);
+        return EBADMSG;
     }
 
     /*
      * Allocate memory for all segments, and read them in
      */
     cf->seg = CALLOC(cf->segbc, sizeof(Seg));
-    nmemb = fread(cf->seg, sizeof(Seg), cf->segbc, fp);
+    long nmemb = fread(cf->seg, sizeof(Seg), cf->segbc, fp);
 
     /*
      * We shouldn't have gone past the end of the file
@@ -256,8 +275,7 @@ static int Meta_read(Cache *cf)
         /*
          * reached EOF
          */
-        lprintf(error, "attempted to read past the end of the \
-file!\n");
+        lprintf(error, "attempted to read past the end of the file!\n");
         return EBADMSG;
     }
 
@@ -706,7 +724,7 @@ int Cache_create(const char *path)
     lprintf(debug, "Creating cache files for %s.\n", fn);
 
     Cache *cf = Cache_alloc();
-    cf->path = strndup(fn, PATH_MAX);
+    cf->path = STRNDUP(fn, PATH_MAX);
     cf->time = this_link->time;
     cf->content_length = this_link->content_length;
     cf->blksz = CONFIG.data_blksz;
@@ -814,7 +832,7 @@ Cache *Cache_open(const char *fn)
         fn = link->sonic.id;
     }
 
-    cf->path = strndup(fn, PATH_MAX);
+    cf->path = STRNDUP(fn, PATH_MAX);
 
     /*
      * Associate the cache structure with a link

--- a/src/config.c
+++ b/src/config.c
@@ -1,7 +1,9 @@
 #include "config.h"
 
 #include "log.h"
+#include "util.h"
 #include <stddef.h>
+#include <stdlib.h>
 
 
 ConfigStruct CONFIG;
@@ -48,8 +50,6 @@ void Config_init(void)
 
     CONFIG.data_blksz = DEFAULT_DATA_BLKSZ;
 
-    CONFIG.max_segbc = DEFAULT_MAX_SEGBC;
-
     /*-------------- Sonic related -------------*/
     CONFIG.sonic_username = NULL;
 
@@ -58,4 +58,5 @@ void Config_init(void)
     CONFIG.sonic_id3 = 0;
 
     CONFIG.sonic_insecure = 0;
+    atexit(mem_cleanup);
 }

--- a/src/config.h
+++ b/src/config.h
@@ -33,13 +33,6 @@
  */
 #define DEFAULT_DATA_BLKSZ (DEFAULT_DATA_BLKSZ_MB * 1024 * 1024)
 
-/**
- * \brief Maximum segment block count
- * \details This is set to 128*1024 blocks, which uses 128KB. By default,
- * this allows the user to store (128*1024)*(8*1024*1024) = 1TB of data
- */
-#define DEFAULT_MAX_SEGBC (128 * 1024)
-
 #define STR(x) #x
 #define XSTR(x) STR(x)
 

--- a/src/fuse_local.c
+++ b/src/fuse_local.c
@@ -167,7 +167,7 @@ static int fs_readdir(const char *path, void *buf, fuse_fill_dir_t dir_add,
     dir_add(buf, ".", NULL, 0, 0);
     dir_add(buf, "..", NULL, 0, 0);
     /* We skip the head link */
-    for (int i = 1; i < linktbl->num; i++) {
+    for (int i = 1; i < linktbl->size; i++) {
         Link *link = linktbl->links[i];
         if (link->type != LINK_INVALID) {
             dir_add(buf, link->linkname, NULL, 0, 0);

--- a/src/link.c
+++ b/src/link.c
@@ -242,7 +242,7 @@ static void LinkTable_uninitialised_fill(LinkTable *linktbl)
      * Start all uninitialized requests once
      */
     int total_uninitialized = 0;
-    for (int i = 0; i < linktbl->num; i++) {
+    for (int i = 0; i < linktbl->size; i++) {
         Link *this_link = linktbl->links[i];
         if (this_link->type == LINK_UNINITIALISED_FILE
             || this_link->type == LINK_UNINITIALISED_DIR) {
@@ -260,7 +260,7 @@ static void LinkTable_uninitialised_fill(LinkTable *linktbl)
     int j = 0;
     do {
         u = 0;
-        for (int i = 0; i < linktbl->num; i++) {
+        for (int i = 0; i < linktbl->size; i++) {
             Link *this_link = linktbl->links[i];
             if (this_link->type == LINK_UNINITIALISED_FILE
                 || this_link->type == LINK_UNINITIALISED_DIR) {
@@ -284,7 +284,7 @@ static void LinkTable_uninitialised_fill(LinkTable *linktbl)
             int n_running = curl_multi_perform_once();
 
             if (n_running == 0) {
-                for (int i = 0; i < linktbl->num; i++) {
+                for (int i = 0; i < linktbl->size; i++) {
                     Link *this_link = linktbl->links[i];
                     if (this_link->type == LINK_UNINITIALISED_FILE
                         || this_link->type == LINK_UNINITIALISED_DIR) {
@@ -367,14 +367,10 @@ LinkTable *LinkSystem_init(const char *url)
 
 void LinkTable_add(LinkTable *linktbl, Link *link)
 {
-    linktbl->num++;
-    Link **tmp = (Link **)realloc((void *)linktbl->links,
-                                  linktbl->num * sizeof(Link *));
-    if (!tmp) {
-        lprintf(fatal, "realloc() failure!\n");
-    }
-    linktbl->links = tmp;
-    linktbl->links[linktbl->num - 1] = link;
+    linktbl->links = (Link **)REALLOC(
+        (void *)linktbl->links, ((size_t)linktbl->size + 1) * sizeof(Link *));
+    linktbl->links[linktbl->size] = link;
+    linktbl->size++;
 }
 
 static LinkType linkname_to_LinkType(const char *linkname)
@@ -479,7 +475,7 @@ static void HTML_to_LinkTable(const char *url, GumboNode *node,
         if ((type == LINK_UNINITIALISED_DIR)
             || (type == LINK_UNINITIALISED_FILE)) {
             int identical_link_found = 0;
-            for (int i = 0; i < linktbl->num; i++) {
+            for (int i = 0; i < linktbl->size; i++) {
                 if (linknames_equal(relative_url,
                                     linktbl->links[i]->linkname)) {
                     identical_link_found = 1;
@@ -544,7 +540,7 @@ static void LinkTable_fill(LinkTable *linktbl)
 {
     Link *head_link = linktbl->links[0];
     lprintf(debug, "Filling %s\n", head_link->f_url);
-    for (int i = 1; i < linktbl->num; i++) {
+    for (int i = 1; i < linktbl->size; i++) {
         Link *this_link = linktbl->links[i];
         /* Some web sites use characters in their href attributes that really
            shouldn't be in their href attributes, most commonly spaces. And
@@ -582,9 +578,13 @@ static void LinkTable_fill(LinkTable *linktbl)
 void LinkTable_free(LinkTable *linktbl)
 {
     if (linktbl) {
-        for (int i = 0; i < linktbl->num; i++) {
-            LinkTable_free(linktbl->links[i]->next_table);
-            FREE(linktbl->links[i]);
+        for (int i = 0; i < linktbl->size; i++) {
+            Link *entry = linktbl->links ? linktbl->links[i] : NULL;
+            if (!entry) {
+                continue;
+            }
+            LinkTable_free(entry->next_table);
+            FREE(entry);
         }
         FREE(linktbl->links);
         FREE(linktbl);
@@ -599,7 +599,7 @@ void LinkTable_print(LinkTable *linktbl)
         lprintf(info, " LinkTable %p for %s\n", (void *)linktbl,
                 linktbl->links[0]->f_url);
         lprintf(info, "--------------------------------------------\n");
-        for (int i = 0; i < linktbl->num; i++) {
+        for (int i = 0; i < linktbl->size; i++) {
             Link *this_link = linktbl->links[i];
             lprintf(info, "%d %c %lu %s %s\n", i, this_link->type,
                     this_link->content_length, this_link->linkname,
@@ -618,7 +618,7 @@ void LinkTable_print(LinkTable *linktbl)
 LinkTable *LinkTable_alloc(const char *url)
 {
     LinkTable *linktbl = CALLOC(1, sizeof(LinkTable));
-    linktbl->num = 0;
+    linktbl->size = 0;
     linktbl->index_time = 0;
     linktbl->links = NULL;
 
@@ -629,7 +629,7 @@ LinkTable *LinkTable_alloc(const char *url)
     Link *head_link = Link_new("/", LINK_HEAD);
     LinkTable_add(linktbl, head_link);
     strncpy(head_link->f_url, url, PATH_MAX);
-    assert(linktbl->num == 1);
+    assert(linktbl->size == 1);
     return linktbl;
 }
 
@@ -743,12 +743,12 @@ int LinkTable_disk_save(LinkTable *linktbl, const char *dirn)
     }
 
     lprintf(debug, "linktbl->index_time: %ld\n", (long)linktbl->index_time);
-    if (fwrite(&linktbl->num, sizeof(int), 1, fp) != 1
+    if (fwrite(&linktbl->size, sizeof(int), 1, fp) != 1
         || fwrite(&linktbl->index_time, sizeof(time_t), 1, fp) != 1) {
         lprintf(error, "Failed to save the header of %s!\n", path);
     }
     FREE(path);
-    for (int i = 0; i < linktbl->num; i++) {
+    for (int i = 0; i < linktbl->size; i++) {
         ignore_value(
             fwrite(linktbl->links[i]->linkname, sizeof(char), NAME_MAX, fp));
         ignore_value(
@@ -788,7 +788,8 @@ LinkTable *LinkTable_disk_open(const char *dirn)
     }
 
     LinkTable *linktbl = CALLOC(1, sizeof(LinkTable));
-    if (fread(&linktbl->num, sizeof(int), 1, fp) != 1
+    int sz = 0;
+    if (fread(&sz, sizeof(int), 1, fp) != 1
         || fread(&linktbl->index_time, sizeof(time_t), 1, fp) != 1) {
         lprintf(error, "Failed to read the header of %s!\n", path);
         fclose(fp);
@@ -797,10 +798,48 @@ LinkTable *LinkTable_disk_open(const char *dirn)
         FREE(path);
         return NULL;
     }
+
+    long entry_size = (long)(NAME_MAX + PATH_MAX + sizeof(LinkType)
+                             + sizeof(size_t) + sizeof(long));
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        lprintf(error, "Failed to seek %s!\n", path);
+        fclose(fp);
+        LinkTable_free(linktbl);
+        LinkTable_disk_delete(dirn);
+        FREE(path);
+        return NULL;
+    }
+    long file_size = ftell(fp);
+    if (file_size < 0
+        || fseek(fp, (long)(sizeof(int) + sizeof(time_t)), SEEK_SET) != 0) {
+        lprintf(error, "Failed to inspect %s!\n", path);
+        fclose(fp);
+        LinkTable_free(linktbl);
+        LinkTable_disk_delete(dirn);
+        FREE(path);
+        return NULL;
+    }
+
+    long max_entries
+        = (file_size - (long)(sizeof(int) + sizeof(time_t))) / entry_size;
+
+    if (sz < 1 || max_entries < sz) {
+        lprintf(error, "Invalid link table size: %d in %s!\n", sz, path);
+        fclose(fp);
+        LinkTable_free(linktbl);
+        LinkTable_disk_delete(dirn);
+        FREE(path);
+        return NULL;
+    }
+
+    linktbl->size = sz;
     lprintf(debug, "linktbl->index_time: %ld\n", (long)linktbl->index_time);
 
-    linktbl->links = (Link **)CALLOC(linktbl->num, sizeof(Link *));
-    for (int i = 0; i < linktbl->num; i++) {
+    linktbl->links
+        = (Link **)CALLOC( // NOLINT(clang-analyzer-optin.taint.TaintedAlloc)
+            sz, sizeof(Link *));
+
+    for (int i = 0; i < sz; i++) {
         linktbl->links[i] = CALLOC(1, sizeof(Link));
         if (fread(linktbl->links[i]->linkname, sizeof(char), NAME_MAX, fp)
                 != NAME_MAX
@@ -905,7 +944,7 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
         /*
          * We cannot find another '/', we have reached the last level
          */
-        for (int i = 1; i < linktbl->num; i++) {
+        for (int i = 1; i < linktbl->size; i++) {
             if (!strncmp(path, linktbl->links[i]->linkname, NAME_MAX)) {
                 /*
                  * We found our link
@@ -928,7 +967,7 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
          * move the pointer past the '/'
          */
         char *next_path = slash + 1;
-        for (int i = 1; i < linktbl->num; i++) {
+        for (int i = 1; i < linktbl->size; i++) {
             if (!strncmp(path, linktbl->links[i]->linkname, NAME_MAX)) {
                 /*
                  * The next sub-directory exists
@@ -964,7 +1003,7 @@ Link *path_to_Link(const char *path)
             (unsigned long)pthread_self());
 
     PTHREAD_MUTEX_LOCK(&link_lock);
-    char *new_path = strndup(path, PATH_MAX);
+    char *new_path = STRNDUP(path, PATH_MAX);
     if (!new_path) {
         lprintf(fatal, "cannot allocate memory\n");
     }

--- a/src/link.h
+++ b/src/link.h
@@ -33,7 +33,7 @@ typedef enum {
  * \details index 0 contains the Link for the base URL
  */
 struct LinkTable {
-    int num;
+    int size;
     time_t index_time;
     Link **links;
 };

--- a/src/main.c
+++ b/src/main.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
     }
 
     /*--- Add the last remaining argument, which is the mountpoint ---*/
-    char *abs_mountpoint = realpath(all_argv[optind + 1], NULL);
+    char *abs_mountpoint = REALPATH(all_argv[optind + 1], NULL);
     if (!abs_mountpoint) {
         fprintf(stderr, "Error: Invalid mountpoint %s: %s\n",
                 all_argv[optind + 1], strerror(errno));
@@ -197,9 +197,10 @@ static char *get_XDG_CONFIG_HOME(void)
             config_dir = path_append(user_home, default_config_subdir);
         } else {
             lprintf(warning, "$HOME is unset\n");
-            const char *cur_dir = realpath("./", NULL);
+            char *cur_dir = REALPATH("./", NULL);
             if (cur_dir) {
                 config_dir = path_append(cur_dir, default_config_subdir);
+                FREE(cur_dir);
             } else {
                 lprintf(warning, "Could not get config directory\n");
             }
@@ -289,26 +290,25 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
            {"proxy-password", required_argument, NULL, 'L'},  /* 7 */
            {"cache", no_argument, NULL, 'L'},                 /* 8 */
            {"dl-seg-size", required_argument, NULL, 'L'},     /* 9 */
-           {"max-seg-count", required_argument, NULL, 'L'},   /* 10 */
-           {"max-conns", required_argument, NULL, 'L'},       /* 11 */
-           {"user-agent", required_argument, NULL, 'L'},      /* 12 */
-           {"retry-wait", required_argument, NULL, 'L'},      /* 13 */
-           {"cache-location", required_argument, NULL, 'L'},  /* 14 */
-           {"sonic-username", required_argument, NULL, 'L'},  /* 15 */
-           {"sonic-password", required_argument, NULL, 'L'},  /* 16 */
-           {"sonic-id3", no_argument, NULL, 'L'},             /* 17 */
-           {"no-range-check", no_argument, NULL, 'L'},        /* 18 */
-           {"sonic-insecure", no_argument, NULL, 'L'},        /* 19 */
-           {"insecure-tls", no_argument, NULL, 'L'},          /* 20 */
-           {"config", required_argument, NULL, 'L'},          /* 21 */
-           {"single-file-mode", no_argument, NULL, 'L'},      /* 22 */
-           {"cacert", required_argument, NULL, 'L'},          /* 23 */
-           {"proxy-cacert", required_argument, NULL, 'L'},    /* 24 */
-           {"refresh-timeout", required_argument, NULL, 'L'}, /* 25 */
-           {"http-header", required_argument, NULL, 'L'},     /* 26 */
-           {"cache-clear", no_argument, NULL, 'L'},           /* 27 */
-           {"zero-len-is-dir", no_argument, NULL, 'L'},       /* 28 */
-           {"invalid-refresh", no_argument, NULL, 'L'},       /* 29 */
+           {"max-conns", required_argument, NULL, 'L'},       /* 10 */
+           {"user-agent", required_argument, NULL, 'L'},      /* 11 */
+           {"retry-wait", required_argument, NULL, 'L'},      /* 12 */
+           {"cache-location", required_argument, NULL, 'L'},  /* 13 */
+           {"sonic-username", required_argument, NULL, 'L'},  /* 14 */
+           {"sonic-password", required_argument, NULL, 'L'},  /* 15 */
+           {"sonic-id3", no_argument, NULL, 'L'},             /* 16 */
+           {"no-range-check", no_argument, NULL, 'L'},        /* 17 */
+           {"sonic-insecure", no_argument, NULL, 'L'},        /* 18 */
+           {"insecure-tls", no_argument, NULL, 'L'},          /* 19 */
+           {"config", required_argument, NULL, 'L'},          /* 20 */
+           {"single-file-mode", no_argument, NULL, 'L'},      /* 21 */
+           {"cacert", required_argument, NULL, 'L'},          /* 22 */
+           {"proxy-cacert", required_argument, NULL, 'L'},    /* 23 */
+           {"refresh-timeout", required_argument, NULL, 'L'}, /* 24 */
+           {"http-header", required_argument, NULL, 'L'},     /* 25 */
+           {"cache-clear", no_argument, NULL, 'L'},           /* 26 */
+           {"zero-len-is-dir", no_argument, NULL, 'L'},       /* 27 */
+           {"invalid-refresh", no_argument, NULL, 'L'},       /* 28 */
            {0, 0, 0, 0}};
     while ((c = getopt_long(argc, argv, short_opts, long_opts, &long_index))
            != -1) {
@@ -365,66 +365,63 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
                 CONFIG.data_blksz = (int)strtol(optarg, NULL, 10) * 1024 * 1024;
                 break;
             case 10:
-                CONFIG.max_segbc = strtol(optarg, NULL, 10);
-                break;
-            case 11:
                 CONFIG.max_conns = (int)strtol(optarg, NULL, 10);
                 break;
-            case 12:
+            case 11:
                 CONFIG.user_agent = STRDUP(optarg);
                 break;
-            case 13:
+            case 12:
                 CONFIG.http_wait_sec = (int)strtol(optarg, NULL, 10);
                 break;
-            case 14:
+            case 13:
                 CONFIG.cache_dir = STRDUP(optarg);
                 break;
-            case 15:
+            case 14:
                 CONFIG.sonic_username = STRDUP(optarg);
                 break;
-            case 16:
+            case 15:
                 CONFIG.sonic_password = STRDUP(optarg);
                 break;
-            case 17:
+            case 16:
                 CONFIG.sonic_id3 = 1;
                 break;
-            case 18:
+            case 17:
                 CONFIG.no_range_check = 1;
                 break;
-            case 19:
+            case 18:
                 CONFIG.sonic_insecure = 1;
                 break;
-            case 20:
+            case 19:
                 CONFIG.insecure_tls = 1;
                 break;
-            case 21:
+            case 20:
                 /*
                  * This is for --config, we don't need to do anything
                  */
                 break;
-            case 22:
+            case 21:
                 CONFIG.mode = SINGLE;
                 break;
-            case 23:
+            case 22:
                 CONFIG.cafile = STRDUP(optarg);
                 break;
-            case 24:
+            case 23:
                 CONFIG.proxy_cafile = STRDUP(optarg);
                 break;
-            case 25:
+            case 24:
                 CONFIG.refresh_timeout = (int)strtol(optarg, NULL, 10);
                 break;
-            case 26:
+            case 25:
                 CONFIG.http_headers
                     = curl_slist_append(CONFIG.http_headers, optarg);
                 break;
-            case 27:
+            case 26:
                 CacheSystem_clear();
                 break;
-            case 28:
+            case 27:
                 CONFIG.zero_len_is_dir = 1;
                 break;
-            case 29:
+            case 28:
                 CONFIG.invalid_refresh = 1;
                 break;
             default:
@@ -446,16 +443,12 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
  */
 void add_arg(char ***fuse_argv_ptr, int *fuse_argc, char *opt_string)
 {
-    char **tmp = (char **)realloc((void *)*fuse_argv_ptr,
-                                  ((size_t)*fuse_argc + 1) * sizeof(char *));
-    if (!tmp) {
-        lprintf(fatal, "realloc failed: %s\n", strerror(errno));
-        return;
-    }
-    *fuse_argv_ptr = tmp;
-    (*fuse_argc)++;
+    char **new_argv = (char **)REALLOC(
+        (void *)*fuse_argv_ptr, ((size_t)*fuse_argc + 1) * sizeof(char *));
+    *fuse_argv_ptr = new_argv;
     char **fuse_argv = *fuse_argv_ptr;
-    fuse_argv[*fuse_argc - 1] = STRDUP(opt_string);
+    fuse_argv[*fuse_argc] = STRDUP(opt_string);
+    (*fuse_argc)++;
 }
 
 static void print_help(char *program_name, int long_help)
@@ -500,11 +493,6 @@ HTTPDirFS options:\n\
                             Note: this setting is ignored if previously\n\
                             cached data is found for the requested file.\n\
         --http-header       Set one or more HTTP headers\n\
-        --max-seg-count     Set maximum number of download segments a file\n\
-                            can have. (default: " XSTR(DEFAULT_MAX_SEGBC) ")\n\
-                            With the default setting, the maximum memory usage\n\
-                            per file is 128KB. This allows caching files up\n\
-                            to 1TB in size using the default segment size.\n\
         --max-conns         Set maximum number of network connections that\n\
                             libcurl is allowed to make. (default: " XSTR(DEFAULT_NETWORK_MAX_CONNS) ")\n\
         --refresh-timeout   The directories are refreshed after the specified\n\

--- a/src/memcache.c
+++ b/src/memcache.c
@@ -9,17 +9,15 @@
 size_t write_memory_callback(void *recv_data, size_t size, size_t nmemb,
                              void *userp)
 {
-    size_t recv_size = size * nmemb;
     TransferStruct *ts = (TransferStruct *)userp;
 
-    char *tmp = realloc(ts->data, ts->curr_size + recv_size + 1);
-    if (!tmp) {
-        /*
-         * out of memory!
-         */
-        lprintf(fatal, "realloc failure!\n");
+    if (size != 0 && nmemb > (SIZE_MAX - ts->curr_size - 1) / size) {
+        lprintf(fatal, "Response buffer size overflow!\n");
     }
-    ts->data = tmp;
+    size_t recv_size = size * nmemb;
+
+    void *new_data = REALLOC(ts->data, ts->curr_size + recv_size + 1);
+    ts->data = new_data;
 
     memmove(&ts->data[ts->curr_size], recv_data, recv_size);
     ts->curr_size += recv_size;

--- a/src/sonic.c
+++ b/src/sonic.c
@@ -29,7 +29,7 @@ static SonicConfigStruct SONIC_CONFIG;
 void sonic_config_init(const char *server, const char *username,
                        const char *password)
 {
-    SONIC_CONFIG.server = strndup(server, PATH_MAX);
+    SONIC_CONFIG.server = STRNDUP(server, PATH_MAX);
     /*
      * Correct for the extra '/'
      */
@@ -37,8 +37,8 @@ void sonic_config_init(const char *server, const char *username,
     if (server_url_len > 0 && SONIC_CONFIG.server[server_url_len - 1] == '/') {
         SONIC_CONFIG.server[server_url_len - 1] = '\0';
     }
-    SONIC_CONFIG.username = strndup(username, NAME_MAX);
-    SONIC_CONFIG.password = strndup(password, NAME_MAX);
+    SONIC_CONFIG.username = STRNDUP(username, NAME_MAX);
+    SONIC_CONFIG.password = STRNDUP(password, NAME_MAX);
     SONIC_CONFIG.client = DEFAULT_USER_AGENT;
 
     if (!CONFIG.sonic_insecure) {
@@ -76,6 +76,7 @@ static char *sonic_gen_auth_str(void)
                  SONIC_CONFIG.client);
         FREE(salt);
         FREE(token);
+        FREE(pwd_salt);
         return auth_str;
     } else {
         char *pwd_hex = str_to_hex(SONIC_CONFIG.password);
@@ -307,7 +308,7 @@ static void XMLCALL XML_parser_general(void *data, const char *elem,
 
 static void sanitise_LinkTable(LinkTable *linktbl)
 {
-    for (int i = 0; i < linktbl->num; i++) {
+    for (int i = 0; i < linktbl->size; i++) {
         if (!strcmp(linktbl->links[i]->linkname, ".")) {
             /* Note the super long sanitised name to avoid collision */
             strcpy(linktbl->links[i]->linkname, "__DOT__");

--- a/src/util.c
+++ b/src/util.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "log.h"
 
+#include <curl/curl.h>
 #include <openssl/evp.h>
 #include <uuid/uuid.h>
 
@@ -28,6 +29,11 @@
  * \details This is basically the length of a UUID
  */
 #define SALT_LEN 36
+
+#ifdef DEBUG
+static MemNode *mem_head = NULL;
+static pthread_mutex_t mem_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
 
 char *path_append(const char *path, const char *filename)
 {
@@ -251,19 +257,300 @@ char *generate_md5sum(const char *str)
     return out;
 }
 
-void *CALLOC(size_t nmemb, size_t size)
+static void *malloc_wrapper_internal(size_t size, const char *file,
+                                     const char *func, int line)
 {
-    void *ptr = calloc(nmemb, size);
-    if (!ptr) {
-        lprintf(fatal, "%s!\n", strerror(errno));
+    void *ptr = malloc(size);
+    if (size != 0 && !ptr) {
+        fatal_log_printf(file, func, line, "%s!\n", strerror(errno));
     }
+
+#ifdef DEBUG
+    log_printf(debug, file, func, line, "MALLOC: %p, %zu bytes\n", ptr, size);
+
+    if (ptr) {
+        MemNode *node = calloc(1, sizeof(MemNode));
+        if (!node) {
+            fatal_log_printf(file, func, line,
+                             "Could not allocate MemNode: %s!\n",
+                             strerror(errno));
+        }
+        node->ptr = ptr;
+        node->size = size;
+        node->file = file;
+        node->func = func;
+        node->line = line;
+
+        pthread_mutex_lock(&mem_mutex);
+        node->next = mem_head;
+        mem_head = node;
+        pthread_mutex_unlock(&mem_mutex);
+    }
+#endif
+
     return ptr;
 }
 
-void FREE_wrapper(void *ptr)
+void *CALLOC_wrapper(size_t nmemb, size_t size, const char *file,
+                     const char *func, int line)
 {
+    void *ptr = calloc(nmemb, size);
+    if (nmemb != 0 && size != 0 && !ptr) {
+        fatal_log_printf(file, func, line, "%s!\n", strerror(errno));
+    }
+
+#ifdef DEBUG
+    log_printf(debug, file, func, line, "CALLOC: %p, %zu bytes\n", ptr,
+               nmemb * size);
+
     if (ptr) {
+        MemNode *node = calloc(1, sizeof(MemNode));
+        if (!node) {
+            fatal_log_printf(file, func, line,
+                             "Could not allocate MemNode: %s!\n",
+                             strerror(errno));
+        }
+        node->ptr = ptr;
+        node->size = nmemb * size;
+        node->file = file;
+        node->func = func;
+        node->line = line;
+
+        pthread_mutex_lock(&mem_mutex);
+        node->next = mem_head;
+        mem_head = node;
+        pthread_mutex_unlock(&mem_mutex);
+    }
+#endif
+
+    return ptr;
+}
+
+char *STRDUP_wrapper(const char *s, const char *file, const char *func,
+                     int line)
+{
+    if (!s) {
+        return NULL;
+    }
+    size_t len = strlen(s) + 1;
+    char *ptr = malloc_wrapper_internal(len, file, func, line);
+    memcpy(ptr, s, len);
+    return ptr;
+}
+
+char *STRNDUP_wrapper(const char *s, size_t n, const char *file,
+                      const char *func, int line)
+{
+    if (!s) {
+        return NULL;
+    }
+    size_t len = strnlen(s, n);
+    char *ptr = malloc_wrapper_internal(len + 1, file, func, line);
+    memcpy(ptr, s, len);
+    ptr[len] = '\0';
+    return ptr;
+}
+
+void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
+                      const char *func, int line)
+{
+    if (!ptr) {
+        return malloc_wrapper_internal(size, file, func, line);
+    }
+
+#ifdef DEBUG
+    log_printf(debug, file, func, line, "REALLOC: %p, %zu bytes\n", ptr, size);
+
+    // Look up in tracker
+    pthread_mutex_lock(&mem_mutex);
+    MemNode **curr = &mem_head;
+    MemNode *found_node = NULL;
+    while (*curr) {
+        if ((*curr)->ptr == ptr) {
+            found_node = *curr;
+            *curr = found_node->next; // Temporarily unlink
+            break;
+        }
+        curr = &((*curr)->next);
+    }
+
+    if (found_node) {
+        void *new_ptr = realloc(ptr, size);
+        if (!new_ptr && size != 0) {
+            // Re-link the node before releasing lock and failing
+            found_node->next = mem_head;
+            mem_head = found_node;
+            pthread_mutex_unlock(&mem_mutex);
+
+            fatal_log_printf(file, func, line, "realloc failed: %s!\n",
+                             strerror(errno));
+            return NULL;
+        }
+
+        if (!new_ptr && size == 0) {
+            pthread_mutex_unlock(&mem_mutex);
+            free(found_node);
+            free(ptr);
+            log_printf(debug, file, func, line,
+                       "REALLOC result: NULL (size 0, freed)\n");
+            return NULL;
+        } else {
+            found_node->ptr = new_ptr;
+            found_node->size = size;
+            found_node->file = file;
+            found_node->func = func;
+            found_node->line = line;
+
+            found_node->next = mem_head;
+            mem_head = found_node;
+            pthread_mutex_unlock(&mem_mutex);
+
+            log_printf(debug, file, func, line, "REALLOC result: %p\n",
+                       new_ptr);
+            return new_ptr;
+        }
+    }
+    pthread_mutex_unlock(&mem_mutex);
+
+    // Fallback path: pointer was not found in tracker
+    log_printf(warning, file, func, line, "REALLOC: %p not found in tracker!\n",
+               ptr);
+
+    void *new_ptr = realloc(ptr, size);
+    if (!new_ptr && size != 0) {
+        fatal_log_printf(file, func, line, "realloc failed: %s!\n",
+                         strerror(errno));
+    }
+
+    if (new_ptr || size == 0) {
+        if (!new_ptr && size == 0) {
+            log_printf(debug, file, func, line,
+                       "REALLOC result: %p (size 0, not found, unchanged)\n",
+                       new_ptr);
+            return new_ptr;
+        } else {
+            MemNode *node = calloc(1, sizeof(MemNode));
+            if (!node) {
+                fatal_log_printf(file, func, line,
+                                 "Could not allocate MemNode: %s!\n",
+                                 strerror(errno));
+            }
+            node->ptr = new_ptr;
+            node->size = size;
+            node->file = file;
+            node->func = func;
+            node->line = line;
+
+            pthread_mutex_lock(&mem_mutex);
+            node->next = mem_head;
+            mem_head = node;
+            pthread_mutex_unlock(&mem_mutex);
+
+            log_printf(debug, file, func, line,
+                       "REALLOC result: %p (adopted)\n", new_ptr);
+            return new_ptr;
+        }
+    }
+
+    return NULL;
+#else
+    void *new_ptr = realloc(ptr, size);
+    if (!new_ptr && size != 0) {
+        fatal_log_printf(file, func, line, "realloc failed: %s!\n",
+                         strerror(errno));
+    }
+    return new_ptr;
+#endif
+}
+
+char *REALPATH_wrapper(const char *path, char *resolved_path, const char *file,
+                       const char *func, int line)
+{
+    char *res = realpath(path, resolved_path);
+#ifdef DEBUG
+    if (res && !resolved_path) {
+        log_printf(debug, file, func, line, "REALPATH: %p\n", (void *)res);
+
+        MemNode *node = calloc(1, sizeof(MemNode));
+        if (!node) {
+            fatal_log_printf(file, func, line,
+                             "Could not allocate MemNode: %s!\n",
+                             strerror(errno));
+        }
+        node->ptr = res;
+        node->size = strlen(res) + 1;
+        node->file = file;
+        node->func = func;
+        node->line = line;
+
+        pthread_mutex_lock(&mem_mutex);
+        node->next = mem_head;
+        mem_head = node;
+        pthread_mutex_unlock(&mem_mutex);
+    }
+#else
+    (void)file;
+    (void)func;
+    (void)line;
+#endif
+    return res;
+}
+
+void FREE_wrapper(void *ptr, const char *file, const char *func, int line)
+{
+    if (!ptr) {
+        return;
+    }
+
+#ifdef DEBUG
+    pthread_mutex_lock(&mem_mutex);
+    MemNode **curr = &mem_head;
+    MemNode *found_node = NULL;
+    while (*curr) {
+        if ((*curr)->ptr == ptr) {
+            found_node = *curr;
+            *curr = found_node->next;
+            break;
+        }
+        curr = &((*curr)->next);
+    }
+    pthread_mutex_unlock(&mem_mutex);
+
+    if (found_node) {
+        free(found_node);
+        log_printf(debug, file, func, line, "FREE: %p\n", ptr);
         free(ptr);
+        return;
+    }
+
+    log_printf(warning, file, func, line, "FREE: %p not found in tracker!\n",
+               ptr);
+#else
+    (void)file;
+    (void)func;
+    (void)line;
+#endif
+    free(ptr);
+}
+
+void mem_cleanup(void)
+{
+#ifdef DEBUG
+    pthread_mutex_lock(&mem_mutex);
+    MemNode *curr = mem_head;
+    while (curr) {
+        MemNode *next = curr->next;
+        free(curr->ptr);
+        free(curr);
+        curr = next;
+    }
+    mem_head = NULL;
+    pthread_mutex_unlock(&mem_mutex);
+    pthread_mutex_destroy(&mem_mutex);
+#endif
+    if (CONFIG.http_headers) {
+        curl_slist_free_all(CONFIG.http_headers);
+        CONFIG.http_headers = NULL;
     }
 }
 
@@ -276,22 +563,4 @@ char *str_to_hex(char *s)
         snprintf(h, 3, "%02x", (unsigned char)s[i]);
     }
     return hex;
-}
-
-char *STRDUP(const char *s)
-{
-    char *ptr = strdup(s);
-    if (!ptr) {
-        lprintf(fatal, "%s!\n", strerror(errno));
-    }
-    return ptr;
-}
-
-char *STRNDUP(const char *s, size_t n)
-{
-    char *ptr = strndup(s, n);
-    if (!ptr) {
-        lprintf(fatal, "%s!\n", strerror(errno));
-    }
-    return ptr;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -9,6 +9,8 @@
 #include <semaphore.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 /**
  * \brief append a path
@@ -113,15 +115,34 @@ char *generate_salt(void);
  */
 char *generate_md5sum(const char *str);
 
+#ifdef DEBUG
+
 /**
- * \brief wrapper for calloc(), with error handling
+ * \brief memory allocation tracker node
  */
-void *CALLOC(size_t nmemb, size_t size);
+typedef struct MemNode {
+    void *ptr;
+    size_t size;
+    const char *file;
+    const char *func;
+    int line;
+    struct MemNode *next;
+} MemNode;
+
+#endif
+
+/**
+ * \brief wrapper for calloc(), with error handling and memory tracking
+ */
+void *CALLOC_wrapper(size_t nmemb, size_t size, const char *file,
+                     const char *func, int line);
+#define CALLOC(nmemb, size)                                                    \
+    CALLOC_wrapper(nmemb, size, __FILE__, __func__, __LINE__)
 
 /**
  * \brief Internal wrapper for free().
  */
-void FREE_wrapper(void *ptr);
+void FREE_wrapper(void *ptr, const char *file, const char *func, int line);
 
 /**
  * \brief Macro wrapper for free() that sets the pointer to NULL afterwards.
@@ -136,24 +157,49 @@ void FREE_wrapper(void *ptr);
 #define FREE(ptr)                                                              \
     do {                                                                       \
         __extension__ __auto_type __ptr_to_free = &(ptr);                      \
-        FREE_wrapper((void *)*__ptr_to_free);                                  \
+        FREE_wrapper((void *)*__ptr_to_free, __FILE__, __func__, __LINE__);    \
         *__ptr_to_free = NULL;                                                 \
     } while (0)
+
+/**
+ * \brief wrapper for STRDUP(), with memory tracking
+ */
+char *STRDUP_wrapper(const char *s, const char *file, const char *func,
+                     int line);
+#define STRDUP(s) STRDUP_wrapper(s, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for STRNDUP(), with memory tracking
+ */
+char *STRNDUP_wrapper(const char *s, size_t n, const char *file,
+                      const char *func, int line);
+#define STRNDUP(s, n) STRNDUP_wrapper(s, n, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for realloc(), with memory tracking
+ */
+void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
+                      const char *func, int line);
+#define REALLOC(ptr, size)                                                     \
+    REALLOC_wrapper(ptr, size, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief wrapper for realpath(), with memory tracking
+ */
+char *REALPATH_wrapper(const char *path, char *resolved_path, const char *file,
+                       const char *func, int line);
+#define REALPATH(path, resolved_path)                                          \
+    REALPATH_wrapper(path, resolved_path, __FILE__, __func__, __LINE__)
+
+/**
+ * \brief cleanup all allocated memory
+ */
+void mem_cleanup(void);
 
 /**
  * \brief Convert a string to hex
  */
 char *str_to_hex(char *s);
-
-/**
- * \brief wrapper for strdup(), with error handling
- */
-char *STRDUP(const char *s);
-
-/**
- * \brief wrapper for strndup(), with error handling
- */
-char *STRNDUP(const char *s, size_t n);
 
 /**
  * \brief initialise the configuration data structure


### PR DESCRIPTION
Introduce a thread-safe memory tracking system in debug builds and harden dynamic allocations, sanitizing cache and input sizes.

Memory Tracking & Cleanup:
- Implement thread-safe allocation tracking in debug builds using mutex-protected wrappers for CALLOC, REALLOC, STRDUP, STRNDUP, REALPATH, and FREE.
- Track source file, function, and line numbers of all allocations in a singly-linked list.
- Register mem_cleanup via atexit in config.c to release remaining tracked memory and headers at exit.

Robust Allocations & Failure Hardening:
- Harden LinkTable_add, add_arg, and write_memory_callback by checking reallocations for success before incrementing state counters (size, argc, curr_size).
- Prevent integer overflows in write_memory_callback size checks.

Cache & Link Table Sanitization:
- Rename LinkTable.num to LinkTable.size for clarity.
- Sanitize the loaded disk link table size in LinkTable_disk_open, deleting the corrupted cache and returning NULL on invalid size.
- Simplify segment count verification in Meta_read, checking against dynamic limits and returning EBADMSG on invalid sizes.

Option Removal & Bug Fixes:
- Remove --max-seg-count CLI option and CONFIG.max_segbc.
- Update getopt indices in parse_arg_list to avoid mismatches.
- Fix a memory leak in sonic_gen_auth_str by freeing pwd_salt.
- Remove outdated staged files note from clang-format hook name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory safety with overflow guards and freed temporary buffers
  * Strengthened validation to prevent integer overflows in cache metadata handling
  * Fixed a memory-leak in auth token generation

* **Behavior**
  * Directory listing iteration adjusted (may alter listed entries)
  * Better handling when HOME is unset for cache/config fallbacks

* **Chores**
  * Removed `--max-seg-count` command-line option
  * Updated pre-commit configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->