### PR TITLE
Implement asynchronous cache downloading and early return

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "log.h"
+#include "memcache.h"
 #include "util.h"
 #include <curl/curl.h>
 
@@ -544,6 +545,10 @@ static Cache *Cache_alloc(void)
     Cache *cf = CALLOC(1, sizeof(Cache));
     PTHREAD_MUTEX_INIT(&cf->seek_lock, NULL);
     PTHREAD_MUTEX_INIT(&cf->w_lock, NULL);
+    PTHREAD_MUTEX_INIT(&cf->dl_lock, NULL);
+    pthread_cond_init(&cf->dl_cond, NULL);
+    cf->active_dl_offset = -1;
+    cf->active_dl_ts = NULL;
     cf->cache_opened = 1;
     SEM_INIT(&cf->bgt_sem, 0, 1);
     return cf;
@@ -556,6 +561,8 @@ static void Cache_free(Cache *cf)
 {
     PTHREAD_MUTEX_DESTROY(&cf->seek_lock);
     PTHREAD_MUTEX_DESTROY(&cf->w_lock);
+    PTHREAD_MUTEX_DESTROY(&cf->dl_lock);
+    pthread_cond_destroy(&cf->dl_cond);
     SEM_DESTROY(&cf->bgt_sem);
 
     if (cf->path) {
@@ -993,27 +1000,26 @@ static void *Cache_bgdl(void *arg)
 {
     Cache *cf = (Cache *)arg;
 
-    lprintf(cache_lock_debug, "thread %lx: locking w_lock;\n",
-            (unsigned long)pthread_self());
-    PTHREAD_MUTEX_LOCK(&cf->w_lock);
-
     uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
     lprintf(debug, "thread %lx spawned.\n ", (unsigned long)pthread_self());
     long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz,
-                              cf->next_dl_offset);
+                              cf->next_dl_offset, cf);
     if (recv < 0) {
         lprintf(error,
                 "thread %lx received %ld bytes, "
                 "which doesn't make sense\n",
                 (unsigned long)pthread_self(), recv);
         FREE(recv_buf);
-        lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-                (unsigned long)pthread_self());
-        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+        PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+        cf->active_dl_offset = -1;
+        cf->active_dl_ts = NULL;
+        pthread_cond_broadcast(&cf->dl_cond);
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         SEM_POST(&cf->bgt_sem);
         pthread_exit(NULL);
     }
 
+    PTHREAD_MUTEX_LOCK(&cf->w_lock);
     if ((recv == cf->blksz)
         || (cf->next_dl_offset
             == (cf->content_length / cf->blksz * cf->blksz))) {
@@ -1026,12 +1032,16 @@ static void *Cache_bgdl(void *arg)
                 "error.\n",
                 recv, cf->blksz);
     }
+    PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
 
     FREE(recv_buf);
 
-    lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-            (unsigned long)pthread_self());
-    PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+    PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+    cf->active_dl_offset = -1;
+    cf->active_dl_ts = NULL;
+    pthread_cond_broadcast(&cf->dl_cond);
+    PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
     SEM_POST(&cf->bgt_sem);
 
     pthread_exit(NULL);
@@ -1065,111 +1075,100 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
                                const off_t len, const off_t offset_start)
 {
     long send;
-
-    /*
-     * The offset of the segment to be downloaded
-     */
     off_t dl_offset = offset_start / cf->blksz * cf->blksz;
 
-    /*
-     * ------------- Check if the segment already exists --------------
-     */
+retry:
+    PTHREAD_MUTEX_LOCK(&cf->w_lock);
     if (Seg_exist(cf, dl_offset)) {
         send = Data_read(cf, (uint8_t *)output_buf, len, offset_start);
-        goto bgdl;
-    } else {
-        /*
-         * Wait for any other download thread to finish
-         */
-
-        lprintf(cache_lock_debug, "thread %lx: locking w_lock;\n",
-                (unsigned long)pthread_self());
-        PTHREAD_MUTEX_LOCK(&cf->w_lock);
-
-        if (Seg_exist(cf, dl_offset)) {
-            /*
-             * The segment now exists - it was downloaded by another
-             * download thread. Send it off and unlock the I/O
-             */
-            send = Data_read(cf, (uint8_t *)output_buf, len, offset_start);
-
-            lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-                    (unsigned long)pthread_self());
-            PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
-
-            goto bgdl;
-        }
-    }
-
-    /*
-     * ------------------ Download the segment ---------------------
-     */
-
-    uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
-    lprintf(debug, "thread %lx: spawned.\n ", (unsigned long)pthread_self());
-    long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz, dl_offset);
-    if (recv < 0) {
-        lprintf(error,
-                "thread %lx received %ld bytes, "
-                "which doesn't make sense\n",
-                (unsigned long)pthread_self(), recv);
-        FREE(recv_buf);
-        lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
-        return recv;
+        goto bgdl;
     }
