### PR TITLE
test: add system integration test suite and fix concurrency race

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,8 @@ jobs:
           meson \
           ninja-build \
           help2man \
-          python3
+          python3 \
+          clang
 
     - name: Setup Meson
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,12 +55,14 @@ jobs:
           libgumbo-dev \
           libcurl4-openssl-dev \
           libfuse3-dev \
+          fuse3 \
           uuid-dev \
           libexpat1-dev \
           libssl-dev \
           meson \
           ninja-build \
-          help2man
+          help2man \
+          python3
 
     - name: Setup Meson
       run: |
@@ -70,5 +72,8 @@ jobs:
     - name: Compile
       run: meson compile -C builddir
 
-    - name: Test
-      run: meson test -C builddir
+    - name: Unit tests
+      run: meson test -C builddir --no-suite integration
+
+    - name: Integration tests
+      run: meson test -C builddir --suite integration --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,13 @@ jobs:
     - name: Test
       run: meson test -C builddir
 
+    - name: Upload Meson logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: meson-logs-mac
+        path: builddir/meson-logs/
+
   build-ubuntu:
     name: Build (Ubuntu, ${{ matrix.compiler }})
     runs-on: ubuntu-latest
@@ -78,3 +85,10 @@ jobs:
 
     - name: Integration tests
       run: meson test -C builddir --suite integration --verbose
+
+    - name: Upload Meson logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: meson-logs-ubuntu-${{ matrix.compiler }}
+        path: builddir/meson-logs/

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get install -y \
             libgumbo-dev libfuse3-dev libssl-dev \
             libcurl4-openssl-dev uuid-dev help2man libexpat1-dev pkg-config \
-            meson ninja-build astyle clang-tidy clang-format \
+            meson ninja-build astyle clang clang-tidy clang-format \
             fuse3 python3
       - name: Set up build directory
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,8 @@ jobs:
           sudo apt-get install -y \
             libgumbo-dev libfuse3-dev libssl-dev \
             libcurl4-openssl-dev uuid-dev help2man libexpat1-dev pkg-config \
-            meson ninja-build astyle clang-tidy clang-format
+            meson ninja-build astyle clang-tidy clang-format \
+            fuse3 python3
       - name: Set up build directory
         run: |
           meson setup builddir

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,12 @@ repos:
         language: system
         pass_filenames: false
         files: \.(c|h|py|sh)$
+    -   id: integration-test-clang
+        name: Integration Test (Clang)
+        entry: >-
+          bash -c 'if [ ! -d builddir_clang ]; then
+          CC=clang meson setup builddir_clang; fi &&
+          meson test -C builddir_clang --suite integration --verbose'
+        language: system
+        pass_filenames: false
+        files: \.(c|h|py|sh)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,13 @@ repos:
         files: \.(c|h)$
     -   id: meson-test
         name: Meson Test
-        entry: meson test -C builddir
+        entry: meson test -C builddir --no-suite integration
         language: system
         pass_filenames: false
         files: \.(c|h)$
+    -   id: integration-test
+        name: Integration Test
+        entry: meson test -C builddir --suite integration --verbose
+        language: system
+        pass_filenames: false
+        files: \.(c|h|py|sh)$

--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,11 @@ fuse_dep = dependency('fuse3')
 uuid_dep = dependency('uuid')
 expat_dep = dependency('expat')
 openssl_dep = dependency('openssl')
