### PR TITLE
⚡ Optimize memory tracker lookups with hash table

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -31,8 +31,14 @@
 #define SALT_LEN 36
 
 #ifdef DEBUG
-static MemNode *mem_head = NULL;
+#define MEM_HASH_TABLE_SIZE 4096
+static MemNode *mem_hash_table[MEM_HASH_TABLE_SIZE] = {0};
 static pthread_mutex_t mem_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static inline size_t hash_ptr(const void *ptr)
+{
+    return ((uintptr_t)ptr >> 4) & (MEM_HASH_TABLE_SIZE - 1);
+}
 #endif
 
 char *path_append(const char *path, const char *filename)
@@ -282,8 +288,9 @@ static void *malloc_wrapper_internal(size_t size, const char *file,
         node->line = line;
 
         pthread_mutex_lock(&mem_mutex);
-        node->next = mem_head;
-        mem_head = node;
+        size_t idx = hash_ptr(ptr);
+        node->next = mem_hash_table[idx];
+        mem_hash_table[idx] = node;
         pthread_mutex_unlock(&mem_mutex);
     }
 #endif
@@ -317,8 +324,9 @@ void *CALLOC_wrapper(size_t nmemb, size_t size, const char *file,
         node->line = line;
 
         pthread_mutex_lock(&mem_mutex);
-        node->next = mem_head;
-        mem_head = node;
+        size_t idx = hash_ptr(ptr);
+        node->next = mem_hash_table[idx];
+        mem_hash_table[idx] = node;
         pthread_mutex_unlock(&mem_mutex);
     }
 #endif
@@ -363,7 +371,8 @@ void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
 
     // Look up in tracker
     pthread_mutex_lock(&mem_mutex);
-    MemNode **curr = &mem_head;
+    size_t idx = hash_ptr(ptr);
+    MemNode **curr = &mem_hash_table[idx];
     MemNode *found_node = NULL;
     while (*curr) {
         if ((*curr)->ptr == ptr) {
@@ -378,8 +387,8 @@ void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
         void *new_ptr = realloc(ptr, size);
         if (!new_ptr && size != 0) {
             // Re-link the node before releasing lock and failing
-            found_node->next = mem_head;
-            mem_head = found_node;
+            found_node->next = mem_hash_table[idx];
+            mem_hash_table[idx] = found_node;
             pthread_mutex_unlock(&mem_mutex);
 
             fatal_log_printf(file, func, line, "realloc failed: %s!\n",
@@ -401,8 +410,9 @@ void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
             found_node->func = func;
             found_node->line = line;
 
-            found_node->next = mem_head;
-            mem_head = found_node;
+            size_t new_idx = hash_ptr(new_ptr);
+            found_node->next = mem_hash_table[new_idx];
+            mem_hash_table[new_idx] = found_node;
             pthread_mutex_unlock(&mem_mutex);
 
             log_printf(debug, file, func, line, "REALLOC result: %p\n",
@@ -442,8 +452,9 @@ void *REALLOC_wrapper(void *ptr, size_t size, const char *file,
             node->line = line;
 
             pthread_mutex_lock(&mem_mutex);
-            node->next = mem_head;
-            mem_head = node;
+            size_t new_idx = hash_ptr(new_ptr);
+            node->next = mem_hash_table[new_idx];
+            mem_hash_table[new_idx] = node;
             pthread_mutex_unlock(&mem_mutex);
 
             log_printf(debug, file, func, line,
@@ -484,8 +495,9 @@ char *REALPATH_wrapper(const char *path, char *resolved_path, const char *file,
         node->line = line;
 
         pthread_mutex_lock(&mem_mutex);
-        node->next = mem_head;
-        mem_head = node;
+        size_t idx = hash_ptr(res);
+        node->next = mem_hash_table[idx];
+        mem_hash_table[idx] = node;
         pthread_mutex_unlock(&mem_mutex);
     }
 #else
@@ -504,7 +516,8 @@ void FREE_wrapper(void *ptr, const char *file, const char *func, int line)
 
 #ifdef DEBUG
     pthread_mutex_lock(&mem_mutex);
-    MemNode **curr = &mem_head;
+    size_t idx = hash_ptr(ptr);
+    MemNode **curr = &mem_hash_table[idx];
     MemNode *found_node = NULL;
     while (*curr) {
         if ((*curr)->ptr == ptr) {
@@ -537,14 +550,16 @@ void mem_cleanup(void)
 {
 #ifdef DEBUG
     pthread_mutex_lock(&mem_mutex);
-    MemNode *curr = mem_head;
-    while (curr) {
-        MemNode *next = curr->next;
-        free(curr->ptr);
-        free(curr);
-        curr = next;
+    for (size_t i = 0; i < MEM_HASH_TABLE_SIZE; i++) {
+        MemNode *curr = mem_hash_table[i];
+        while (curr) {
+            MemNode *next = curr->next;
+            free(curr->ptr);
+            free(curr);
+            curr = next;
+        }
+        mem_hash_table[i] = NULL;
     }
-    mem_head = NULL;
     pthread_mutex_unlock(&mem_mutex);
     pthread_mutex_destroy(&mem_mutex);
 #endif


### PR DESCRIPTION
💡 **What:** Replaced the `mem_head` linked list in `src/util.c` with a hash table (`mem_hash_table` of size 4096) for tracking memory allocations in DEBUG mode. Updated `malloc`, `calloc`, `realloc`, `realpath`, `free` wrappers, and `mem_cleanup` to interact with the new hash table.
🎯 **Why:** To improve performance. The original linked list caused `REALLOC_wrapper` and `FREE_wrapper` to run in O(N) time for each call, leading to O(N^2) total execution time when allocating and freeing many blocks. The hash table changes lookups to O(1) average time.
📊 **Measured Improvement:** Running a benchmark that calls `CALLOC_wrapper` and `FREE_wrapper` 20,000 times showed an improvement from ~1.36s (baseline) to ~0.005s (optimized) execution time.

---
*PR created automatically by Jules for task [11465356005539375609](https://jules.google.com/task/11465356005539375609) started by @fangfufu*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal memory allocation tracking mechanisms for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->