### PR TITLE
Address PR 251 review comments

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -228,8 +228,8 @@ static int Meta_read(Cache *cf)
     /* These things really should not be zero! */
     if (!cf->content_length || !cf->blksz || !cf->segbc) {
         lprintf(error,
-                "corruption: content_length: %ld, blksz: %d, segbc: %ld\n",
-                cf->content_length, cf->blksz, cf->segbc);
+                "corruption: content_length: %jd, blksz: %d, segbc: %jd\n",
+                (intmax_t)cf->content_length, cf->blksz, (intmax_t)cf->segbc);
         return EBADMSG;
     }
 
@@ -325,8 +325,8 @@ static int Meta_write(Cache *cf)
      * These things really should not be zero!
      */
     if (!cf->content_length || !cf->blksz || !cf->segbc) {
-        lprintf(error, "content_length: %ld, blksz: %d, segbc: %ld\n",
-                cf->content_length, cf->blksz, cf->segbc);
+        lprintf(error, "content_length: %jd, blksz: %d, segbc: %jd\n",
+                (intmax_t)cf->content_length, cf->blksz, (intmax_t)cf->segbc);
     }
 
     fwrite(&cf->time, sizeof(long), 1, fp);
@@ -375,7 +375,7 @@ static void Data_create(Cache *cf)
  * \brief obtain the data file size
  * \return file size on success, -1 on error
  */
-static long Data_size(const char *fn)
+static off_t Data_size(const char *fn)
 {
     char *datafn = path_append(DATA_DIR, fn);
     struct stat st;
@@ -728,7 +728,10 @@ int Cache_create(const char *path)
     cf->time = this_link->time;
     cf->content_length = this_link->content_length;
     cf->blksz = CONFIG.data_blksz;
-    cf->segbc = (cf->content_length + cf->blksz - 1) / cf->blksz;
+    cf->segbc = cf->content_length / cf->blksz;
+    if (cf->content_length % cf->blksz != 0) {
+        cf->segbc += 1;
+    }
     cf->seg = CALLOC(cf->segbc, sizeof(Seg));
 
     Meta_create(cf);
@@ -835,17 +838,21 @@ Cache *Cache_open(const char *fn)
         } else if (Meta_read(cf)) {
             lprintf(error, "metadata error: %s.\n", actual_fn);
             ok = 0;
-        } else if (cf->content_length > Data_size(actual_fn)) {
-            lprintf(error, "metadata inconsistency %s, \
-cf->content_length: %ld, Data_size(fn): %ld.\n",
-                    actual_fn, cf->content_length, Data_size(actual_fn));
-            ok = 0;
-        } else if (cf->time != cf->link->time) {
-            lprintf(warning, "outdated cache file: %s.\n", actual_fn);
-            ok = 0;
-        } else if (Data_open(cf)) {
-            lprintf(error, "cannot open data file %s.\n", actual_fn);
-            ok = 0;
+        } else {
+            off_t d_size = Data_size(actual_fn);
+            if (cf->content_length > d_size) {
+                lprintf(error, "metadata inconsistency %s, \
+cf->content_length: %jd, Data_size(fn): %jd.\n",
+                        actual_fn, (intmax_t)cf->content_length,
+                        (intmax_t)d_size);
+                ok = 0;
+            } else if (cf->time != cf->link->time) {
+                lprintf(warning, "outdated cache file: %s.\n", actual_fn);
+                ok = 0;
+            } else if (Data_open(cf)) {
+                lprintf(error, "cannot open data file %s.\n", actual_fn);
+                ok = 0;
+            }
         }
 
         if (ok) {
@@ -860,7 +867,15 @@ cf->content_length: %ld, Data_size(fn): %ld.\n",
             return cf;
         }
 
-        // Clean up memory and delete files before retry
+        // Clean up opened resources before retry
+        if (cf->mfp) {
+            fclose(cf->mfp);
+            cf->mfp = NULL;
+        }
+        if (cf->dfp) {
+            fclose(cf->dfp);
+            cf->dfp = NULL;
+        }
         Cache_free(cf);
         Cache_delete(fn);
     }

--- a/src/cache.c
+++ b/src/cache.c
@@ -840,9 +840,13 @@ Cache *Cache_open(const char *fn)
             ok = 0;
         } else {
             off_t d_size = Data_size(actual_fn);
-            if (cf->content_length > d_size) {
-                lprintf(error, "metadata inconsistency %s, \
-cf->content_length: %jd, Data_size(fn): %jd.\n",
+            if (d_size < 0) {
+                lprintf(error, "cannot stat data file %s.\n", actual_fn);
+                ok = 0;
+            } else if (cf->content_length > d_size) {
+                lprintf(error,
+                        "metadata inconsistency %s, "
+                        "cf->content_length: %jd, Data_size(fn): %jd.\n",
                         actual_fn, (intmax_t)cf->content_length,
                         (intmax_t)d_size);
                 ok = 0;

--- a/tests/integration/multithread_read.py
+++ b/tests/integration/multithread_read.py
@@ -81,8 +81,10 @@ def main():
             sys.exit(1)
 
     # Reassemble and verify
-    full_data = b"".join(results)
-    actual_sha256 = hashlib.sha256(full_data).hexdigest()
+    hasher = hashlib.sha256()
+    for chunk in results:
+        hasher.update(chunk)
+    actual_sha256 = hasher.hexdigest()
 
     if actual_sha256 == expected_sha256:
         print(f"  SHA-256 OK: {actual_sha256}")


### PR DESCRIPTION
This pull request addresses the key remaining review comments for PR #251 in `httpdirfs`, focusing on cache reliability, resource management, and test performance.

### Summary of Changes

1. **C Cache System Hardening (`src/cache.c`)**:
   - **Safe Ceiling Division**: Replaced `(cf->content_length + cf->blksz - 1) / cf->blksz` inside `Cache_create()` with a remainder-based ceiling division that is free from signed-integer overflow.
   - **32-Bit System Portability**: Changed `Data_size()` return type from `long` to `off_t` to avoid truncation/sign-extension bugs when caching files larger than 2 GB on 32-bit platforms.
   - **C99 formatting**: Migrated all occurrences of `off_t`/`segbc` prints in `src/cache.c` (at lines 231, 328, and 843) from `%ld` to `%jd` using standard C99/POSIX `(intmax_t)` casting.
   - **File Descriptor Leak Fix**: Updated the retry/failure cleanup path in `Cache_open()` to close any open file handles (`cf->mfp` and `cf->dfp`) before freeing memory.

2. **Python Test Infrastructure Optimization (`tests/integration/multithread_read.py`)**:
   - **Incremental SHA-256 Hashing**: Changed the multithreaded test verifier to compute the SHA-256 hash incrementally chunk-by-chunk rather than joining all thread buffers in memory, dramatically reducing memory overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata and error logging for clearer, accurate diagnostics.
  * Enhanced cleanup in retry paths to close and release file handles, reducing resource leaks.
  * Adjusted size-handling and comparison logic to ensure consistent checks between stored metadata and actual data.

* **Tests**
  * Optimized SHA-256 verification to compute the hash incrementally for more efficient multi-threaded reads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->