-    /*
-     * check if we have received enough data, write it to the disk
-     *
-     * Condition 1: received the exact amount as the segment size.
-     * Condition 2: offset is the last segment
-     */
-    if ((recv == cf->blksz)
-        || (dl_offset == (cf->content_length / cf->blksz * cf->blksz))) {
-        if (Data_write(cf, recv_buf, recv, dl_offset) == recv) {
-            Seg_set(cf, dl_offset, 1);
+
+    PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+    if (cf->active_dl_offset == dl_offset) {
+        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+
+        while (cf->active_dl_offset == dl_offset) {
+            if (cf->active_dl_ts
+                && cf->active_dl_ts->curr_size
+                       >= (size_t)(offset_start - dl_offset + len)) {
+                memcpy(output_buf,
+                       cf->active_dl_ts->data + (offset_start - dl_offset),
+                       len);
+                PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+                send = len;
+                goto bgdl;
+            }
+            if (cf->active_dl_ts && !cf->active_dl_ts->transferring) {
+                break;
+            }
+            pthread_cond_wait(&cf->dl_cond, &cf->dl_lock);
         }
-    } else {
-        lprintf(error,
-                "received %ld rather than %d, possible network "
-                "error.\n",
-                recv, cf->blksz);
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+        goto retry;
     }
-    send = len;
-    if (offset_start < dl_offset
-        || (size_t)(offset_start - dl_offset) + (size_t)send
-               > (size_t)cf->blksz) {
-        lprintf(error, "invalid offset or length for memcpy, aborting copy\n");
-        send = 0;
+    PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
+    int ret = sem_trywait(&cf->bgt_sem);
+    if (ret == 0) {
+        PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+        cf->active_dl_offset = dl_offset;
+        cf->next_dl_offset = dl_offset;
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+        Cache_bgdl_launcher(cf);
+        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+        goto retry;
     } else {
-        memcpy(output_buf, recv_buf + (offset_start - dl_offset), send);
+        uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
+        long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz,
+                                  dl_offset, cf);
+        if (recv < 0) {
+            FREE(recv_buf);
+            PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+            return recv;
+        }
+        if ((recv == cf->blksz)
+            || (dl_offset == (cf->content_length / cf->blksz * cf->blksz))) {
+            if (Data_write(cf, recv_buf, recv, dl_offset) == recv) {
+                Seg_set(cf, dl_offset, 1);
+            }
+        } else {
+            lprintf(error,
+                    "received %ld rather than %d, possible network "
+                    "error.\n",
+                    recv, cf->blksz);
+        }
+        send = len;
+        if (offset_start < dl_offset
+            || (size_t)(offset_start - dl_offset) + (size_t)send
+                   > (size_t)cf->blksz) {
+            lprintf(error,
+                    "invalid offset or length for memcpy, aborting copy\n");
+            send = 0;
+        } else {
+            memcpy(output_buf, recv_buf + (offset_start - dl_offset), send);
+        }
+        FREE(recv_buf);
+        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
     }
-    FREE(recv_buf);
 
-    lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-            (unsigned long)pthread_self());
-    PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
-
-    /*
-     * ----------- Download the next segment in background -----------------
-     */
 bgdl: {
 }
     off_t next_dl_offset = dl_offset + cf->blksz;
     if (!Seg_exist(cf, next_dl_offset) && next_dl_offset < cf->content_length) {
-        /*
-         * Stop the spawning of multiple background pthreads
-         */
-        int ret = sem_trywait(&cf->bgt_sem);
+        ret = sem_trywait(&cf->bgt_sem);
         if (!ret) {
-            lprintf(cache_lock_debug,
-                    "parent thread %lx: sem_trywait successful\n",
-                    (unsigned long)pthread_self());
-            cf->next_dl_offset = next_dl_offset;
-            Cache_bgdl_launcher(cf);
-        } else if (errno != EAGAIN) {
-            lprintf(fatal, "sem_trywait(): %d, %s\n", errno, strerror(errno));
+            PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+            if (cf->active_dl_offset == next_dl_offset) {
+                PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+                SEM_POST(&cf->bgt_sem);
+            } else {
+                cf->active_dl_offset = next_dl_offset;
+                cf->next_dl_offset = next_dl_offset;
+                PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+                Cache_bgdl_launcher(cf);
+            }
         }
     }
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -14,6 +14,8 @@ typedef struct Cache Cache;
 #include "link.h"
 #include "network.h"
 
+struct TransferStruct;
+
 #include <stdio.h>
 #include <stdint.h>
 #include <pthread.h>
@@ -59,6 +61,15 @@ struct Cache {
     sem_t bgt_sem;
     /** \brief the offset of the next segment to be downloaded in background*/
     off_t next_dl_offset;
+
+    /** \brief mutex lock for background download progress */
+    pthread_mutex_t dl_lock;
+    /** \brief condition variable for background download progress */
+    pthread_cond_t dl_cond;
+    /** \brief the active TransferStruct for the background download */
+    struct TransferStruct *active_dl_ts;
+    /** \brief the offset currently being downloaded in background */
+    off_t active_dl_offset;
 
     /** \brief the FUSE filesystem path to the remote file*/
     char *fs_path;

--- a/src/link.c
+++ b/src/link.c
@@ -1158,7 +1158,8 @@ bug report, please include the following HTTP header information:\n%s\n",
     return recv;
 }
 
-long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
+long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
+                   Cache *cf)
 {
     TransferStruct ts;
     TransferStruct header;
@@ -1177,9 +1178,17 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
         ts.data = NULL;
         ts.type = DATA;
         ts.transferring = 1;
+        ts.cache_ptr = cf;
+
+        if (cf) {
+            PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+            cf->active_dl_ts = &ts;
+            PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+        }
 
         header.curr_size = 0;
         header.data = NULL;
+        header.cache_ptr = NULL;
 
         CURL *curl
             = Link_download_curl_setup(link, req_size, offset, &header, &ts);
@@ -1230,7 +1239,7 @@ long path_download(const char *path, char *output_buf, size_t req_size,
         return -ENOENT;
     }
 
-    return Link_download(link, output_buf, req_size, offset);
+    return Link_download(link, output_buf, req_size, offset, NULL);
 }
 
 static void make_link_relative(const char *page_url, char *link_url)

