### PR TITLE
feat: add FUSE releasedir handling and LinkTable memory eviction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ doxygen
 
 # Build directories
 /builddir/
+/.pre-commit-builds/
 
 # Meson subprojects (ignore cloned sources but keep wrap files tracked)
 /subprojects/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,18 +32,37 @@ repos:
         files: \.(c|h)$
     -   id: meson-test
         name: Meson Test
-        entry: meson test -C builddir
+        entry: >-
+          bash -c 'if [ ! -d .pre-commit-builds/release ]; then
+          meson setup .pre-commit-builds/release; fi &&
+          meson test -C .pre-commit-builds/release'
         language: system
         pass_filenames: false
         files: \.(c|h)$
     -   id: all-tests
         name: All Tests
         entry: >-
-          meson test -C builddir
+          bash -c 'if [ ! -d .pre-commit-builds/release ]; then
+          meson setup .pre-commit-builds/release; fi &&
+          meson test -C .pre-commit-builds/release
           --suite unit_test
           --suite integration_short
           --suite integration_long
-          --verbose
+          --verbose'
+        language: system
+        pass_filenames: false
+        files: \.(c|h|py|sh)$
+        stages: [manual]
+    -   id: all-tests-debug
+        name: All Tests (Debug)
+        entry: >-
+          bash -c 'if [ ! -d .pre-commit-builds/debug ]; then
+          meson setup .pre-commit-builds/debug --buildtype=debug; fi &&
+          meson test -C .pre-commit-builds/debug
+          --suite unit_test
+          --suite integration_short
+          --suite integration_long
+          --verbose'
         language: system
         pass_filenames: false
         files: \.(c|h|py|sh)$
@@ -51,9 +70,23 @@ repos:
     -   id: all-tests-clang
         name: All Tests (Clang)
         entry: >-
-          bash -c 'if [ ! -d builddir_clang ]; then
-          CC=clang meson setup builddir_clang; fi &&
-          meson test -C builddir_clang
+          bash -c 'if [ ! -d .pre-commit-builds/clang-release ]; then
+          CC=clang meson setup .pre-commit-builds/clang-release; fi &&
+          meson test -C .pre-commit-builds/clang-release
+          --suite unit_test
+          --suite integration_short
+          --suite integration_long
+          --verbose'
+        language: system
+        pass_filenames: false
+        files: \.(c|h|py|sh)$
+        stages: [manual]
+    -   id: all-tests-clang-debug
+        name: All Tests (Clang Debug)
+        entry: >-
+          bash -c 'if [ ! -d .pre-commit-builds/clang-debug ]; then
+          CC=clang meson setup .pre-commit-builds/clang-debug --buildtype=debug; fi &&
+          meson test -C .pre-commit-builds/clang-debug
           --suite unit_test
           --suite integration_short
           --suite integration_long

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,9 +33,9 @@ repos:
     -   id: meson-test
         name: Meson Test
         entry: >-
-          bash -c 'if [ ! -d .pre-commit-builds/gcc-release ]; then
-          CC=gcc meson setup .pre-commit-builds/gcc-release; fi &&
-          meson test -C .pre-commit-builds/gcc-release'
+          bash -c 'if [ ! -d .pre-commit-builds/default-release ]; then
+          meson setup .pre-commit-builds/default-release; fi &&
+          meson test -C .pre-commit-builds/default-release'
         language: system
         pass_filenames: false
         files: \.(c|h)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,23 +32,32 @@ repos:
         files: \.(c|h)$
     -   id: meson-test
         name: Meson Test
-        entry: meson test -C builddir --no-suite integration
+        entry: meson test -C builddir
         language: system
         pass_filenames: false
         files: \.(c|h)$
-    -   id: integration-test
-        name: Integration Test
-        entry: meson test -C builddir --suite integration --verbose
+    -   id: all-tests
+        name: All Tests
+        entry: >-
+          meson test -C builddir
+          --suite unit_test
+          --suite integration_short
+          --suite integration_long
+          --verbose
         language: system
         pass_filenames: false
         files: \.(c|h|py|sh)$
         stages: [manual]
-    -   id: integration-test-clang
-        name: Integration Test (Clang)
+    -   id: all-tests-clang
+        name: All Tests (Clang)
         entry: >-
           bash -c 'if [ ! -d builddir_clang ]; then
           CC=clang meson setup builddir_clang; fi &&
-          meson test -C builddir_clang --suite integration --verbose'
+          meson test -C builddir_clang
+          --suite unit_test
+          --suite integration_short
+          --suite integration_long
+          --verbose'
         language: system
         pass_filenames: false
         files: \.(c|h|py|sh)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,15 +30,6 @@ repos:
         entry: clang-format -i
         language: system
         files: \.(c|h)$
-    -   id: meson-test
-        name: Meson Test
-        entry: >-
-          bash -c 'if [ ! -d .pre-commit-builds/default-release ]; then
-          meson setup .pre-commit-builds/default-release; fi &&
-          meson test -C .pre-commit-builds/default-release'
-        language: system
-        pass_filenames: false
-        files: \.(c|h)$
     -   id: meson-test-debug
         name: Meson Test (Debug)
         entry: >-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,15 @@ repos:
         language: system
         pass_filenames: false
         files: \.(c|h)$
+    -   id: meson-test-debug
+        name: Meson Test (Debug)
+        entry: >-
+          bash -c 'if [ ! -d .pre-commit-builds/default-debug ]; then
+          meson setup .pre-commit-builds/default-debug --buildtype=debug; fi &&
+          meson test -C .pre-commit-builds/default-debug'
+        language: system
+        pass_filenames: false
+        files: \.(c|h)$
     -   id: all-tests-gcc
         name: All Tests (GCC)
         entry: >-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,18 +33,18 @@ repos:
     -   id: meson-test
         name: Meson Test
         entry: >-
-          bash -c 'if [ ! -d .pre-commit-builds/release ]; then
-          meson setup .pre-commit-builds/release; fi &&
-          meson test -C .pre-commit-builds/release'
+          bash -c 'if [ ! -d .pre-commit-builds/gcc-release ]; then
+          CC=gcc meson setup .pre-commit-builds/gcc-release; fi &&
+          meson test -C .pre-commit-builds/gcc-release'
         language: system
         pass_filenames: false
         files: \.(c|h)$
-    -   id: all-tests
-        name: All Tests
+    -   id: all-tests-gcc
+        name: All Tests (GCC)
         entry: >-
-          bash -c 'if [ ! -d .pre-commit-builds/release ]; then
-          meson setup .pre-commit-builds/release; fi &&
-          meson test -C .pre-commit-builds/release
+          bash -c 'if [ ! -d .pre-commit-builds/gcc-release ]; then
+          CC=gcc meson setup .pre-commit-builds/gcc-release; fi &&
+          meson test -C .pre-commit-builds/gcc-release
           --suite unit_test
           --suite integration_short
           --suite integration_long