-execinfo_dep = cc.find_library('execinfo', required: false)
+if cc.has_function('backtrace', prefix: '#include <execinfo.h>')
+    execinfo_dep = dependency('', required: false)
+else
+    execinfo_dep = cc.find_library('execinfo', required: false)
+endif
 
 httpdirfs_deps = [
     gumbo_dep,

--- a/src/README.md
+++ b/src/README.md
@@ -119,6 +119,13 @@ pre-commit run --all-files
 > meson setup builddir
 > ```
 
+<!-- prettier-ignore -->
+> [!IMPORTANT]
+> The `integration-test-clang` hook requires `clang` to be installed on the
+> system (e.g., `sudo apt install clang` on Debian/Ubuntu systems). Please
+> ensure that `clang` is installed so the Clang-based integration tests can run
+> successfully during pre-commit checks.
+
 ---
 
 ## Logging and Error Handling

--- a/src/cache.c
+++ b/src/cache.c
@@ -728,7 +728,7 @@ int Cache_create(const char *path)
     cf->time = this_link->time;
     cf->content_length = this_link->content_length;
     cf->blksz = CONFIG.data_blksz;
-    cf->segbc = (cf->content_length / cf->blksz) + 1;
+    cf->segbc = (cf->content_length + cf->blksz - 1) / cf->blksz;
     cf->seg = CALLOC(cf->segbc, sizeof(Seg));
 
     Meta_create(cf);

--- a/src/cache.c
+++ b/src/cache.c
@@ -791,126 +791,84 @@ Cache *Cache_open(const char *fn)
         return link->cache_ptr;
     }
 
-    /*
-     * Check if both metadata and data file exist
-     */
-    if (CONFIG.mode == NORMAL || CONFIG.mode == SINGLE) {
-        if (Cache_exist(fn)) {
-
-            lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
-                    (unsigned long)pthread_self());
-            PTHREAD_MUTEX_UNLOCK(&cf_lock);
-            return NULL;
-        }
-    } else if (CONFIG.mode == SONIC) {
-        if (Cache_exist(link->sonic.id)) {
-
-            lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
-                    (unsigned long)pthread_self());
-            PTHREAD_MUTEX_UNLOCK(&cf_lock);
-            return NULL;
-        }
-    } else {
-        lprintf(fatal, "Invalid CONFIG.mode\n");
-    }
-
-    /*
-     * Create the cache in-memory data structure
-     */
-    Cache *cf = Cache_alloc();
-
-    /*
-     * Fill in the fs_path
-     */
-    cf->fs_path = CALLOC(PATH_MAX + 1, sizeof(char));
-    snprintf(cf->fs_path, PATH_MAX + 1, "%s", fn);
-
-    /*
-     * Set the path for the local cache file, if we are in sonic mode
-     */
+    const char *actual_fn = fn;
     if (CONFIG.mode == SONIC) {
-        fn = link->sonic.id;
+        actual_fn = link->sonic.id;
     }
 
-    cf->path = STRNDUP(fn, PATH_MAX);
+    // Try up to 2 times. If opening fails on the first attempt (outdated,
+    // corrupt, etc.), we delete the cache and try creating and opening a fresh
+    // one.
+    for (int attempt = 0; attempt < 2; attempt++) {
+        if (Cache_exist(actual_fn) != 0) {
+            Cache_delete(fn);
+            if (Cache_create(fn) != 0) {
+                lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                        (unsigned long)pthread_self());
+                PTHREAD_MUTEX_UNLOCK(&cf_lock);
+                return NULL;
+            }
+        }
 
-    /*
-     * Associate the cache structure with a link
-     */
-    cf->link = link;
+        /*
+         * Create the cache in-memory data structure
+         */
+        Cache *cf = Cache_alloc();
 
-    if (Meta_open(cf)) {
-        lprintf(error, "cannot open metadata file %s.\n", fn);
-        Cache_free(cf);
+        /*
+         * Fill in the fs_path
+         */
+        cf->fs_path = CALLOC(PATH_MAX + 1, sizeof(char));
+        snprintf(cf->fs_path, PATH_MAX + 1, "%s", fn);
 
-        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
-                (unsigned long)pthread_self());
-        PTHREAD_MUTEX_UNLOCK(&cf_lock);
-        return NULL;
-    }
+        cf->path = STRNDUP(actual_fn, PATH_MAX);
 
-    /*
-     * Corrupt metadata
-     */
-    if (Meta_read(cf)) {
-        lprintf(error, "metadata error: %s.\n", fn);
-        Cache_free(cf);
+        /*
+         * Associate the cache structure with a link
+         */
+        cf->link = link;
 
-        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
-                (unsigned long)pthread_self());
-        PTHREAD_MUTEX_UNLOCK(&cf_lock);
-        return NULL;
-    }
-
-    /*
-     * Inconsistency between metadata and data file, note that on disk file
-     * size might be bigger than content_length, due to on-disk filesystem
-     * allocation policy.
-     */
-    if (cf->content_length > Data_size(fn)) {
-        lprintf(error, "metadata inconsistency %s, \
+        int ok = 1;
+        if (Meta_open(cf)) {
+            lprintf(error, "cannot open metadata file %s.\n", actual_fn);
+            ok = 0;
+        } else if (Meta_read(cf)) {
+            lprintf(error, "metadata error: %s.\n", actual_fn);
+            ok = 0;
+        } else if (cf->content_length > Data_size(actual_fn)) {
+            lprintf(error, "metadata inconsistency %s, \
 cf->content_length: %ld, Data_size(fn): %ld.\n",
-                fn, cf->content_length, Data_size(fn));
+                    actual_fn, cf->content_length, Data_size(actual_fn));
+            ok = 0;
+        } else if (cf->time != cf->link->time) {
+            lprintf(warning, "outdated cache file: %s.\n", actual_fn);
+            ok = 0;
+        } else if (Data_open(cf)) {
+            lprintf(error, "cannot open data file %s.\n", actual_fn);
+            ok = 0;
+        }
+
+        if (ok) {
+            /*
+             * Yup, we just created a circular loop. ;)
+             */
+            cf->link->cache_ptr = cf;
+
+            lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                    (unsigned long)pthread_self());
+            PTHREAD_MUTEX_UNLOCK(&cf_lock);
+            return cf;
+        }
+
+        // Clean up memory and delete files before retry
         Cache_free(cf);
-
-        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
-                (unsigned long)pthread_self());
-        PTHREAD_MUTEX_UNLOCK(&cf_lock);
-        return NULL;
+        Cache_delete(fn);
     }
-
-    /*
-     * Check if the cache files are not outdated
-     */
-    if (cf->time != cf->link->time) {
-        lprintf(warning, "outdated cache file: %s.\n", fn);
-        Cache_free(cf);
-
-        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
-                (unsigned long)pthread_self());
-        PTHREAD_MUTEX_UNLOCK(&cf_lock);
-        return NULL;
-    }
-
-    if (Data_open(cf)) {
-        lprintf(error, "cannot open data file %s.\n", fn);
-        Cache_free(cf);
-
-        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
-                (unsigned long)pthread_self());
-        PTHREAD_MUTEX_UNLOCK(&cf_lock);
-        return NULL;
-    }
-
-    /*
-     * Yup, we just created a circular loop. ;)
-     */
-    cf->link->cache_ptr = cf;
 
     lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
             (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf_lock);
-    return cf;
+    return NULL;
 }
 
 void Cache_close(Cache *cf)

--- a/src/fuse_local.c
+++ b/src/fuse_local.c
@@ -110,24 +110,12 @@ static int fs_open(const char *path, struct fuse_file_info *fi)
     if (CACHE_SYSTEM_INIT) {
         lprintf(debug, "Cache_open(%s);\n", path);
         fi->fh = (uint64_t)Cache_open(path);
+        /*
+         * The cache definitely cannot be opened for some reason.
+         */
         if (!fi->fh) {
-            /*
-             * The link clearly exists, the cache cannot be opened, attempt
-             * cache creation
-             */
-            lprintf(debug, "Cache_delete(%s);\n", path);
-            Cache_delete(path);
-            lprintf(debug, "Cache_create(%s);\n", path);
-            Cache_create(path);
-            lprintf(debug, "Cache_open(%s);\n", path);
-            fi->fh = (uint64_t)Cache_open(path);
-            /*
-             * The cache definitely cannot be opened for some reason.
-             */
-            if (!fi->fh) {
-                lprintf(fatal, "Cache file creation failure for %s.\n", path);
-                return -ENOENT;
-            }
+            lprintf(fatal, "Cache file creation failure for %s.\n", path);
+            return -ENOENT;
         }
     }
     return 0;

--- a/tests/integration/generate_test_files.py
+++ b/tests/integration/generate_test_files.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Generate test files with various filenames for HTTPDirFS integration tests.
+
+Creates a set of files with known content and checksums to verify filesystem
+correctness after mounting with httpdirfs. Filenames include
+non-alphanumeric characters, spaces, and other edge cases.
+
+File sizes are randomised between 1 KB and 10 MB using a deterministic seed
+so that the manifest is reproducible across runs.
+"""
+
+import hashlib
+import json
+import os
+import random
+import sys
+
+# Fixed seed so that file sizes are reproducible across runs, while still
+# being "random" in the sense that they cover a wide range.
+RNG_SEED = 20260518
+
+# 64 KB write chunk — balances memory usage and I/O throughput
+CHUNK_SIZE = 64 * 1024
+
+
+def write_deterministic_file(filepath, name, size):
+    """Write a file with deterministic content and return its SHA-256.
+
+    Uses a name-derived seed with Python's Mersenne Twister PRNG.
+    Streams to disk in 64 KB chunks so even multi-GB files use constant
+    memory.
+    """
+    if size == 0:
+        with open(filepath, "wb"):
+            pass
+        return hashlib.sha256(b"").hexdigest()
+
+    seed_hash = hashlib.sha256(name.encode()).digest()
+    file_rng = random.Random(int.from_bytes(seed_hash[:8], "big"))
+    h = hashlib.sha256()
+    written = 0
+
+    with open(filepath, "wb") as f:
+        while written < size:
+            n = min(CHUNK_SIZE, size - written)
+            chunk = file_rng.randbytes(n)
+            f.write(chunk)
+            h.update(chunk)
+            written += n
+
+    return h.hexdigest()
+
+
+def random_size(rng):
+    """Return a random file size between 1 KB and 10 MB."""
+    return rng.randint(1024, 10 * 1024 * 1024)
+
+
+def format_size(size):
+    """Human-readable size string."""
+    if size >= 1024 * 1024 * 1024:
+        return f"{size / (1024**3):.1f} GB"
+    if size >= 1024 * 1024:
+        return f"{size / (1024**2):.1f} MB"
+    if size >= 1024:
+        return f"{size / 1024:.1f} KB"
+    return f"{size} bytes"
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <output_directory> [--large]",
+              file=sys.stderr)
+        sys.exit(1)
+
+    output_dir = sys.argv[1]
+    include_large = "--large" in sys.argv
+    os.makedirs(output_dir, exist_ok=True)
+
+    rng = random.Random(RNG_SEED)
+
+    # Filenames that exercise interesting edge cases.  Each file gets a
+    # random size between 1 KB and 10 MB.
+    filenames = [
+        # Basic ASCII filenames
+        "simple.txt",
+        "UPPERCASE.DAT",
+
+        # Filenames with spaces
+        "file with spaces.txt",
+        "multiple   spaces   here.bin",
+
+        # Non-alphanumeric characters that are valid in URLs
+        "file-with-dashes.txt",
+        "file_with_underscores.txt",
+        "file.multiple.dots.txt",
+        "file~tilde.txt",
+
+        # Percent-encoded characters in HTTP (common edge cases)
+        "parens(1).txt",
+        "brackets[2].txt",
+        "curly{3}.txt",
+        "hash#tag.txt",
+        "at@sign.txt",
+        "plus+plus.txt",
+        "equals=value.txt",
+        "comma,separated.txt",
+        "semi;colon.txt",
+        "exclaim!mark.txt",
+        "single'quote.txt",
+
+        # Mixed case and numbers
+        "CamelCase123.txt",
+        "MiXeD_cAsE-456.dat",
+
+        # Longer filenames
+        "a" * 200 + ".txt",
+    ]
+
+    # Build (filename, size) pairs with random sizes
+    test_files = [(name, random_size(rng)) for name in filenames]
+
+    # Keep a few deterministic edge-case sizes
+    test_files.append(("empty_file.txt", 0))
+    test_files.append(("tiny.txt", 1))
+
+    # Add the 1 GB file for cache system testing when --large is given
+    if include_large:
+        test_files.append(("large_1g.bin", 1024 * 1024 * 1024))
+
+    manifest = {}
+
+    for filename, size in test_files:
+        filepath = os.path.join(output_dir, filename)
+        checksum = write_deterministic_file(filepath, filename, size)
+
+        manifest[filename] = {
+            "size": size,
+            "sha256": checksum,
+        }
+        print(f"  Created: {filename} ({format_size(size)},"
+              f" sha256={checksum[:16]}...)")
+
+    # Also create a subdirectory with files (random sizes too)
+    subdir = os.path.join(output_dir, "subdir with spaces")
+    os.makedirs(subdir, exist_ok=True)
+
+    subdir_filenames = [
+        "nested file.txt",
+        "deep-data.bin",
+    ]
+
+    for filename in subdir_filenames:
+        size = random_size(rng)
+        filepath = os.path.join(subdir, filename)
+        seed_name = f"subdir/{filename}"
+        checksum = write_deterministic_file(filepath, seed_name, size)
+
+        relative = os.path.join("subdir with spaces", filename)
+        manifest[relative] = {
+            "size": size,
+            "sha256": checksum,
+        }
+        print(f"  Created: {relative} ({format_size(size)},"
+              f" sha256={checksum[:16]}...)")
+
+    # Write manifest
+    manifest_path = os.path.join(output_dir, "manifest.json")
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+    print(f"\nManifest written to {manifest_path}")
+    print(f"Total files: {len(manifest)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/multithread_read.py
+++ b/tests/integration/multithread_read.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Multithreaded file reader for cache system integration testing.
+
+Reads a file from multiple threads simultaneously, each thread reading
+different byte ranges. Verifies each range against expected SHA-256 checksums
+computed from the original file content.
+
+Usage:
+    python3 multithread_read.py <filepath> <expected_sha256> <num_threads>
+
+Exit code 0 on success, 1 on verification failure.
+"""
+
+import hashlib
+import os
+import sys
+import threading
+
+
+def read_range(filepath, start, length, results, index):
+    """Read a byte range from the file and store it in results."""
+    try:
+        with open(filepath, "rb") as f:
+            f.seek(start)
+            data = f.read(length)
+        results[index] = data
+    except Exception as e:
+        results[index] = e
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <filepath> <expected_sha256>"
+              f" <num_threads>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    expected_sha256 = sys.argv[2]
+    num_threads = int(sys.argv[3])
+
+    file_size = os.path.getsize(filepath)
+    chunk_size = file_size // num_threads
+    remainder = file_size % num_threads
+
+    print(f"  File: {os.path.basename(filepath)}")
+    print(f"  Size: {file_size} bytes ({file_size / (1024*1024):.1f} MB)")
+    print(f"  Threads: {num_threads}")
+    print(f"  Chunk size: {chunk_size} bytes")
+
+    # Launch threads to read different ranges
+    threads = []
+    results = [None] * num_threads
+
+    offset = 0
+    for i in range(num_threads):
+        # Last thread gets any remainder bytes
+        length = chunk_size + (remainder if i == num_threads - 1 else 0)
+        t = threading.Thread(
+            target=read_range,
+            args=(filepath, offset, length, results, i),
+        )
+        threads.append(t)
+        offset += length
+
+    # Start all threads simultaneously
+    for t in threads:
+        t.start()
+
+    # Wait for all to complete
+    for t in threads:
+        t.join()
+
+    # Check for errors
+    for i, result in enumerate(results):
+        if isinstance(result, Exception):
+            print(f"  ERROR: Thread {i} failed: {result}", file=sys.stderr)
+            sys.exit(1)
+        if result is None:
+            print(f"  ERROR: Thread {i} returned no data", file=sys.stderr)
+            sys.exit(1)
+
+    # Reassemble and verify
+    full_data = b"".join(results)
+    actual_sha256 = hashlib.sha256(full_data).hexdigest()
+
+    if actual_sha256 == expected_sha256:
+        print(f"  SHA-256 OK: {actual_sha256}")
+        sys.exit(0)
+    else:
+        print(f"  SHA-256 MISMATCH!", file=sys.stderr)
+        print(f"    Expected: {expected_sha256}", file=sys.stderr)
+        print(f"    Actual:   {actual_sha256}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/range_http_server.py
+++ b/tests/integration/range_http_server.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""HTTP server with Range request support for HTTPDirFS integration tests.
+
+Python's built-in SimpleHTTPRequestHandler does not support HTTP Range
+requests.  HTTPDirFS relies on Range requests to fetch file segments, so we
+need a handler that honours the Range header and responds with 206 Partial
+Content when appropriate.
+
+Usage:
+    python3 range_http_server.py <directory> <port> <port_file>
+
+The server writes its actual listening port to <port_file> once ready, then
+serves <directory> until terminated.
+"""
+
+import http.server
+import os
+import signal
+import socketserver
+import sys
+import urllib.parse
+
+
+class RangeHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """HTTP request handler with Range header support."""
+
+    def log_message(self, format, *args):
+        """Suppress default request logging."""
+        pass
+
+    def send_head(self):
+        """Common code for GET and HEAD commands (with Range support).
+
+        Returns a file object, or None if an error response was sent.
+        """
+        path = self.translate_path(self.path)
+        if os.path.isdir(path):
+            # Delegate directory listing to the base class
+            return super().send_head()
+
+        try:
+            f = open(path, "rb")
+        except OSError:
+            self.send_error(404, "File not found")
+            return None
+
+        try:
+            fs = os.fstat(f.fileno())
+            file_size = fs.st_size
+
+            range_header = self.headers.get("Range")
+            if range_header:
+                return self._handle_range_request(f, file_size, fs, path)
+
+            # No Range header — send the whole file
+            ctype = self.guess_type(path)
+            self.send_response(200)
+            self.send_header("Content-type", ctype)
+            self.send_header("Content-Length", str(file_size))
+            self.send_header("Accept-Ranges", "bytes")
+            self.send_header(
+                "Last-Modified", self.date_time_string(fs.st_mtime)
+            )
+            self.end_headers()
+            return f
+        except Exception:
+            f.close()
+            raise
+
+    def _handle_range_request(self, f, file_size, fs, path):
+        """Handle a request containing a Range header."""
+        range_header = self.headers.get("Range")
+        try:
+            # Parse "bytes=START-END"
+            unit, ranges_str = range_header.split("=", 1)
+            if unit.strip().lower() != "bytes":
+                raise ValueError("Unsupported range unit")
+
+            # We only support a single range
+            range_spec = ranges_str.split(",")[0].strip()
+            start_str, end_str = range_spec.split("-", 1)
+
+            if start_str:
+                start = int(start_str)
+                end = int(end_str) if end_str else file_size - 1
+            elif end_str:
+                # Suffix range: last N bytes
+                suffix_len = int(end_str)
+                start = max(0, file_size - suffix_len)
+                end = file_size - 1
+            else:
+                raise ValueError("Invalid range")
+
+            # Clamp to file size
+            end = min(end, file_size - 1)
+
+            if start > end or start >= file_size:
+                self.send_error(416, "Requested Range Not Satisfiable")
+                self.send_header(
+                    "Content-Range", f"bytes */{file_size}"
+                )
+                self.end_headers()
+                f.close()
+                return None
+
+            content_length = end - start + 1
+            ctype = self.guess_type(path)
+
+            self.send_response(206)
+            self.send_header("Content-type", ctype)
+            self.send_header("Content-Length", str(content_length))
+            self.send_header("Accept-Ranges", "bytes")
+            self.send_header(
+                "Content-Range",
+                f"bytes {start}-{end}/{file_size}",
+            )
+            self.send_header(
+                "Last-Modified", self.date_time_string(fs.st_mtime)
+            )
+            self.end_headers()
+
+            f.seek(start)
+            return _RangeFile(f, content_length)
+
+        except (ValueError, IndexError):
+            # Malformed range — fall back to full file
+            f.seek(0)
+            ctype = self.guess_type(path)
+            self.send_response(200)
+            self.send_header("Content-type", ctype)
+            self.send_header("Content-Length", str(file_size))
+            self.send_header("Accept-Ranges", "bytes")
+            self.send_header(
+                "Last-Modified", self.date_time_string(fs.st_mtime)
+            )
+            self.end_headers()
+            return f
+
+    def do_HEAD(self):
+        """Handle HEAD request."""
+        f = self.send_head()
+        if f:
+            f.close()
+
+
+class _RangeFile:
+    """Wraps a file object to limit reads to a byte range."""
+
+    def __init__(self, f, length):
+        self._f = f
+        self._remaining = length
+
+    def read(self, n=-1):
+        if self._remaining <= 0:
+            return b""
+        if n < 0 or n > self._remaining:
+            n = self._remaining
+        data = self._f.read(n)
+        self._remaining -= len(data)
+        return data
+
+    def close(self):
+        self._f.close()
+
+
+class ReusableTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+    allow_reuse_port = True
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(
+            f"Usage: {sys.argv[0]} <directory> <port> <port_file>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    directory = sys.argv[1]
+    port = int(sys.argv[2])
+    port_file = sys.argv[3]
+
+    os.chdir(directory)
+
+    handler = RangeHTTPRequestHandler
+
+    with ReusableTCPServer(("127.0.0.1", port), handler) as httpd:
+        actual_port = httpd.server_address[1]
+        with open(port_file, "w") as f:
+            f.write(str(actual_port))
+
+        signal.signal(signal.SIGTERM, lambda *a: sys.exit(0))
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -365,8 +365,11 @@ else
     for BLKSZ in ${BLOCK_SIZES}; do
         log_info "--- Cache test: --dl-seg-size ${BLKSZ} ---"
 
-        # Clean cache directory for each run
-        rm -rf "${CACHE_DIR:?}"/*
+        # Remove and recreate the cache directory for a completely
+        # clean state — ensures no metadata from a previous block size
+        # can affect the next run
+        rm -rf "${CACHE_DIR:?}"
+        mkdir -p "${CACHE_DIR}"
 
         "${HTTPDIRFS_BIN}" \
             -f \

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -337,7 +337,7 @@ log_info "Unmounted successfully."
 
 # ─── Step 6: Cache mode with multithreaded reads ────────────────────────────
 
-log_info "=== Cache mode test ==="
+log_info "=== Cache mode tests ==="
 
 # Get the large file's expected SHA-256 from the manifest
 LARGE_FILE_SHA256=$(python3 -c "
@@ -354,60 +354,76 @@ else:
 if [[ -z "${LARGE_FILE_SHA256}" ]]; then
     skip "Cache test: large_1g.bin not in manifest"
 else
-    log_info "Mounting with httpdirfs (cache mode)..."
+    # Test with multiple block sizes to exercise segbc edge cases:
+    #   8 MB  - default, 1 GB / 8 MB  = 128 exactly (no remainder)
+    #  16 MB  - fewer segments, 1 GB / 16 MB = 64 exactly
+    #   1 MB  - many segments, 1 GB / 1 MB  = 1024 exactly
+    #   7 MB  - 1 GB / 7 MB ≈ 146.3 (remainder)
+    #   3 MB  - 1 GB / 3 MB ≈ 341.3 (remainder)
+    BLOCK_SIZES="8 16 1 7 3"
 
-    "${HTTPDIRFS_BIN}" \
-        -f \
-        --cache \
-        --cache-location "${CACHE_DIR}" \
-        "${BASE_URL}" \
-        "${CACHE_MOUNT_DIR}" &
-    CACHE_HTTPDIRFS_PID=$!
+    for BLKSZ in ${BLOCK_SIZES}; do
+        log_info "--- Cache test: --dl-seg-size ${BLKSZ} ---"
 
-    # Wait for mount
-    for i in $(seq 1 "${MOUNT_TIMEOUT}"); do
-        if mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
-            break
+        # Clean cache directory for each run
+        rm -rf "${CACHE_DIR:?}"/*
+
+        "${HTTPDIRFS_BIN}" \
+            -f \
+            --cache \
+            --cache-location "${CACHE_DIR}" \
+            --dl-seg-size "${BLKSZ}" \
+            "${BASE_URL}" \
+            "${CACHE_MOUNT_DIR}" &
+        CACHE_HTTPDIRFS_PID=$!
+
+        # Wait for mount
+        for i in $(seq 1 "${MOUNT_TIMEOUT}"); do
+            if mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
+                break
+            fi
+            sleep 1
+        done
+
+        if ! mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
+            log_error "httpdirfs (cache, blksz=${BLKSZ}M) failed to mount."
+            skip "Cache mode tests (mount failed, blksz=${BLKSZ}M)"
+            wait "${CACHE_HTTPDIRFS_PID}" 2>/dev/null || true
+            continue
         fi
-        sleep 1
-    done
 
-    if ! mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
-        log_error "httpdirfs (cache) failed to mount within ${MOUNT_TIMEOUT}s."
-        skip "Cache mode tests (mount failed)"
-    else
-        log_info "httpdirfs (cache) mounted at ${CACHE_MOUNT_DIR}"
+        log_info "httpdirfs (cache, blksz=${BLKSZ}M) mounted"
 
         LARGE_FILE="${CACHE_MOUNT_DIR}/large_1g.bin"
 
         # Test: Multithreaded read with 8 threads
-        log_info "Test group: Multithreaded cache read (8 threads)"
+        log_info "Test group: Multithreaded cache read (blksz=${BLKSZ}M)"
         if python3 "${SCRIPT_DIR}/multithread_read.py" \
             "${LARGE_FILE}" "${LARGE_FILE_SHA256}" 8; then
-            pass "Multithreaded read (8 threads): checksum OK"
+            pass "Multithreaded read (blksz=${BLKSZ}M, 8 threads): OK"
         else
-            fail "Multithreaded read (8 threads): checksum mismatch"
+            fail "Multithreaded read (blksz=${BLKSZ}M, 8 threads): FAIL"
         fi
 
-        # Test: Sequential read of the same file (should come from cache now)
-        log_info "Test group: Cached sequential re-read"
+        # Test: Sequential re-read (should come from cache now)
+        log_info "Test group: Cached re-read (blksz=${BLKSZ}M)"
         actual_sha256=$(sha256sum "${LARGE_FILE}" 2>/dev/null \
             | awk '{print $1}')
         if [[ "${actual_sha256}" == "${LARGE_FILE_SHA256}" ]]; then
-            pass "Cached re-read: checksum OK"
+            pass "Cached re-read (blksz=${BLKSZ}M): OK"
         else
-            fail "Cached re-read: checksum mismatch"
+            fail "Cached re-read (blksz=${BLKSZ}M): FAIL"
             log_error "  expected: ${LARGE_FILE_SHA256}"
             log_error "  actual:   ${actual_sha256}"
         fi
 
-        # Unmount cache mode
-        log_info "Unmounting cache mount..."
+        # Unmount
         do_unmount "${CACHE_MOUNT_DIR}"
         wait "${CACHE_HTTPDIRFS_PID}" 2>/dev/null || true
-        log_info "Cache mount unmounted."
-    fi
+        log_info "Cache mount (blksz=${BLKSZ}M) unmounted."
+    done
 fi
+
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+#
+# Integration test for HTTPDirFS
+#
+# This script:
+#   1. Generates test files with various filenames (including non-alphanumeric)
+#   2. Starts an HTTP server with Range request support
+#   3. Mounts the HTTP directory with httpdirfs
+#   4. Verifies file listing, content integrity (SHA-256), and sizes
+#   5. Tests cache mode with multithreaded reads on a large file
+#   6. Cleans up (unmount, stop server, remove temp files)
+#
+# Usage: ./run_integration_test.sh [path_to_httpdirfs_binary]
+#
+# Exit codes:
+#   0 - All tests passed
+#   1 - Test failure or setup error
+
+set -euo pipefail
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HTTPDIRFS_BIN="${1:-}"
+HTTP_PORT="${HTTPDIRFS_TEST_PORT:-0}"
+
+# Colours for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Colour
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+log_info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC}: $*"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC}: $*"; }
+skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC}: $*"; }
+
+do_unmount() {
+    local mnt="$1"
+    fusermount3 -u "${mnt}" 2>/dev/null || \
+        fusermount -u "${mnt}" 2>/dev/null || \
+        umount "${mnt}" 2>/dev/null || true
+}
+
+cleanup() {
+    log_info "Cleaning up..."
+
+    # Unmount if still mounted
+    if mountpoint -q "${MOUNT_DIR}" 2>/dev/null; then
+        do_unmount "${MOUNT_DIR}"
+        sleep 1
+    fi
+    if [[ -n "${CACHE_MOUNT_DIR:-}" ]] \
+        && mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
+        do_unmount "${CACHE_MOUNT_DIR}"
+        sleep 1
+    fi
+
+    # Stop HTTP server
+    if [[ -n "${HTTP_PID:-}" ]] && kill -0 "${HTTP_PID}" 2>/dev/null; then
+        kill "${HTTP_PID}" 2>/dev/null || true
+        wait "${HTTP_PID}" 2>/dev/null || true
+    fi
+
+    # Remove temp directories
+    if [[ -n "${WORK_DIR:-}" && -d "${WORK_DIR}" ]]; then
+        rm -rf "${WORK_DIR}"
+    fi
+
+    log_info "Cleanup complete."
+}
+
+trap cleanup EXIT
+
+# ─── Precondition checks ────────────────────────────────────────────────────
+
+if [[ -z "${HTTPDIRFS_BIN}" ]]; then
+    log_error "Usage: $0 <path_to_httpdirfs_binary>"
+    exit 1
+fi
+
+if [[ ! -x "${HTTPDIRFS_BIN}" ]]; then
+    log_error "httpdirfs binary not found or not executable: ${HTTPDIRFS_BIN}"
+    exit 1
+fi
+
+if [[ ! -e /dev/fuse ]]; then
+    log_warn "/dev/fuse not found — FUSE is not available, skipping tests."
+    exit 0
+fi
+
+if ! command -v python3 &>/dev/null; then
+    log_error "python3 is required but not found."
+    exit 1
+fi
+
+if ! command -v fusermount3 &>/dev/null && ! command -v fusermount &>/dev/null; then
+    log_error "fusermount3 (or fusermount) is required but not found."
+    exit 1
+fi
+
+# ─── Setup ───────────────────────────────────────────────────────────────────
+
+WORK_DIR="$(mktemp -d /tmp/httpdirfs-integration-test.XXXXXX)"
+SERVE_DIR="${WORK_DIR}/serve"
+MOUNT_DIR="${WORK_DIR}/mnt"
+CACHE_MOUNT_DIR="${WORK_DIR}/cache_mnt"
+CACHE_DIR="${WORK_DIR}/cache"
+
+mkdir -p "${SERVE_DIR}" "${MOUNT_DIR}" "${CACHE_MOUNT_DIR}" "${CACHE_DIR}"
+
+log_info "Work directory: ${WORK_DIR}"
+log_info "httpdirfs binary: ${HTTPDIRFS_BIN}"
+
+# ─── Step 1: Generate test files ────────────────────────────────────────────
+
+log_info "Generating test files (including 1 GB large file)..."
+python3 "${SCRIPT_DIR}/generate_test_files.py" "${SERVE_DIR}" --large
+
+# ─── Step 2: Start HTTP server with Range support ───────────────────────────
+
+log_info "Starting HTTP server with Range support..."
+
+PORT_FILE="${WORK_DIR}/port"
+
+python3 "${SCRIPT_DIR}/range_http_server.py" \
+    "${SERVE_DIR}" "${HTTP_PORT}" "${PORT_FILE}" &
+HTTP_PID=$!
+
+# Wait for port file to appear
+for i in $(seq 1 10); do
+    if [[ -f "${PORT_FILE}" ]]; then
+        break
+    fi
+    sleep 0.5
+done
+
+if [[ ! -f "${PORT_FILE}" ]]; then
+    log_error "HTTP server did not write port file."
+    exit 1
+fi
+
+ACTUAL_PORT="$(cat "${PORT_FILE}")"
+
+if [[ -z "${ACTUAL_PORT}" ]]; then
+    log_error "Could not determine HTTP server port."
+    exit 1
+fi
+
+log_info "HTTP server running on port ${ACTUAL_PORT} (PID: ${HTTP_PID})"
+
+# Verify server is responding
+if ! curl -sf "http://127.0.0.1:${ACTUAL_PORT}/" >/dev/null 2>&1; then
+    log_error "HTTP server is not responding."
+    exit 1
+fi
+
+# Verify Range support works
+RANGE_TEST=$(curl -sf -r 0-3 "http://127.0.0.1:${ACTUAL_PORT}/simple.txt" \
+    -w "%{http_code}" -o /dev/null 2>/dev/null)
+if [[ "${RANGE_TEST}" == "206" ]]; then
+    log_info "HTTP server supports Range requests (206 Partial Content)."
+else
+    log_warn "Range request returned HTTP ${RANGE_TEST} (expected 206)."
+fi
+
+BASE_URL="http://127.0.0.1:${ACTUAL_PORT}/"
+
+# ─── Step 3: Mount with httpdirfs (non-cache mode) ─────────────────────────
+
+log_info "Mounting with httpdirfs (non-cache mode)..."
+
+"${HTTPDIRFS_BIN}" \
+    -f \
+    "${BASE_URL}" \
+    "${MOUNT_DIR}" &
+HTTPDIRFS_PID=$!
+
+# Wait for the mount to become available
+MOUNT_TIMEOUT=15
+for i in $(seq 1 "${MOUNT_TIMEOUT}"); do
+    if mountpoint -q "${MOUNT_DIR}" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+if ! mountpoint -q "${MOUNT_DIR}" 2>/dev/null; then
+    log_error "httpdirfs failed to mount within ${MOUNT_TIMEOUT} seconds."
+    # Try to see if the process is still alive
+    if ! kill -0 "${HTTPDIRFS_PID}" 2>/dev/null; then
+        log_error "httpdirfs process has exited."
+    fi
+    exit 1
+fi
+
+log_info "httpdirfs mounted successfully at ${MOUNT_DIR}"
+
+# ─── Step 4: Run basic tests ────────────────────────────────────────────────
+
+log_info "Running integration tests..."
+
+# Load the manifest
+MANIFEST="${SERVE_DIR}/manifest.json"
+
+# Generate a test plan from the manifest — one line per file with
+# tab-separated fields: filename, size, sha256
+TEST_PLAN="${WORK_DIR}/test_plan.tsv"
+python3 -c "
+import json
+with open('${MANIFEST}') as f:
+    m = json.load(f)
+for name in sorted(m.keys()):
+    size = m[name]['size']
+    sha = m[name]['sha256']
+    print(f'{name}\t{size}\t{sha}')
+" > "${TEST_PLAN}"
+
+# 4a. Test: Directory listing contains expected files
+log_info "Test group: Directory listing"
+
+while IFS=$'\t' read -r filename expected_size expected_sha256; do
+    target="${MOUNT_DIR}/${filename}"
+
+    if [[ -e "${target}" ]]; then
+        pass "File exists: ${filename}"
+    else
+        fail "File missing: ${filename}"
+    fi
+done < "${TEST_PLAN}"
+
+# 4b. Test: File sizes match
+log_info "Test group: File sizes"
+
+while IFS=$'\t' read -r filename expected_size expected_sha256; do
+    target="${MOUNT_DIR}/${filename}"
+    if [[ ! -e "${target}" ]]; then
+        skip "Size check (file missing): ${filename}"
+        continue
+    fi
+
+    actual_size=$(stat -c%s "${target}" 2>/dev/null || echo "-1")
+    if [[ "${actual_size}" == "${expected_size}" ]]; then
+        pass "Size correct: ${filename} (${actual_size} bytes)"
+    else
+        fail "Size mismatch: ${filename} (expected=${expected_size}, actual=${actual_size})"
+    fi
+done < "${TEST_PLAN}"
+
+# 4c. Test: Content integrity (SHA-256 checksums)
+log_info "Test group: Content integrity (SHA-256)"
+
+while IFS=$'\t' read -r filename expected_size expected_sha256; do
+    target="${MOUNT_DIR}/${filename}"
+    if [[ ! -e "${target}" ]]; then
+        skip "Checksum (file missing): ${filename}"
+        continue
+    fi
+
+    actual_sha256=$(sha256sum "${target}" 2>/dev/null | awk '{print $1}')
+    if [[ "${actual_sha256}" == "${expected_sha256}" ]]; then
+        pass "Checksum OK: ${filename}"
+    else
+        fail "Checksum mismatch: ${filename}"
+        log_error "  expected: ${expected_sha256}"
+        log_error "  actual:   ${actual_sha256}"
+    fi
+done < "${TEST_PLAN}"
+
+# 4d. Test: Read the empty file specifically
+log_info "Test group: Edge cases"
+
+EMPTY_FILE="${MOUNT_DIR}/empty_file.txt"
+if [[ -e "${EMPTY_FILE}" ]]; then
+    content=$(cat "${EMPTY_FILE}")
+    if [[ -z "${content}" ]]; then
+        pass "Empty file reads as empty"
+    else
+        fail "Empty file has unexpected content"
+    fi
+else
+    skip "Empty file not found"
+fi
+
+# 4e. Test: Tiny file (1 byte)
+TINY_FILE="${MOUNT_DIR}/tiny.txt"
+if [[ -e "${TINY_FILE}" ]]; then
+    tiny_size=$(stat -c%s "${TINY_FILE}" 2>/dev/null || echo "-1")
+    if [[ "${tiny_size}" == "1" ]]; then
+        pass "Tiny file has correct size (1 byte)"
+    else
+        fail "Tiny file size mismatch (expected=1, actual=${tiny_size})"
+    fi
+else
+    skip "Tiny file not found"
+fi
+
+# 4f. Test: Subdirectory is readable
+SUBDIR="${MOUNT_DIR}/subdir with spaces"
+if [[ -d "${SUBDIR}" ]]; then
+    pass "Subdirectory with spaces is accessible"
+    subdir_count=$(ls -1 "${SUBDIR}" 2>/dev/null | wc -l)
+    if [[ "${subdir_count}" -ge 2 ]]; then
+        pass "Subdirectory contains expected files (${subdir_count} entries)"
+    else
+        fail "Subdirectory has unexpected entry count: ${subdir_count}"
+    fi
+else
+    skip "Subdirectory with spaces not found"
+fi
+
+# 4g. Test: Read-only enforcement
+log_info "Test group: Read-only enforcement"
+
+if touch "${MOUNT_DIR}/should_not_exist.txt" 2>/dev/null; then
+    fail "Write should have been rejected (read-only filesystem)"
+    rm -f "${MOUNT_DIR}/should_not_exist.txt" 2>/dev/null || true
+else
+    pass "Write correctly rejected (read-only filesystem)"
+fi
+
+# ─── Step 5: Unmount non-cache mount ────────────────────────────────────────
+
+log_info "Unmounting non-cache mount..."
+do_unmount "${MOUNT_DIR}"
+wait "${HTTPDIRFS_PID}" 2>/dev/null || true
+log_info "Unmounted successfully."
+
+# ─── Step 6: Cache mode with multithreaded reads ────────────────────────────
+
+log_info "=== Cache mode test ==="
+
+# Get the large file's expected SHA-256 from the manifest
+LARGE_FILE_SHA256=$(python3 -c "
+import json
+with open('${MANIFEST}') as f:
+    m = json.load(f)
+entry = m.get('large_1g.bin')
+if entry:
+    print(entry['sha256'])
+else:
+    print('')
+")
+
+if [[ -z "${LARGE_FILE_SHA256}" ]]; then
+    skip "Cache test: large_1g.bin not in manifest"
+else
+    log_info "Mounting with httpdirfs (cache mode)..."
+
+    "${HTTPDIRFS_BIN}" \
+        -f \
+        --cache \
+        --cache-location "${CACHE_DIR}" \
+        --dl-seg-size 7 \
+        "${BASE_URL}" \
+        "${CACHE_MOUNT_DIR}" &
+    CACHE_HTTPDIRFS_PID=$!
+
+    # Wait for mount
+    for i in $(seq 1 "${MOUNT_TIMEOUT}"); do
+        if mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+
+    if ! mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
+        log_error "httpdirfs (cache) failed to mount within ${MOUNT_TIMEOUT}s."
+        skip "Cache mode tests (mount failed)"
+    else
+        log_info "httpdirfs (cache) mounted at ${CACHE_MOUNT_DIR}"
+
+        LARGE_FILE="${CACHE_MOUNT_DIR}/large_1g.bin"
+
+        # Test: Multithreaded read with 8 threads
+        log_info "Test group: Multithreaded cache read (8 threads)"
+        if python3 "${SCRIPT_DIR}/multithread_read.py" \
+            "${LARGE_FILE}" "${LARGE_FILE_SHA256}" 8; then
+            pass "Multithreaded read (8 threads): checksum OK"
+        else
+            fail "Multithreaded read (8 threads): checksum mismatch"
+        fi
+
+        # Test: Sequential read of the same file (should come from cache now)
+        log_info "Test group: Cached sequential re-read"
+        actual_sha256=$(sha256sum "${LARGE_FILE}" 2>/dev/null \
+            | awk '{print $1}')
+        if [[ "${actual_sha256}" == "${LARGE_FILE_SHA256}" ]]; then
+            pass "Cached re-read: checksum OK"
+        else
+            fail "Cached re-read: checksum mismatch"
+            log_error "  expected: ${LARGE_FILE_SHA256}"
+            log_error "  actual:   ${actual_sha256}"
+        fi
+
+        # Unmount cache mode
+        log_info "Unmounting cache mount..."
+        do_unmount "${CACHE_MOUNT_DIR}"
+        wait "${CACHE_HTTPDIRFS_PID}" 2>/dev/null || true
+        log_info "Cache mount unmounted."
+    fi
+fi
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════════════"
+echo -e "  Results: ${GREEN}${PASS_COUNT} passed${NC}, ${RED}${FAIL_COUNT} failed${NC}, ${YELLOW}${SKIP_COUNT} skipped${NC}"
+echo "═══════════════════════════════════════════════"
+echo ""
+
+if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+    log_error "Some tests FAILED."
+    exit 1
+fi
+
+log_info "All tests passed!"
+exit 0

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -55,7 +55,7 @@ cleanup() {
     log_info "Cleaning up..."
 
     # Unmount if still mounted
-    if mountpoint -q "${MOUNT_DIR}" 2>/dev/null; then
+    if [[ -n "${MOUNT_DIR:-}" ]] && mountpoint -q "${MOUNT_DIR}" 2>/dev/null; then
         do_unmount "${MOUNT_DIR}"
         sleep 1
     fi

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -360,7 +360,6 @@ else
         -f \
         --cache \
         --cache-location "${CACHE_DIR}" \
-        --dl-seg-size 7 \
         "${BASE_URL}" \
         "${CACHE_MOUNT_DIR}" &
     CACHE_HTTPDIRFS_PID=$!

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -38,3 +38,16 @@ test_link = executable('test_link',
     c_args: c_args
 )
 test('test_link', test_link)
+
+# Integration test (requires FUSE and Python 3)
+integration_test = find_program('integration/run_integration_test.sh',
+                                required: false)
+if integration_test.found()
+    httpdirfs_exe = meson.project_source_root() / 'builddir' / 'httpdirfs'
+    test('integration',
+         integration_test,
+         args: [httpdirfs_exe],
+         timeout: 900,
+         is_parallel: false,
+         suite: 'integration')
+endif


### PR DESCRIPTION
## Summary

Add end-to-end integration tests that verify HTTPDirFS can mount an HTTP
directory and correctly serve files, plus fix cache bugs and concurrency race conditions discovered during testing. Closes #237.

## Commits

| Commit | Description |
|---|---|
| `0480611` | `test:` add system integration test suite |
| `bacb858` | `fix:` correct off-by-one in cache segment count calculation |
| `99a9678` | `test:` run cache tests with multiple block sizes |
| `598b0b5` | `test:` recreate cache dir between block size iterations |
| `e71940f` | `fix:` resolve concurrent cache initialization race in fs_open |
| `0bcdfcf` | `ci:` install clang in build and pre-commit workflow environments |
| `11e166c` | `ci:` upload meson test logs as build artifacts |
| `84a6269` | `build:` check backtrace in libc before searching for execinfo |
| `e3b873f` | `test:` prevent unbound MOUNT_DIR error in integration test cleanup |

## What it does

### Test infrastructure (`tests/integration/`)

- **`range_http_server.py`** — Python HTTP server with Range request support
  (206 Partial Content). Python's built-in `SimpleHTTPRequestHandler` does not
  support ranges; httpdirfs requires them.
- **`generate_test_files.py`** — Generates test files with deterministic,
  randomised sizes (1 KB–10 MB, fixed seed) and writes a JSON manifest
  containing sizes and SHA-256 checksums.
- **`multithread_read.py`** — Reads a file from 8 threads concurrently, each
  covering a different byte range, then reassembles and verifies the checksum.
- **`run_integration_test.sh`** — Main test driver.

### Test coverage

**Phase 1 — non-cache mode**
- Directory listing: all generated files appear through FUSE
- File sizes match expected values from the manifest
- SHA-256 integrity for every file
- Edge cases: empty file (0 B), tiny file (1 B), subdirectory with spaces
- Read-only enforcement (writes correctly rejected)

**Phase 2 — cache mode (5 block sizes)**

The cache test loops over five `--dl-seg-size` values to exercise both
exact-division and remainder cases in the segment count calculation:

| Block size | 1 GB / blksz | Remainder? |
|---|---|---|
| 8 MB (default) | 128 segments | none (exact) |
| 16 MB | 64 segments | none (exact) |
| 1 MB | 1024 segments | none (exact) |
| 7 MB | ≈ 146.3 segments | yes |
| 3 MB | ≈ 341.3 segments | yes |

Each iteration:
1. Recreates the cache directory (`rm -rf` and `mkdir`) for a guaranteed clean state and block-size isolation.
2. Mounts httpdirfs with `--cache` and the given `--dl-seg-size`
3. Reads the 1 GB file from 8 concurrent threads and verifies the checksum
4. Re-reads the file sequentially (verifies the cache hit is also correct)
5. Unmounts

### Bug Fixes

#### 1. Cache Segment Count Calculation (`src/cache.c`)
`Cache_create` computed the segment count as:
```c
// Before: unconditionally adds 1 — wrong when content_length % blksz == 0
cf->segbc = (cf->content_length / cf->blksz) + 1;

// After: correct ceiling division
cf->segbc = (cf->content_length + cf->blksz - 1) / cf->blksz;
```
With a 1 GB file and the default 8 MB block size, the old code produced 129 segments; `Meta_read` validation expected at most 128 and rejected the cache file as corrupt.

#### 2. Thread-safe Cache Initialization Race (`src/cache.c` and `src/fuse_local.c`)
During multithreaded reads on a file that hasn't been cached yet, concurrent FUSE threads entered `fs_open` and raced to check cache existence, perform file deletions, and run cache creation. This resulted in FUSE crashes and `Cache file partially missing` errors.

- Refactored `Cache_open` to perform check-and-create/retry logic atomically under `cf_lock`.
- Simplified `fs_open` in `fuse_local.c` to directly call `Cache_open` safely.
- Resolves random Clang/GCC failures under high parallel FUSE read load.

#### 3. Resolving Spurious macOS `execinfo` Link Failures (`meson.build`)
On macOS (and other GLIBC/standard-compliant Unix platforms), the backtrace functionality is built directly into standard `libc` (system library) and does not need to link with `-lexecinfo` (which does not exist by default on macOS, causing compiler check/link failures).
- Updated `meson.build` to first check if `backtrace` is available natively using `cc.has_function('backtrace', prefix: '#include <execinfo.h>')`.
- Only falls back to checking/linking `execinfo` library when it is not present in standard libraries (e.g. Alpine/BSD/musl).

#### 4. Handling macOS CI environment with no FUSE (`tests/integration/run_integration_test.sh`)
On macOS GitHub Actions pipelines, the integration test executes inside a runner that does not have FUSE access (leading to `/dev/fuse not found`).
- Under `set -u` (nounset), triggering the early exit skips tests cleanly but runs the `EXIT` trap `cleanup()` function.
- Since `MOUNT_DIR` was not yet initialized at the time of the early exit, this previously threw `MOUNT_DIR: unbound variable` and returned a exit status 1.
- Updated [run_integration_test.sh](file:///home/fangfufu/projects/httpdirfs/tests/integration/run_integration_test.sh#L58) to use safe expansion `\${MOUNT_DIR:-}` in the cleanup phase to prevent unbound variable crashes, allowing macOS CI pipelines to skip FUSE tests cleanly with exit status 0.

### CI / Pre-commit & Docs changes

- **`.github/workflows/build.yml`** — Adds `fuse3` and `python3` deps; splits test step into "Unit tests" (`--no-suite integration`) and "Integration tests" (`--suite integration --verbose`). Specifically installs `clang` for the build-ubuntu matrix runs. Configures `actions/upload-artifact@v4` steps to upload test logs for post-mortem debugging.
- **`.github/workflows/pre-commit.yml`** — Adds `fuse3`, `python3`, and `clang` deps so the pre-commit checks and integration hooks can run in CI.
- **`.pre-commit-config.yaml`** — Adds both `integration-test` (GCC) and `integration-test-clang` (Clang) hooks to run integration tests under both compilers. Scopes existing `meson-test` hook to `--no-suite integration`.
- **`src/README.md`** — Updated developer guide to document `clang` installation requirement for pre-commit integration testing.

### Meson changes

- Registers integration test under `suite: 'integration'` with a 900 s timeout
- `is_parallel: false` to avoid concurrent FUSE mount conflicts

## Test results (local)

```
96 passed, 0 failed, 0 skipped  (30.29 s)
```