### PR TITLE
Support CAPATH and PROXY_CAPATH configuration for SSL certificates

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -25,6 +25,8 @@ void Config_init(void)
 
     CONFIG.proxy_password = NULL;
 
+    CONFIG.proxy_cafile = NULL;
+
     CONFIG.proxy_capath = NULL;
 
     CONFIG.max_conns = DEFAULT_NETWORK_MAX_CONNS;

--- a/src/config.c
+++ b/src/config.c
@@ -25,6 +25,8 @@ void Config_init(void)
 
     CONFIG.proxy_password = NULL;
 
+    CONFIG.proxy_capath = NULL;
+
     CONFIG.max_conns = DEFAULT_NETWORK_MAX_CONNS;
 
     CONFIG.user_agent = DEFAULT_USER_AGENT;
@@ -38,6 +40,10 @@ void Config_init(void)
     CONFIG.zero_len_is_dir = 0;
 
     CONFIG.insecure_tls = 0;
+
+    CONFIG.cafile = NULL;
+
+    CONFIG.capath = NULL;
 
     CONFIG.refresh_timeout = DEFAULT_REFRESH_TIMEOUT;
 

--- a/src/config.h
+++ b/src/config.h
@@ -63,6 +63,8 @@ typedef struct {
     char *proxy_password;
     /** \brief HTTP proxy certificate file */
     char *proxy_cafile;
+    /** \brief HTTP proxy certificate directory */
+    char *proxy_capath;
     /** \brief HTTP maximum connection count */
     long max_conns;
     /** \brief HTTP user agent*/
@@ -79,6 +81,8 @@ typedef struct {
     int insecure_tls;
     /** \brief Server certificate file */
     char *cafile;
+    /** \brief Server certificate directory */
+    char *capath;
     /** \brief Refresh directory listing after refresh_timeout seconds */
     int refresh_timeout;
     /** \brief Try refreshing invalid links when reading a directory */

--- a/src/link.c
+++ b/src/link.c
@@ -100,16 +100,13 @@ static CURL *Link_to_curl(Link *link)
     if (ret) {
         lprintf(error, "%s", curl_easy_strerror(ret));
     }
-    if (CONFIG.cafile) {
+    if (CONFIG.cafile || CONFIG.capath) {
         /*
-         * Having been given a certificate file, disable any search directory
-         * built into libcurl, so that we exclusively use the explicitly given
-         * certificate(s).
-         *
-         * If we ever add a CAPATH option, we should do the mirror for CAINFO,
-         * too: disable both and then enable whichever one(s) were given.
+         * Having been given a certificate file or directory, disable any search
+         * paths built into libcurl, so that we exclusively use the explicitly
+         * given certificate(s).
          */
-        ret = curl_easy_setopt(curl, CURLOPT_CAPATH, NULL);
+        ret = curl_easy_setopt(curl, CURLOPT_CAPATH, CONFIG.capath);
         if (ret) {
             lprintf(error, "%s", curl_easy_strerror(ret));
         }
@@ -177,9 +174,9 @@ static CURL *Link_to_curl(Link *link)
         }
     }
 
-    if (CONFIG.proxy_cafile) {
+    if (CONFIG.proxy_cafile || CONFIG.proxy_capath) {
         /* See CONFIG.cafile above */
-        ret = curl_easy_setopt(curl, CURLOPT_PROXY_CAPATH, NULL);
+        ret = curl_easy_setopt(curl, CURLOPT_PROXY_CAPATH, CONFIG.proxy_capath);
         if (ret) {
             lprintf(error, "%s", curl_easy_strerror(ret));
         }

--- a/src/main.c
+++ b/src/main.c
@@ -309,6 +309,8 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
            {"cache-clear", no_argument, NULL, 'L'},           /* 26 */
            {"zero-len-is-dir", no_argument, NULL, 'L'},       /* 27 */
            {"invalid-refresh", no_argument, NULL, 'L'},       /* 28 */
+           {"capath", required_argument, NULL, 'L'},          /* 29 */
+           {"proxy-capath", required_argument, NULL, 'L'},    /* 30 */
            {0, 0, 0, 0}};
     while ((c = getopt_long(argc, argv, short_opts, long_opts, &long_index))
            != -1) {
@@ -424,6 +426,12 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
             case 28:
                 CONFIG.invalid_refresh = 1;
                 break;
+            case 29:
+                CONFIG.capath = STRDUP(optarg);
+                break;
+            case 30:
+                CONFIG.proxy_capath = STRDUP(optarg);
+                break;
             default:
                 fprintf(stderr, "see httpdirfs -h for usage\n");
                 return 1;
@@ -481,6 +489,7 @@ HTTPDirFS options:\n\
         --proxy-username    Username for the proxy\n\
         --proxy-password    Password for the proxy\n\
         --proxy-cacert      Certificate authority for the proxy\n\
+        --proxy-capath      Certificate authority directory for the proxy\n\
         --cache             Enable cache (default: off)\n\
         --cache-location    Set a custom cache location\n\
                             (default: \"${XDG_CACHE_HOME}/httpdirfs\")\n\
@@ -488,6 +497,7 @@ HTTPDirFS options:\n\
                             specified with `--cache-location`, if the option is\n\
                             seen first. Then exit in either case.\n\
         --cacert            Certificate authority for the server\n\
+        --capath            Certificate authority directory for the server\n\
         --dl-seg-size       Set cache download segment size, in MB (default: " XSTR(
                         DEFAULT_DATA_BLKSZ_MB) ")\n\
                             Note: this setting is ignored if previously\n\


### PR DESCRIPTION
Implemented the feature request in src/link.c to add support for a CAPATH directory configuration, mapping it to libcurl's `CURLOPT_CAPATH` and `CURLOPT_PROXY_CAPATH`. 

Added `--capath` and `--proxy-capath` command-line arguments, parsed them into the `ConfigStruct`, and updated `src/link.c` logic to gracefully handle setting either `cafile` or `capath` paths. Verified with clean code review.

---
*PR created automatically by Jules for task [7364106300339330812](https://jules.google.com/task/7364106300339330812) started by @fangfufu*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --capath to specify a TLS CA certificate directory for server verification.
  * Added --proxy-capath to specify a TLS CA certificate directory for proxy verification.
  * Enhanced TLS handling so directory-based CA paths and file-based CA certificates can be used together for both server and proxy certificate validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->