@@ -53,12 +53,12 @@ repos:
         pass_filenames: false
         files: \.(c|h|py|sh)$
         stages: [manual]
-    -   id: all-tests-debug
-        name: All Tests (Debug)
+    -   id: all-tests-gcc-debug
+        name: All Tests (GCC Debug)
         entry: >-
-          bash -c 'if [ ! -d .pre-commit-builds/debug ]; then
-          meson setup .pre-commit-builds/debug --buildtype=debug; fi &&
-          meson test -C .pre-commit-builds/debug
+          bash -c 'if [ ! -d .pre-commit-builds/gcc-debug ]; then
+          CC=gcc meson setup .pre-commit-builds/gcc-debug --buildtype=debug; fi &&
+          meson test -C .pre-commit-builds/gcc-debug
           --suite unit_test
           --suite integration_short
           --suite integration_long

--- a/src/README.md
+++ b/src/README.md
@@ -133,10 +133,16 @@ pre-commit run --all-files
 > # Run all tests using the default compiler (GCC)
 > pre-commit run all-tests --hook-stage manual --all-files
 >
+> # Run all tests (GCC Debug)
+> pre-commit run all-tests-debug --hook-stage manual --all-files
+>
 > # Run all tests using Clang
 > pre-commit run all-tests-clang --hook-stage manual --all-files
+>
+> # Run all tests (Clang Debug)
+> pre-commit run all-tests-clang-debug --hook-stage manual --all-files
 > ```
-> Note that `all-tests-clang` requires `clang` to be installed (e.g.,
+> Note that the Clang-based hooks require `clang` to be installed (e.g.,
 > `sudo apt install clang` on Debian/Ubuntu systems).
 
 ### Running Tests
@@ -180,15 +186,21 @@ configurations:
 ##### 3. Required Pre-Push Validation
 
 Before pushing changes, developers are **required** to manually run the full
-suite using the manual pre-commit hooks to catch potential cache regressions
-locally:
+suite using the manual pre-commit hooks to catch potential cache regressions and
+memory leaks locally:
 
 ```bash
 # Run GCC-based compilation and all tests (unit_test, integration_short, integration_long)
 pre-commit run all-tests --hook-stage manual --all-files
 
+# Run GCC-based compilation in Debug mode (with leak detection enabled) and all tests
+pre-commit run all-tests-debug --hook-stage manual --all-files
+
 # Run Clang-based compilation and all tests
 pre-commit run all-tests-clang --hook-stage manual --all-files
+
+# Run Clang-based compilation in Debug mode (with leak detection enabled) and all tests
+pre-commit run all-tests-clang-debug --hook-stage manual --all-files
 ```
 
 ---

--- a/src/README.md
+++ b/src/README.md
@@ -120,34 +120,80 @@ pre-commit run --all-files
 > ```
 
 <!-- prettier-ignore -->
-> [!NOTE]
-> The integration test hooks (`integration-test` and `integration-test-clang`)
-> are configured to run only in the CI (via the `manual` stage) to speed up local
-> pre-commit checks. If you wish to run them locally, you can run them manually
-> using:
+> [!IMPORTANT]
+> **Manual Hooks Requirement Before Pushing:**
+> While basic unit tests and short integration tests run automatically on every
+> commit, the slow/intensive integration tests (`integration_long`) are placed
+> in the `manual` stage to keep the default local commit feedback loop fast.
+>
+> **You are required to manually run the full test suite hooks before pushing
+> your changes:**
 >
 > ```bash
-> pre-commit run --all-files --hook-stage manual
-> ```
+> # Run all tests using the default compiler (GCC)
+> pre-commit run all-tests --hook-stage manual --all-files
 >
-> Note that the `integration-test-clang` hook requires `clang` to be installed on the
-> system (e.g., `sudo apt install clang` on Debian/Ubuntu systems).
+> # Run all tests using Clang
+> pre-commit run all-tests-clang --hook-stage manual --all-files
+> ```
+> Note that `all-tests-clang` requires `clang` to be installed (e.g.,
+> `sudo apt install clang` on Debian/Ubuntu systems).
 
 ### Running Tests
 
-We support both unit testing and end-to-end system integration testing. The
-tests are configured and managed via Meson.
+We support three test suites configured and managed via Meson:
 
-<!-- prettier-ignore -->
-> [!NOTE]
-> By default, `meson test` only runs the unit tests. The system integration tests
-> are excluded from the default test setup to speed up local test execution and
-> prevent failures in environments without FUSE access.
+1. **`unit_test`**: Runs all C-level unit tests (`test_util`, `test_cache`,
+   `test_config`, `test_link`).
+2. **`integration_short`**: Runs fast integration tests (excludes the large 1 GB
+   file) verifying core mounting, directory traversal, read-only structures, and
+   integrity. Completes in **~3 seconds**.
+3. **`integration_long`**: Runs resource-intensive cache integration tests
+   involving concurrent multithreaded reads of a 1 GB file. Completes in **~25
+   seconds**.
 
-#### Unit Tests
+#### Test Execution Environments
 
-We use the [Unity Test Project](https://github.com/ThrowTheSwitch/Unity)
-framework for unit testing.
+##### 1. Default/Local Pre-Commit Behavior
+
+To speed up local development feedback, only the fast tests are executed by
+default.
+
+- **Command**: Running a plain `meson test -C builddir` or triggering the
+  default local `git commit` hook.
+- **Behavior**: Runs the `unit_test` and `integration_short` suites. The
+  `integration_long` suite is explicitly excluded by default via the default
+  test setup in `tests/meson.build`.
+
+##### 2. CI Pipeline Behavior
+
+The GitHub Actions workflow (`build.yml`) validates the entire test suite on
+every pull request and push to the master branch using GCC and Clang
+configurations:
+
+- **Unit tests step**: `meson test -C builddir --no-suite integration` (runs
+  only the `unit_test` suite)
+- **Integration tests step**:
+  `meson test -C builddir --suite integration --verbose` (runs both
+  `integration_short` and `integration_long` suites)
+
+##### 3. Required Pre-Push Validation
+
+Before pushing changes, developers are **required** to manually run the full
+suite using the manual pre-commit hooks to catch potential cache regressions
+locally:
+
+```bash
+# Run GCC-based compilation and all tests (unit_test, integration_short, integration_long)
+pre-commit run all-tests --hook-stage manual --all-files
+
+# Run Clang-based compilation and all tests
+pre-commit run all-tests-clang --hook-stage manual --all-files
+```
+
+---
+
+#### Running Specific Suites Manually via Meson
 
 ##### Setup
 
@@ -157,32 +203,34 @@ Before running tests, ensure that the build directory is configured:
 meson setup builddir
 ```
 