--- a/src/link.h
+++ b/src/link.h
@@ -98,7 +98,8 @@ long path_download(const char *path, char *output_buf, size_t size,
  * \brief Download a Link
  * \return the number of bytes downloaded
  */
-long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset);
+long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
+                   Cache *cf);
 
 /**
  * \brief find the link associated with a path

--- a/src/memcache.c
+++ b/src/memcache.c
@@ -16,12 +16,21 @@ size_t write_memory_callback(void *recv_data, size_t size, size_t nmemb,
     }
     size_t recv_size = size * nmemb;
 
+    if (ts->cache_ptr) {
+        PTHREAD_MUTEX_LOCK(&ts->cache_ptr->dl_lock);
+    }
+
     void *new_data = REALLOC(ts->data, ts->curr_size + recv_size + 1);
     ts->data = new_data;
 
     memmove(&ts->data[ts->curr_size], recv_data, recv_size);
     ts->curr_size += recv_size;
     ts->data[ts->curr_size] = '\0';
+
+    if (ts->cache_ptr) {
+        pthread_cond_broadcast(&ts->cache_ptr->dl_cond);
+        PTHREAD_MUTEX_UNLOCK(&ts->cache_ptr->dl_lock);
+    }
 
     return recv_size;
 }

--- a/src/memcache.h
+++ b/src/memcache.h
@@ -21,6 +21,8 @@ struct TransferStruct {
     volatile int transferring;
     /** \brief The link associated with the transfer */
     Link *link;
+    /** \brief The Cache structure associated with the transfer */
+    Cache *cache_ptr;
 };
 
 /**


### PR DESCRIPTION
This PR resolves #239 by introducing asynchronous cache mode downloading. 

It optimizes the cache mode by returning chunks of data to the FUSE system immediately as they become available from the libcurl multi transfer routine. This is achieved by introducing a thread synchronization primitive (`dl_lock` and `dl_cond`) to the cache state. This change prevents the high latency previously experienced when waiting for complete blocks to download before returning partial payloads.

Resolves #239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved thread synchronization for concurrent download operations, preventing potential race conditions and data corruption
  * Enhanced error recovery mechanisms when downloads fail or are interrupted
  * Optimized background download coordination to reduce redundant transfer attempts and improve efficiency
  * Strengthened consistency guarantees between background operations and reader threads through better state management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->