### PR TITLE
Fix logic gap in make_link_relative when page_url does not end with slash

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -1295,7 +1295,7 @@ static void make_link_relative(const char *page_url, char *link_url)
     }
     int skip_len = strlen(page_url);
     if (page_url[skip_len - 1] != '/') {
-        if (page_url[skip_len] != '/') {
+        if (link_url[skip_len] != '/') {
             /* Um, I'm not sure what to do here, so give up. */
             return;
         }


### PR DESCRIPTION
This patch correctly evaluates `link_url` instead of `page_url` at the `skip_len` index to check for a `/`. `page_url[skip_len]` was always evaluating to `\0`, so the fallback condition was completely broken.

---
*PR created automatically by Jules for task [12934046964053362087](https://jules.google.com/task/12934046964053362087) started by @fangfufu*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a validation check in relative link normalization that was incorrectly referencing the wrong variable, causing improper control flow in certain relative-link processing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->