-##### Run All Unit Tests
+##### Run Unit Tests Individually
 
-To build and run all unit tests, execute:
+If you want to run only the unit tests:
 
 ```bash
-meson test -C builddir
+meson test -C builddir --suite unit_test
 ```
 
-This will run only the unit test suite. Meson will automatically compile any
-modified source and test files before running.
-
-##### Run a Specific Test
-
-If you only want to execute a specific test suite (e.g., `test_util`), you can
-specify its name:
+You can also execute specific unit tests by target name:
 
 ```bash
 meson test -C builddir test_util
+meson test -C builddir test_cache
+meson test -C builddir test_config
+meson test -C builddir test_link
 ```
 
-The available test suites are:
+##### Run Short Integration Tests Individually
 
-- `test_util`
-- `test_cache`
-- `test_config`
-- `test_link`
+```bash
+meson test -C builddir --suite integration_short
+```
+
+##### Run Long Integration Tests Individually
+
+```bash
+meson test -C builddir --suite integration_long
+```
 
 ##### Verbose Output and Debugging
 
@@ -198,13 +246,7 @@ results, use the following options:
   meson test -C builddir -v
   ```
 
-#### Integration Tests
-
-The project includes an end-to-end system integration test suite that verifies
-that `httpdirfs` can mount an HTTP directory, traverse subdirectories, verify
-file integrity (via SHA-256), and perform concurrent cached reads.
-
-##### Prerequisites
+#### Integration Tests Runner Prerequisites
 
 The integration tests require the following system dependencies:
 
@@ -212,21 +254,17 @@ The integration tests require the following system dependencies:
 - `fusermount3` (or `fusermount`)
 - **Python 3**
 
-##### Run Integration Tests via Meson
-
-To run the integration tests using Meson, execute:
-
-```bash
-meson test -C builddir --suite integration
-```
-
 ##### Run Integration Tests Manually
 
 Alternatively, you can run the test runner script directly by providing the path
-to the compiled `httpdirfs` binary:
+to the compiled `httpdirfs` binary and the desired mode flag:
 
 ```bash
-./tests/integration/run_integration_test.sh builddir/httpdirfs
+# Run short integration tests
+./tests/integration/run_integration_test.sh --short builddir/httpdirfs
+
+# Run long integration tests
+./tests/integration/run_integration_test.sh --long builddir/httpdirfs
 ```
 
 ---

--- a/src/README.md
+++ b/src/README.md
@@ -130,11 +130,11 @@ pre-commit run --all-files
 > your changes:**
 >
 > ```bash
-> # Run all tests using the default compiler (GCC)
-> pre-commit run all-tests --hook-stage manual --all-files
+> # Run all tests using GCC
+> pre-commit run all-tests-gcc --hook-stage manual --all-files
 >
 > # Run all tests (GCC Debug)
-> pre-commit run all-tests-debug --hook-stage manual --all-files
+> pre-commit run all-tests-gcc-debug --hook-stage manual --all-files
 >
 > # Run all tests using Clang
 > pre-commit run all-tests-clang --hook-stage manual --all-files
@@ -191,10 +191,10 @@ memory leaks locally:
 
 ```bash
 # Run GCC-based compilation and all tests (unit_test, integration_short, integration_long)
-pre-commit run all-tests --hook-stage manual --all-files
+pre-commit run all-tests-gcc --hook-stage manual --all-files
 
 # Run GCC-based compilation in Debug mode (with leak detection enabled) and all tests
-pre-commit run all-tests-debug --hook-stage manual --all-files
+pre-commit run all-tests-gcc-debug --hook-stage manual --all-files
 
 # Run Clang-based compilation and all tests
 pre-commit run all-tests-clang --hook-stage manual --all-files

--- a/src/cache.c
+++ b/src/cache.c
@@ -632,12 +632,12 @@ static int Cache_exist(const char *fn)
  */
 void Cache_delete(const char *fn)
 {
-    Link *link = NULL;
+    Link *link = path_to_Link(fn);
     if (CONFIG.mode == SONIC) {
-        link = path_to_Link(fn);
+        if (!link) {
+            return;
+        }
         fn = link->sonic.id;
-    } else {
-        link = path_to_Link(fn);
     }
 
     char *metafn = path_append(META_DIR, fn);

--- a/src/cache.c
+++ b/src/cache.c
@@ -622,9 +622,12 @@ static int Cache_exist(const char *fn)
  */
 void Cache_delete(const char *fn)
 {
+    Link *link = NULL;
     if (CONFIG.mode == SONIC) {
-        Link *link = path_to_Link(fn);
+        link = path_to_Link(fn);
         fn = link->sonic.id;
+    } else {
+        link = path_to_Link(fn);
     }
 
     char *metafn = path_append(META_DIR, fn);
@@ -638,6 +641,9 @@ void Cache_delete(const char *fn)
     }
     FREE(metafn);
     FREE(datafn);
+    if (link) {
+        LinkTable_unref(link->parent_table);
+    }
 }
 
 /**
@@ -766,6 +772,8 @@ int Cache_create(const char *path)
         curl_free(fn);
     }
 
+    LinkTable_unref(this_link->parent_table);
+
     return res;
 }
 
@@ -791,6 +799,7 @@ Cache *Cache_open(const char *fn)
         lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
                 (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
+        LinkTable_unref(link->parent_table);
         return link->cache_ptr;
     }
 
@@ -809,6 +818,7 @@ Cache *Cache_open(const char *fn)
                 lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
                         (unsigned long)pthread_self());
                 PTHREAD_MUTEX_UNLOCK(&cf_lock);
+                LinkTable_unref(link->parent_table);
                 return NULL;
             }
         }
@@ -887,6 +897,7 @@ Cache *Cache_open(const char *fn)
     lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
             (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf_lock);
+    LinkTable_unref(link->parent_table);
     return NULL;
 }
 
@@ -928,12 +939,14 @@ void Cache_close(Cache *cf)
         lprintf(error, "cannot close data file %s.\n", strerror(errno));
     }
 
-    cf->link->cache_ptr = NULL;
+    Link *link = cf->link;
+    link->cache_ptr = NULL;
 
     lprintf(cache_lock_debug,
             "thread %lx: unlocking cf_lock, cache closed: %s\n",
             (unsigned long)pthread_self(), cf->path);
     Cache_free(cf);
+    LinkTable_unref(link->parent_table);
     PTHREAD_MUTEX_UNLOCK(&cf_lock);
 }
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -724,6 +724,9 @@ static void Meta_create(Cache *cf)
 int Cache_create(const char *path)
 {
     Link *this_link = path_to_Link(path);
+    if (!this_link) {
+        return 1;
+    }
 
     char *fn;
 
@@ -782,7 +785,9 @@ int Cache_create(const char *path)
         curl_free(fn);
     }
 
-    LinkTable_unref(this_link->parent_table);
+    if (this_link) {
+        LinkTable_unref(this_link->parent_table);
+    }
 
     return res;
 }

--- a/src/cache.c
+++ b/src/cache.c
@@ -172,6 +172,16 @@ void CacheSystem_init(const char *path, int url_supplied)
     CACHE_SYSTEM_INIT = 1;
 }
 
+void CacheSystem_cleanup(void)
+{
+    if (CACHE_SYSTEM_INIT) {
+        FREE(META_DIR);
+        FREE(DATA_DIR);
+        PTHREAD_MUTEX_DESTROY(&cf_lock);
+        CACHE_SYSTEM_INIT = 0;
+    }
+}
+
 static int ntfw_cb(const char *fpath, const struct stat *sb, int typeflag,
                    struct FTW *ftwbuf)
 {

--- a/src/cache.h
+++ b/src/cache.h
@@ -86,6 +86,11 @@ extern char *META_DIR;
 void CacheSystem_init(const char *path, int url_supplied);
 
 /**
+ * \brief clean up the cache system, freeing meta and data directories
+ */
+void CacheSystem_cleanup(void);
+
+/**
  * \brief clear the content of the cache directory
  */
 void CacheSystem_clear(void);

--- a/src/config.c
+++ b/src/config.c
@@ -68,3 +68,23 @@ void Config_init(void)
     CONFIG.sonic_insecure = 0;
     atexit(mem_cleanup);
 }
+
+void Config_cleanup(void)
+{
+    FREE(CONFIG.http_username);
+    FREE(CONFIG.http_password);
+    FREE(CONFIG.proxy);
+    FREE(CONFIG.proxy_username);
+    FREE(CONFIG.proxy_password);
+    FREE(CONFIG.proxy_cafile);
+    FREE(CONFIG.proxy_capath);
+    if (CONFIG.user_agent
+        && strcmp(CONFIG.user_agent, DEFAULT_USER_AGENT) != 0) {
+        FREE(CONFIG.user_agent);
+    }
+    FREE(CONFIG.cafile);
+    FREE(CONFIG.capath);
+    FREE(CONFIG.cache_dir);
+    FREE(CONFIG.sonic_username);
+    FREE(CONFIG.sonic_password);
+}

--- a/src/config.h
+++ b/src/config.h
@@ -112,4 +112,9 @@ typedef struct {
  */
 extern ConfigStruct CONFIG;
 
+/**
+ * \brief Free any heap-allocated configuration options
+ */
+void Config_cleanup(void);
+
 #endif

--- a/src/fuse_local.c
+++ b/src/fuse_local.c
@@ -73,8 +73,10 @@ static int fs_getattr(const char *path, struct stat *stbuf,
             stbuf->st_blocks = (link->content_length) / 512;
             break;
         default:
+            LinkTable_unref(link->parent_table);
             return -ENOENT;
         }
+        LinkTable_unref(link->parent_table);
     }
     stbuf->st_uid = getuid();
     stbuf->st_gid = getgid();
@@ -105,6 +107,7 @@ static int fs_open(const char *path, struct fuse_file_info *fi)
     }
     lprintf(debug, "%s found.\n", path);
     if ((fi->flags & O_RDWR) != O_RDONLY) {
+        LinkTable_unref(link->parent_table);
         return -EROFS;
     }
     if (CACHE_SYSTEM_INIT) {
@@ -115,33 +118,47 @@ static int fs_open(const char *path, struct fuse_file_info *fi)
          */
         if (!fi->fh) {
             lprintf(fatal, "Cache file creation failure for %s.\n", path);
+            LinkTable_unref(link->parent_table);
             return -ENOENT;
         }
+    }
+    LinkTable_unref(link->parent_table);
+    return 0;
+}
+
+static int fs_opendir(const char *path, struct fuse_file_info *fi)
+{
+    LinkTable *linktbl = path_to_LinkTable(path);
+    if (!linktbl) {
+        return -ENOENT;
+    }
+    fi->fh = (uint64_t)linktbl;
+    return 0;
+}
+
+static int fs_releasedir(const char *path, struct fuse_file_info *fi)
+{
+    LinkTable *linktbl = (LinkTable *)fi->fh;
+    if (linktbl) {
+        if (strcmp(path, "/") != 0) {
+            LinkTable_mark_orphaned(linktbl);
+        }
+        LinkTable_unref(linktbl);
     }
     return 0;
 }
 
 /**
  * \brief read the directory indicated by the path
- * \note
- *  - releasedir() is not implemented, because I don't see why anybody want
- * the LinkTables to be evicted from the memory during the runtime of this
- * program. If you want to evict LinkTables, just unmount the filesystem.
- *  - There is no real need to associate the LinkTable with the fi of each
- * directory data structure. If you want a deep level directory, you need to
- * generate the LinkTables for previous level directories. We might
- * as well maintain our own tree structure.
  */
 static int fs_readdir(const char *path, void *buf, fuse_fill_dir_t dir_add,
                       off_t offset, struct fuse_file_info *fi,
                       enum fuse_readdir_flags fr_flags)
 {
+    (void)path;
     (void)offset;
-    (void)fi;
     (void)fr_flags;
-    LinkTable *linktbl;
-
-    linktbl = path_to_LinkTable(path);
+    LinkTable *linktbl = (LinkTable *)fi->fh;
 
     if (!linktbl) {
         lprintf(debug, "linktbl empty!\n");
@@ -166,7 +183,9 @@ static int fs_readdir(const char *path, void *buf, fuse_fill_dir_t dir_add,
 }
 
 static struct fuse_operations fs_oper = {.getattr = fs_getattr,
+                                         .opendir = fs_opendir,
                                          .readdir = fs_readdir,
+                                         .releasedir = fs_releasedir,
                                          .open = fs_open,
                                          .read = fs_read,
                                          .init = fs_init,

--- a/src/fuse_local.c
+++ b/src/fuse_local.c
@@ -118,8 +118,6 @@ static int fs_open(const char *path, struct fuse_file_info *fi)
          */
         if (!fi->fh) {
             lprintf(fatal, "Cache file creation failure for %s.\n", path);
-            LinkTable_unref(link->parent_table);
-            return -ENOENT;
         }
     }
     LinkTable_unref(link->parent_table);

--- a/src/link.c
+++ b/src/link.c
@@ -929,6 +929,10 @@ LinkTable *path_to_LinkTable(const char *path)
 
         PTHREAD_MUTEX_LOCK(&link_lock);
         next_table = link->next_table;
+        if (next_table) {
+            next_table->refcount++;
+            next_table->orphaned = 0;
+        }
         PTHREAD_MUTEX_UNLOCK(&link_lock);
     }
 
@@ -949,6 +953,13 @@ LinkTable *path_to_LinkTable(const char *path)
             lprintf(fatal, "Invalid CONFIG.mode: %d\n", CONFIG.mode);
         }
 
+        if (!new_table) {
+            if (link) {
+                LinkTable_unref(link->parent_table);
+            }
+            return NULL;
+        }
+
         PTHREAD_MUTEX_LOCK(&link_lock);
         if (!link->next_table) {
             link->next_table = new_table;
@@ -957,12 +968,16 @@ LinkTable *path_to_LinkTable(const char *path)
             if (new_table->parent_tbl) {
                 new_table->parent_tbl->refcount++;
             }
+            new_table->refcount++;
+            new_table->orphaned = 0;
             next_table = new_table;
         } else {
             PTHREAD_MUTEX_UNLOCK(&link_lock);
             LinkTable_free(new_table);
             PTHREAD_MUTEX_LOCK(&link_lock);
             next_table = link->next_table;
+            next_table->refcount++;
+            next_table->orphaned = 0;
         }
         PTHREAD_MUTEX_UNLOCK(&link_lock);
 
@@ -970,8 +985,6 @@ LinkTable *path_to_LinkTable(const char *path)
             LinkTable_uninitialised_fill(next_table);
         }
     }
-
-    LinkTable_ref(next_table);
 
     if (link) {
         LinkTable_unref(link->parent_table);
@@ -1039,6 +1052,7 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
                  */
                 LinkTable *next_table = linktbl->links[i]->next_table;
                 if (!next_table) {
+                    linktbl->refcount++;
                     PTHREAD_MUTEX_UNLOCK(&link_lock);
                     LinkTable *new_table = NULL;
                     if (CONFIG.mode == NORMAL) {
@@ -1055,6 +1069,26 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
                     } else {
                         lprintf(fatal, "Invalid CONFIG.mode\n");
                     }
+
+                    if (!new_table) {
+                        PTHREAD_MUTEX_LOCK(&link_lock);
+                        linktbl->refcount--;
+                        if (linktbl->refcount == 0 && linktbl->orphaned) {
+                            LinkTable *parent = linktbl->parent_tbl;
+                            Link *parent_link = linktbl->parent_link;
+                            if (parent_link) {
+                                parent_link->next_table = NULL;
+                            }
+                            PTHREAD_MUTEX_UNLOCK(&link_lock);
+                            LinkTable_free(linktbl);
+                            if (parent) {
+                                LinkTable_unref(parent);
+                            }
+                            PTHREAD_MUTEX_LOCK(&link_lock);
+                        }
+                        return NULL;
+                    }
+
                     PTHREAD_MUTEX_LOCK(&link_lock);
                     if (!linktbl->links[i]->next_table) {
                         linktbl->links[i]->next_table = new_table;
@@ -1068,6 +1102,7 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
                         PTHREAD_MUTEX_LOCK(&link_lock);
                         next_table = linktbl->links[i]->next_table;
                     }
+                    linktbl->refcount--;
                 }
                 return path_to_Link_recursive(next_path, next_table);
             }
@@ -1091,7 +1126,6 @@ Link *path_to_Link(const char *path)
 
     if (link && link->parent_table) {
         link->parent_table->refcount++;
-        link->parent_table->orphaned = 0;
     }
 
     lprintf(link_lock_debug, "thread %lx: unlocking link_lock;\n",

--- a/src/link.c
+++ b/src/link.c
@@ -972,9 +972,7 @@ LinkTable *path_to_LinkTable(const char *path)
             new_table->orphaned = 0;
             next_table = new_table;
         } else {
-            PTHREAD_MUTEX_UNLOCK(&link_lock);
             LinkTable_free(new_table);
-            PTHREAD_MUTEX_LOCK(&link_lock);
             next_table = link->next_table;
             next_table->refcount++;
             next_table->orphaned = 0;
@@ -1097,9 +1095,7 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
                         linktbl->refcount++;
                         next_table = new_table;
                     } else {
-                        PTHREAD_MUTEX_UNLOCK(&link_lock);
                         LinkTable_free(new_table);
-                        PTHREAD_MUTEX_LOCK(&link_lock);
                         next_table = linktbl->links[i]->next_table;
                     }
                     linktbl->refcount--;

--- a/src/link.c
+++ b/src/link.c
@@ -367,6 +367,7 @@ void LinkTable_add(LinkTable *linktbl, Link *link)
     linktbl->links = (Link **)REALLOC(
         (void *)linktbl->links, ((size_t)linktbl->size + 1) * sizeof(Link *));
     linktbl->links[linktbl->size] = link;
+    link->parent_table = linktbl;
     linktbl->size++;
 }
 
@@ -570,6 +571,52 @@ static void LinkTable_fill(LinkTable *linktbl)
         curl_free(unescaped_linkname);
     }
     LinkTable_uninitialised_fill(linktbl);
+}
+
+void LinkTable_ref(LinkTable *tbl)
+{
+    if (!tbl) {
+        return;
+    }
+    PTHREAD_MUTEX_LOCK(&link_lock);
+    tbl->refcount++;
+    tbl->orphaned = 0;
+    PTHREAD_MUTEX_UNLOCK(&link_lock);
+}
+
+void LinkTable_mark_orphaned(LinkTable *tbl)
+{
+    if (!tbl) {
+        return;
+    }
+    PTHREAD_MUTEX_LOCK(&link_lock);
+    tbl->orphaned = 1;
+    PTHREAD_MUTEX_UNLOCK(&link_lock);
+}
+
+void LinkTable_unref(LinkTable *tbl)
+{
+    if (!tbl) {
+        return;
+    }
+    PTHREAD_MUTEX_LOCK(&link_lock);
+    tbl->refcount--;
+    if (tbl->refcount == 0 && tbl->orphaned) {
+        LinkTable *parent = tbl->parent_tbl;
+        Link *parent_link = tbl->parent_link;
+        if (parent_link) {
+            parent_link->next_table = NULL;
+        }
+        PTHREAD_MUTEX_UNLOCK(&link_lock);
+
+        LinkTable_free(tbl);
+
+        if (parent) {
+            LinkTable_unref(parent);
+        }
+        return;
+    }
+    PTHREAD_MUTEX_UNLOCK(&link_lock);
 }
 
 void LinkTable_free(LinkTable *linktbl)
@@ -838,6 +885,7 @@ LinkTable *LinkTable_disk_open(const char *dirn)
 
     for (int i = 0; i < sz; i++) {
         linktbl->links[i] = CALLOC(1, sizeof(Link));
+        linktbl->links[i]->parent_table = linktbl;
         if (fread(linktbl->links[i]->linkname, sizeof(char), NAME_MAX, fp)
                 != NAME_MAX
             || fread(linktbl->links[i]->f_url, sizeof(char), PATH_MAX, fp)
@@ -866,47 +914,67 @@ LinkTable *path_to_LinkTable(const char *path)
 {
     Link *link = NULL;
     Link *tmp_link = NULL;
-    Link link_cpy = {0};
     LinkTable *next_table = NULL;
 
     if (!strcmp(path, "/")) {
         next_table = ROOT_LINK_TBL;
-        link_cpy = *next_table->links[0];
-        tmp_link = &link_cpy;
+        LinkTable_ref(next_table);
+        return next_table;
     } else {
         link = path_to_Link(path);
         if (!link) {
             return NULL;
         }
         tmp_link = link;
+
+        PTHREAD_MUTEX_LOCK(&link_lock);
         next_table = link->next_table;
+        PTHREAD_MUTEX_UNLOCK(&link_lock);
     }
 
     if (!next_table) {
+        LinkTable *new_table = NULL;
         if (CONFIG.mode == NORMAL) {
-            next_table = LinkTable_new(tmp_link->f_url);
+            new_table = LinkTable_new(tmp_link->f_url);
         } else if (CONFIG.mode == SINGLE) {
-            next_table = single_LinkTable_new(tmp_link->f_url);
+            new_table = single_LinkTable_new(tmp_link->f_url);
         } else if (CONFIG.mode == SONIC) {
             if (!CONFIG.sonic_id3) {
-                next_table = sonic_LinkTable_new_index(tmp_link->sonic.id);
+                new_table = sonic_LinkTable_new_index(tmp_link->sonic.id);
             } else {
-                next_table = sonic_LinkTable_new_id3(tmp_link->sonic.depth,
-                                                     tmp_link->sonic.id);
+                new_table = sonic_LinkTable_new_id3(tmp_link->sonic.depth,
+                                                    tmp_link->sonic.id);
             }
         } else {
             lprintf(fatal, "Invalid CONFIG.mode: %d\n", CONFIG.mode);
         }
+
+        PTHREAD_MUTEX_LOCK(&link_lock);
+        if (!link->next_table) {
+            link->next_table = new_table;
+            new_table->parent_tbl = link->parent_table;
+            new_table->parent_link = link;
+            if (new_table->parent_tbl) {
+                new_table->parent_tbl->refcount++;
+            }
+            next_table = new_table;
+        } else {
+            PTHREAD_MUTEX_UNLOCK(&link_lock);
+            LinkTable_free(new_table);
+            PTHREAD_MUTEX_LOCK(&link_lock);
+            next_table = link->next_table;
+        }
+        PTHREAD_MUTEX_UNLOCK(&link_lock);
+
+        if (CONFIG.invalid_refresh) {
+            LinkTable_uninitialised_fill(next_table);
+        }
     }
+
+    LinkTable_ref(next_table);
 
     if (link) {
-        link->next_table = next_table;
-    } else {
-        ROOT_LINK_TBL = next_table;
-    }
-
-    if (CONFIG.invalid_refresh) {
-        LinkTable_uninitialised_fill(next_table);
+        LinkTable_unref(link->parent_table);
     }
 
     return next_table;
@@ -971,22 +1039,36 @@ static Link *path_to_Link_recursive(char *path, LinkTable *linktbl)
                  */
                 LinkTable *next_table = linktbl->links[i]->next_table;
                 if (!next_table) {
+                    PTHREAD_MUTEX_UNLOCK(&link_lock);
+                    LinkTable *new_table = NULL;
                     if (CONFIG.mode == NORMAL) {
-                        next_table = LinkTable_new(linktbl->links[i]->f_url);
+                        new_table = LinkTable_new(linktbl->links[i]->f_url);
                     } else if (CONFIG.mode == SONIC) {
                         if (!CONFIG.sonic_id3) {
-                            next_table = sonic_LinkTable_new_index(
+                            new_table = sonic_LinkTable_new_index(
                                 linktbl->links[i]->sonic.id);
                         } else {
-                            next_table = sonic_LinkTable_new_id3(
+                            new_table = sonic_LinkTable_new_id3(
                                 linktbl->links[i]->sonic.depth,
                                 linktbl->links[i]->sonic.id);
                         }
                     } else {
                         lprintf(fatal, "Invalid CONFIG.mode\n");
                     }
+                    PTHREAD_MUTEX_LOCK(&link_lock);
+                    if (!linktbl->links[i]->next_table) {
+                        linktbl->links[i]->next_table = new_table;
+                        new_table->parent_tbl = linktbl;
+                        new_table->parent_link = linktbl->links[i];
+                        linktbl->refcount++;
+                        next_table = new_table;
+                    } else {
+                        PTHREAD_MUTEX_UNLOCK(&link_lock);
+                        LinkTable_free(new_table);
+                        PTHREAD_MUTEX_LOCK(&link_lock);
+                        next_table = linktbl->links[i]->next_table;
+                    }
                 }
-                linktbl->links[i]->next_table = next_table;
                 return path_to_Link_recursive(next_path, next_table);
             }
         }
@@ -1006,6 +1088,11 @@ Link *path_to_Link(const char *path)
     }
     Link *link = path_to_Link_recursive(new_path, ROOT_LINK_TBL);
     FREE(new_path);
+
+    if (link && link->parent_table) {
+        link->parent_table->refcount++;
+        link->parent_table->orphaned = 0;
+    }
 
     lprintf(link_lock_debug, "thread %lx: unlocking link_lock;\n",
             (unsigned long)pthread_self());
@@ -1227,7 +1314,9 @@ long path_download(const char *path, char *output_buf, size_t req_size,
         return -ENOENT;
     }
 
-    return Link_download(link, output_buf, req_size, offset);
+    long res = Link_download(link, output_buf, req_size, offset);
+    LinkTable_unref(link->parent_table);
+    return res;
 }
 
 static void make_link_relative(const char *page_url, char *link_url)

--- a/src/link.h
+++ b/src/link.h
@@ -36,12 +36,18 @@ struct LinkTable {
     int size;
     time_t index_time;
     Link **links;
+    int refcount;
+    int orphaned;
+    struct LinkTable *parent_tbl;
+    Link *parent_link;
 };
 
 /**
  * \brief Link type data structure
  */
 struct Link {
+    /** \brief The parent LinkTable of this link */
+    struct LinkTable *parent_table;
     /** \brief The link name in the last level of the URL */
     char linkname[NAME_MAX + 1];
     /** \brief This is for storing the unescaped path */
@@ -137,6 +143,21 @@ LinkTable *LinkTable_alloc(const char *url);
  * \brief free a LinkTable
  */
 void LinkTable_free(LinkTable *linktbl);
+
+/**
+ * \brief increment the reference count of a LinkTable
+ */
+void LinkTable_ref(LinkTable *tbl);
+
+/**
+ * \brief decrement the reference count of a LinkTable
+ */
+void LinkTable_unref(LinkTable *tbl);
+
+/**
+ * \brief mark a LinkTable as orphaned so it can be evicted
+ */
+void LinkTable_mark_orphaned(LinkTable *tbl);
 
 /**
  * \brief print a LinkTable

--- a/src/util.c
+++ b/src/util.c
@@ -551,6 +551,11 @@ void FREE_wrapper(void *ptr, const char *file, const char *func, int line)
 
 void mem_cleanup(void)
 {
+    if (CONFIG.http_headers) {
+        curl_slist_free_all(CONFIG.http_headers);
+        CONFIG.http_headers = NULL;
+    }
+
 #ifdef DEBUG
     // 1. Traverse and tear down the whole filesystem recursively
     if (ROOT_LINK_TBL) {
@@ -619,10 +624,6 @@ void mem_cleanup(void)
     pthread_mutex_unlock(&mem_mutex);
     pthread_mutex_destroy(&mem_mutex);
 #endif
-    if (CONFIG.http_headers) {
-        curl_slist_free_all(CONFIG.http_headers);
-        CONFIG.http_headers = NULL;
-    }
 }
 
 char *str_to_hex(char *s)

--- a/src/util.c
+++ b/src/util.c
@@ -3,6 +3,11 @@
 #include "config.h"
 #include "log.h"
 
+#ifdef DEBUG
+#include "link.h"
+#include "cache.h"
+#endif
+
 #include <curl/curl.h>
 #include <openssl/evp.h>
 #include <uuid/uuid.h>
@@ -547,7 +552,60 @@ void FREE_wrapper(void *ptr, const char *file, const char *func, int line)
 void mem_cleanup(void)
 {
 #ifdef DEBUG
+    // 1. Traverse and tear down the whole filesystem recursively
+    if (ROOT_LINK_TBL) {
+        LinkTable_free(ROOT_LINK_TBL);
+        ROOT_LINK_TBL = NULL;
+    }
+
+    // 2. Clean up any other heap-allocated cache directories
+    CacheSystem_cleanup();
+
+    // 3. Clean up CONFIG heap strings
+    Config_cleanup();
+
+    // 4. Consult the memory allocation tracker to check for leaks
     pthread_mutex_lock(&mem_mutex);
+    int leak_count = 0;
+    for (size_t i = 0; i < MEM_HASH_SIZE; i++) {
+        MemNode *curr = mem_hash_table[i];
+        while (curr) {
+            leak_count++;
+            curr = curr->next;
+        }
+    }
+
+    if (leak_count > 0) {
+        lprintf(error, "======================================================="
+                       "===============\n");
+        lprintf(error, "                     MEMORY LEAK REPORT\n");
+        lprintf(error, "======================================================="
+                       "===============\n");
+        for (size_t i = 0; i < MEM_HASH_SIZE; i++) {
+            MemNode *curr = mem_hash_table[i];
+            while (curr) {
+                lprintf(error, "[LEAK] Address: %p | Size: %zu bytes\n",
+                        curr->ptr, curr->size);
+                lprintf(error, "       Allocated at: %s:%d in %s()\n",
+                        curr->file, curr->line, curr->func);
+                lprintf(error,
+                        "---------------------------------------------------"
+                        "-------------------\n");
+                curr = curr->next;
+            }
+        }
+        lprintf(error, "Total Leaks: %d\n", leak_count);
+        lprintf(error, "======================================================="
+                       "===============\n");
+    } else {
+        lprintf(info, "========================================================"
+                      "==============\n");
+        lprintf(info, "No memory leaks detected!\n");
+        lprintf(info, "========================================================"
+                      "==============\n");
+    }
+
+    // Now forcefully free whatever was leaked so OS exit is completely clean
     for (size_t i = 0; i < MEM_HASH_SIZE; i++) {
         MemNode *curr = mem_hash_table[i];
         while (curr) {

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -21,8 +21,37 @@ set -euo pipefail
 # ─── Configuration ───────────────────────────────────────────────────────────
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HTTPDIRFS_BIN="${1:-}"
 HTTP_PORT="${HTTPDIRFS_TEST_PORT:-0}"
+
+# Parse options
+MODE="all"
+HTTPDIRFS_BIN=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --short)
+            MODE="short"
+            shift
+            ;;
+        --long)
+            MODE="long"
+            shift
+            ;;
+        -*)
+            echo -e "\033[0;31m[ERROR]\033[0m Unknown option: $1" >&2
+            exit 1
+            ;;
+        *)
+            if [[ -z "${HTTPDIRFS_BIN}" ]]; then
+                HTTPDIRFS_BIN="$1"
+            else
+                echo -e "\033[0;31m[ERROR]\033[0m Multiple binary paths specified or extra arguments: $@" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
 
 # Colours for output
 RED='\033[0;31m'
@@ -115,6 +144,8 @@ SERVE_DIR="${WORK_DIR}/serve"
 MOUNT_DIR="${WORK_DIR}/mnt"
 CACHE_MOUNT_DIR="${WORK_DIR}/cache_mnt"
 CACHE_DIR="${WORK_DIR}/cache"
+MANIFEST="${SERVE_DIR}/manifest.json"
+MOUNT_TIMEOUT=15
 
 mkdir -p "${SERVE_DIR}" "${MOUNT_DIR}" "${CACHE_MOUNT_DIR}" "${CACHE_DIR}"
 
@@ -123,8 +154,13 @@ log_info "httpdirfs binary: ${HTTPDIRFS_BIN}"
 
 # ─── Step 1: Generate test files ────────────────────────────────────────────
 
-log_info "Generating test files (including 1 GB large file)..."
-python3 "${SCRIPT_DIR}/generate_test_files.py" "${SERVE_DIR}" --large
+if [[ "${MODE}" == "short" ]]; then
+    log_info "Generating test files (excluding 1 GB large file)..."
+    python3 "${SCRIPT_DIR}/generate_test_files.py" "${SERVE_DIR}"
+else
+    log_info "Generating test files (including 1 GB large file)..."
+    python3 "${SCRIPT_DIR}/generate_test_files.py" "${SERVE_DIR}" --large
+fi
 
 # ─── Step 2: Start HTTP server with Range support ───────────────────────────
 
@@ -175,6 +211,7 @@ fi
 
 BASE_URL="http://127.0.0.1:${ACTUAL_PORT}/"
 
+if [[ "${MODE}" != "long" ]]; then
 # ─── Step 3: Mount with httpdirfs (non-cache mode) ─────────────────────────
 
 log_info "Mounting with httpdirfs (non-cache mode)..."
@@ -186,7 +223,6 @@ log_info "Mounting with httpdirfs (non-cache mode)..."
 HTTPDIRFS_PID=$!
 
 # Wait for the mount to become available
-MOUNT_TIMEOUT=15
 for i in $(seq 1 "${MOUNT_TIMEOUT}"); do
     if mountpoint -q "${MOUNT_DIR}" 2>/dev/null; then
         break
@@ -334,9 +370,11 @@ log_info "Unmounting non-cache mount..."
 do_unmount "${MOUNT_DIR}"
 wait "${HTTPDIRFS_PID}" 2>/dev/null || true
 log_info "Unmounted successfully."
+fi
 
 # ─── Step 6: Cache mode with multithreaded reads ────────────────────────────
 
+if [[ "${MODE}" != "short" ]]; then
 log_info "=== Cache mode tests ==="
 
 # Get the large file's expected SHA-256 from the manifest
@@ -425,6 +463,7 @@ else
         wait "${CACHE_HTTPDIRFS_PID}" 2>/dev/null || true
         log_info "Cache mount (blksz=${BLKSZ}M) unmounted."
     done
+fi
 fi
 
 

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -45,7 +45,7 @@ while [[ $# -gt 0 ]]; do
             if [[ -z "${HTTPDIRFS_BIN}" ]]; then
                 HTTPDIRFS_BIN="$1"
             else
-                echo -e "\033[0;31m[ERROR]\033[0m Multiple binary paths specified or extra arguments: $@" >&2
+                echo -e "\033[0;31m[ERROR]\033[0m Multiple binary paths specified or extra arguments: $*" >&2
                 exit 1
             fi
             shift

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,5 @@
 add_test_setup('default',
-               exclude_suites: ['integration'],
+               exclude_suites: ['integration_long'],
                is_default: true)
 
 unity_sub = subproject('unity')
@@ -14,7 +14,7 @@ test_util = executable('test_util',
     include_directories: include_directories('../src'),
     c_args: c_args
 )
-test('test_util', test_util)
+test('test_util', test_util, suite: 'unit_test')
 
 test_cache = executable('test_cache',
     sources: ['test_cache.c'],
@@ -23,7 +23,7 @@ test_cache = executable('test_cache',
     include_directories: include_directories('../src'),
     c_args: c_args
 )
-test('test_cache', test_cache)
+test('test_cache', test_cache, suite: 'unit_test')
 
 test_config = executable('test_config',
     sources: ['test_config.c'],
@@ -32,7 +32,7 @@ test_config = executable('test_config',
     include_directories: include_directories('../src'),
     c_args: c_args
 )
-test('test_config', test_config)
+test('test_config', test_config, suite: 'unit_test')
 
 test_link = executable('test_link',
     sources: ['test_link.c'],
@@ -41,16 +41,23 @@ test_link = executable('test_link',
     include_directories: include_directories('../src'),
     c_args: c_args
 )
-test('test_link', test_link)
+test('test_link', test_link, suite: 'unit_test')
 
 # Integration test (requires FUSE and Python 3)
 integration_test = find_program('integration/run_integration_test.sh',
                                 required: false)
 if integration_test.found()
-    test('integration',
+    test('integration_short',
          integration_test,
-         args: [httpdirfs],
+         args: ['--short', httpdirfs],
+         timeout: 300,
+         is_parallel: false,
+         suite: 'integration_short')
+
+    test('integration_long',
+         integration_test,
+         args: ['--long', httpdirfs],
          timeout: 900,
          is_parallel: false,
-         suite: 'integration')
+         suite: 'integration_long')
 endif


### PR DESCRIPTION
## Summary

This pull request implements an atomic, reference-counted memory management strategy for `LinkTable` directories to safely evict unused directory structures from memory without impacting parallel cache, read, or stat routines.

Additionally, this PR addresses critical concurrency, memory safety, and thread-safety feedback from reviews to ensure the eviction engine is robust against race conditions, null dereferences, and use-after-free paths under high multi-threaded concurrency.

---

## Key Changes

### 1. FUSE Directory `releasedir` & `LinkTable` Memory Eviction
- **Directory Lifecycle Handlers**: Added FUSE `.opendir` and `.releasedir` handlers to safely flag and evict directory tables from memory during runtime when they are no longer in use.
- **Atomic Reference Counting**: Introduced a robust `refcount` and `orphaned` lifecycle model to `LinkTable` so structures are reclaimed only when all active FUSE operations on them conclude.
- **Race-Free Resolution & Lock Protection**:
  - Refactored `path_to_LinkTable` and `path_to_Link_recursive` to resolve, lock, and reference tables atomically under a shared `link_lock`.
  - Guarded unlocked windows during directory resolutions by incrementing the parent `linktbl->refcount` under lock, shielding it from eviction by concurrent `releasedir` threads.
  - Eliminated TOCTOU lock release-reacquire races when disposing of duplicate local tables, ensuring target table pointers are never invalidated before they are resolved.
- **Null Safety**: Added strict `NULL` pointer checks on `path_to_Link` lookups across cache routines (`Cache_delete` and `Cache_create`) to prevent potential segmentation faults when files or paths cannot be resolved.

### 2. Debug Shutdown Memory Leak Tracking & Hygiene
- **VFS Teardown**: Implemented clean, recursive teardown of the directory tree at exit in `DEBUG` configuration.
- **Leak Hygiene**: Released global configurations (`CONFIG.http_headers`) early in `mem_cleanup()` to suppress false-positive leak reports, ensuring clean leak tracking runs at shutdown.

### 3. Test Suite Segmentation & Developer Workflow
- **Granular Test Suites**: Segmented tests into three categories: `unit_test`, `integration_short` (fast, lightweight integration tests), and `integration_long` (slow, multithreaded 1GB stress test).
- **Hook Optimization**: Updated `.pre-commit-config.yaml` to run fast debug tests locally, and separated Clang and GCC verification hook-stages to maintain maximum velocity during everyday commits while offering comprehensive verification triggers via `--hook-stage manual`.
- **Documentation**: Fully documented the testing architecture and verification instructions in `src/README.md`.