### PR TITLE
cache: implement async early-return downloads

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "log.h"
+#include "memcache.h"
 #include "util.h"
 #include <curl/curl.h>
 
@@ -554,6 +555,10 @@ static Cache *Cache_alloc(void)
     Cache *cf = CALLOC(1, sizeof(Cache));
     PTHREAD_MUTEX_INIT(&cf->seek_lock, NULL);
     PTHREAD_MUTEX_INIT(&cf->w_lock, NULL);
+    PTHREAD_MUTEX_INIT(&cf->dl_lock, NULL);
+    pthread_cond_init(&cf->dl_cond, NULL);
+    cf->active_dl_offset = -1;
+    cf->active_dl_ts = NULL;
     cf->cache_opened = 1;
     SEM_INIT(&cf->bgt_sem, 0, 1);
     return cf;
@@ -566,6 +571,8 @@ static void Cache_free(Cache *cf)
 {
     PTHREAD_MUTEX_DESTROY(&cf->seek_lock);
     PTHREAD_MUTEX_DESTROY(&cf->w_lock);
+    PTHREAD_MUTEX_DESTROY(&cf->dl_lock);
+    pthread_cond_destroy(&cf->dl_cond);
     SEM_DESTROY(&cf->bgt_sem);
 
     if (cf->path) {
@@ -997,33 +1004,33 @@ static void Seg_set(Cache *cf, off_t offset, int i)
 static void *Cache_bgdl(void *arg)
 {
     Cache *cf = (Cache *)arg;
-
-    lprintf(cache_lock_debug, "thread %lx: locking w_lock;\n",
-            (unsigned long)pthread_self());
-    PTHREAD_MUTEX_LOCK(&cf->w_lock);
+    off_t dl_offset = cf->next_dl_offset;
 
     uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
     lprintf(debug, "thread %lx spawned.\n ", (unsigned long)pthread_self());
-    long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz,
-                              cf->next_dl_offset);
+    long recv
+        = Link_download(cf->link, (char *)recv_buf, cf->blksz, dl_offset, cf);
     if (recv < 0) {
         lprintf(error,
                 "thread %lx received %ld bytes, "
                 "which doesn't make sense\n",
                 (unsigned long)pthread_self(), recv);
         FREE(recv_buf);
-        lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-                (unsigned long)pthread_self());
-        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+        PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+        if (cf->active_dl_offset == dl_offset) {
+            cf->active_dl_offset = -1;
+            pthread_cond_broadcast(&cf->dl_cond);
+        }
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         SEM_POST(&cf->bgt_sem);
         pthread_exit(NULL);
     }
 
+    PTHREAD_MUTEX_LOCK(&cf->w_lock);
     if ((recv == cf->blksz)
-        || (cf->next_dl_offset
-            == (cf->content_length / cf->blksz * cf->blksz))) {
-        if (Data_write(cf, recv_buf, recv, cf->next_dl_offset) == recv) {
-            Seg_set(cf, cf->next_dl_offset, 1);
+        || (dl_offset == (cf->content_length / cf->blksz * cf->blksz))) {
+        if (Data_write(cf, recv_buf, recv, dl_offset) == recv) {
+            Seg_set(cf, dl_offset, 1);
         }
     } else {
         lprintf(error,
@@ -1031,12 +1038,17 @@ static void *Cache_bgdl(void *arg)
                 "error.\n",
                 recv, cf->blksz);
     }
+    PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
 
     FREE(recv_buf);
 
-    lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-            (unsigned long)pthread_self());
-    PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+    PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+    if (cf->active_dl_offset == dl_offset) {
+        cf->active_dl_offset = -1;
+        pthread_cond_broadcast(&cf->dl_cond);
+    }
+    PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
     SEM_POST(&cf->bgt_sem);
 
     pthread_exit(NULL);
@@ -1070,111 +1082,148 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
                                const off_t len, const off_t offset_start)
 {
     long send;
-
-    /*
-     * The offset of the segment to be downloaded
-     */
     off_t dl_offset = offset_start / cf->blksz * cf->blksz;
 
-    /*
-     * ------------- Check if the segment already exists --------------
-     */
+retry:
+    PTHREAD_MUTEX_LOCK(&cf->w_lock);
     if (Seg_exist(cf, dl_offset)) {
         send = Data_read(cf, (uint8_t *)output_buf, len, offset_start);
+        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
         goto bgdl;
-    } else {
-        /*
-         * Wait for any other download thread to finish
-         */
+    }
 
-        lprintf(cache_lock_debug, "thread %lx: locking w_lock;\n",
-                (unsigned long)pthread_self());
+    PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+    if (cf->active_dl_offset == dl_offset) {
+        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+
+        while (cf->active_dl_offset == dl_offset) {
+            if (cf->active_dl_ts
+                && cf->active_dl_ts->curr_size
+                       >= (size_t)(offset_start - dl_offset + len)) {
+                memcpy(output_buf,
+                       cf->active_dl_ts->data + (offset_start - dl_offset),
+                       len);
+                PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+                send = len;
+                goto bgdl;
+            }
+            if (cf->active_dl_ts && !cf->active_dl_ts->transferring) {
+                break;
+            }
+            pthread_cond_wait(&cf->dl_cond, &cf->dl_lock);
+        }
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+        goto retry;
+    }
+    PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
+    int ret = sem_trywait(&cf->bgt_sem);
+    if (ret == 0) {
+        PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+        cf->active_dl_offset = dl_offset;
+        cf->next_dl_offset = dl_offset;
+        cf->active_dl_ts = NULL;
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+        Cache_bgdl_launcher(cf);
+        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+        goto retry;
+    } else {
+        PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+        cf->active_dl_offset = dl_offset;
+        cf->active_dl_ts = NULL;
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
+        PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+
+        uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
+        long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz,
+                                  dl_offset, cf);
+
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
 
-        if (Seg_exist(cf, dl_offset)) {
-            /*
-             * The segment now exists - it was downloaded by another
-             * download thread. Send it off and unlock the I/O
-             */
-            send = Data_read(cf, (uint8_t *)output_buf, len, offset_start);
-
-            lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-                    (unsigned long)pthread_self());
+        if (recv < 0) {
+            PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+            if (cf->active_dl_offset == dl_offset) {
+                cf->active_dl_offset = -1;
+                pthread_cond_broadcast(&cf->dl_cond);
+            }
+            PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+            FREE(recv_buf);
             PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
-
-            goto bgdl;
+            return recv;
         }
-    }
+        if ((recv == cf->blksz)
+            || (dl_offset == (cf->content_length / cf->blksz * cf->blksz))) {
+            if (recv < (offset_start - dl_offset) + len) {
+                lprintf(error,
+                        "received %ld bytes, but required at least %ld bytes\n",
+                        recv, (long)((offset_start - dl_offset) + len));
+                PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+                if (cf->active_dl_offset == dl_offset) {
+                    cf->active_dl_offset = -1;
+                    pthread_cond_broadcast(&cf->dl_cond);
+                }
+                PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+                FREE(recv_buf);
+                PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+                return -EIO;
+            }
+            if (Data_write(cf, recv_buf, recv, dl_offset) == recv) {
+                Seg_set(cf, dl_offset, 1);
+            }
+        } else {
+            lprintf(error,
+                    "received %ld rather than %d, possible network "
+                    "error.\n",
+                    recv, cf->blksz);
+            PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+            if (cf->active_dl_offset == dl_offset) {
+                cf->active_dl_offset = -1;
+                pthread_cond_broadcast(&cf->dl_cond);
+            }
+            PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+            FREE(recv_buf);
+            PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+            return -EIO;
+        }
 
-    /*
-     * ------------------ Download the segment ---------------------
-     */
-
-    uint8_t *recv_buf = CALLOC(cf->blksz, sizeof(uint8_t));
-    lprintf(debug, "thread %lx: spawned.\n ", (unsigned long)pthread_self());
-    long recv = Link_download(cf->link, (char *)recv_buf, cf->blksz, dl_offset);
-    if (recv < 0) {
-        lprintf(error,
-                "thread %lx received %ld bytes, "
-                "which doesn't make sense\n",
-                (unsigned long)pthread_self(), recv);
+        PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+        if (cf->active_dl_offset == dl_offset) {
+            cf->active_dl_offset = -1;
+            pthread_cond_broadcast(&cf->dl_cond);
+        }
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+        send = len;
+        if (offset_start < dl_offset
+            || (size_t)(offset_start - dl_offset) + (size_t)send
+                   > (size_t)cf->blksz) {
+            lprintf(error,
+                    "invalid offset or length for memcpy, aborting copy\n");
+            send = 0;
+        } else {
+            memcpy(output_buf, recv_buf + (offset_start - dl_offset), send);
+        }
         FREE(recv_buf);
-        lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-                (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
-        return recv;
     }
-    /*
-     * check if we have received enough data, write it to the disk
-     *
-     * Condition 1: received the exact amount as the segment size.
-     * Condition 2: offset is the last segment
-     */
-    if ((recv == cf->blksz)
-        || (dl_offset == (cf->content_length / cf->blksz * cf->blksz))) {
-        if (Data_write(cf, recv_buf, recv, dl_offset) == recv) {
-            Seg_set(cf, dl_offset, 1);
-        }
-    } else {
-        lprintf(error,
-                "received %ld rather than %d, possible network "
-                "error.\n",
-                recv, cf->blksz);
-    }
-    send = len;
-    if (offset_start < dl_offset
-        || (size_t)(offset_start - dl_offset) + (size_t)send
-               > (size_t)cf->blksz) {
-        lprintf(error, "invalid offset or length for memcpy, aborting copy\n");
-        send = 0;
-    } else {
-        memcpy(output_buf, recv_buf + (offset_start - dl_offset), send);
-    }
-    FREE(recv_buf);
 
-    lprintf(cache_lock_debug, "thread %lx: unlocking w_lock;\n",
-            (unsigned long)pthread_self());
-    PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
-
-    /*
-     * ----------- Download the next segment in background -----------------
-     */
 bgdl: {
 }
     off_t next_dl_offset = dl_offset + cf->blksz;
     if (!Seg_exist(cf, next_dl_offset) && next_dl_offset < cf->content_length) {
-        /*
-         * Stop the spawning of multiple background pthreads
-         */
-        int ret = sem_trywait(&cf->bgt_sem);
+        ret = sem_trywait(&cf->bgt_sem);
         if (!ret) {
-            lprintf(cache_lock_debug,
-                    "parent thread %lx: sem_trywait successful\n",
-                    (unsigned long)pthread_self());
-            cf->next_dl_offset = next_dl_offset;
-            Cache_bgdl_launcher(cf);
-        } else if (errno != EAGAIN) {
-            lprintf(fatal, "sem_trywait(): %d, %s\n", errno, strerror(errno));
+            PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+            if (cf->active_dl_offset == next_dl_offset) {
+                PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+                SEM_POST(&cf->bgt_sem);
+            } else {
+                cf->active_dl_offset = next_dl_offset;
+                cf->next_dl_offset = next_dl_offset;
+                cf->active_dl_ts = NULL;
+                PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+                Cache_bgdl_launcher(cf);
+            }
         }
     }
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -14,6 +14,8 @@ typedef struct Cache Cache;
 #include "link.h"
 #include "network.h"
 
+struct TransferStruct;
+
 #include <stdio.h>
 #include <stdint.h>
 #include <pthread.h>
@@ -59,6 +61,15 @@ struct Cache {
     sem_t bgt_sem;
     /** \brief the offset of the next segment to be downloaded in background*/
     off_t next_dl_offset;
+
+    /** \brief mutex lock for background download progress */
+    pthread_mutex_t dl_lock;
+    /** \brief condition variable for background download progress */
+    pthread_cond_t dl_cond;
+    /** \brief the active TransferStruct for the background download */
+    struct TransferStruct *active_dl_ts;
+    /** \brief the offset currently being downloaded in background */
+    off_t active_dl_offset;
 
     /** \brief the FUSE filesystem path to the remote file*/
     char *fs_path;

--- a/src/link.c
+++ b/src/link.c
@@ -1270,7 +1270,8 @@ bug report, please include the following HTTP header information:\n%s\n",
     return recv;
 }
 
-long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
+long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
+                   Cache *cf)
 {
     TransferStruct ts = {0};
     TransferStruct header = {0};
@@ -1289,9 +1290,20 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
         ts.data = NULL;
         ts.type = DATA;
         ts.transferring = 1;
+        ts.cache_ptr = cf;
+
+        if (cf) {
+            PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+            if (cf->active_dl_offset == offset) {
+                cf->active_dl_ts = &ts;
+                pthread_cond_broadcast(&cf->dl_cond);
+            }
+            PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+        }
 
         header.curr_size = 0;
         header.data = NULL;
+        header.cache_ptr = NULL;
 
         CURL *curl
             = Link_download_curl_setup(link, req_size, offset, &header, &ts);
@@ -1301,6 +1313,17 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
         recv_sz = Link_download_cleanup(curl, &header);
 
         if (recv_sz < 0) {
+            if (cf) {
+                PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+                ts.transferring = 0;
+                if (cf->active_dl_ts == &ts) {
+                    cf->active_dl_ts = NULL;
+                }
+                pthread_cond_broadcast(&cf->dl_cond);
+                PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+            } else {
+                ts.transferring = 0;
+            }
             FREE(ts.data);
             if (recv_sz == -EAGAIN) {
                 lprintf(warning, "HTTP temporary failure, retrying...\n");
@@ -1314,6 +1337,17 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
             lprintf(error,
                     "req_size != recv, req_size: %lu, recv: %ld, retrying...\n",
                     req_size, recv_sz);
+            if (cf) {
+                PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+                ts.transferring = 0;
+                if (cf->active_dl_ts == &ts) {
+                    cf->active_dl_ts = NULL;
+                }
+                pthread_cond_broadcast(&cf->dl_cond);
+                PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+            } else {
+                ts.transferring = 0;
+            }
             FREE(ts.data);
             sleep(CONFIG.http_wait_sec);
             continue;
@@ -1322,6 +1356,18 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
         /* success */
         break;
     } while (1);
+
+    if (cf) {
+        PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+        ts.transferring = 0;
+        if (cf->active_dl_ts == &ts) {
+            cf->active_dl_ts = NULL;
+        }
+        pthread_cond_broadcast(&cf->dl_cond);
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+    } else {
+        ts.transferring = 0;
+    }
 
     memmove(output_buf, ts.data, recv_sz);
     FREE(ts.data);
@@ -1342,7 +1388,7 @@ long path_download(const char *path, char *output_buf, size_t req_size,
         return -ENOENT;
     }
 
-    long res = Link_download(link, output_buf, req_size, offset);
+    long res = Link_download(link, output_buf, req_size, offset, NULL);
     LinkTable_unref(link->parent_table);
     return res;
 }

--- a/src/link.c
+++ b/src/link.c
@@ -1135,9 +1135,7 @@ TransferStruct Link_download_full(Link *link)
     char *url = link->f_url;
     CURL *curl = Link_to_curl(link);
 
-    TransferStruct ts;
-    ts.curr_size = 0;
-    ts.data = NULL;
+    TransferStruct ts = {0};
     ts.type = DATA;
     ts.transferring = 1;
 
@@ -1274,8 +1272,8 @@ bug report, please include the following HTTP header information:\n%s\n",
 
 long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset)
 {
-    TransferStruct ts;
-    TransferStruct header;
+    TransferStruct ts = {0};
+    TransferStruct header = {0};
     curl_off_t recv_sz;
 
     size_t request_end = offset + req_size;

--- a/src/link.h
+++ b/src/link.h
@@ -104,7 +104,8 @@ long path_download(const char *path, char *output_buf, size_t size,
  * \brief Download a Link
  * \return the number of bytes downloaded
  */
-long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset);
+long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
+                   Cache *cf);
 
 /**
  * \brief find the link associated with a path

--- a/src/memcache.c
+++ b/src/memcache.c
@@ -16,12 +16,21 @@ size_t write_memory_callback(void *recv_data, size_t size, size_t nmemb,
     }
     size_t recv_size = size * nmemb;
 
+    if (ts->cache_ptr) {
+        PTHREAD_MUTEX_LOCK(&ts->cache_ptr->dl_lock);
+    }
+
     void *new_data = REALLOC(ts->data, ts->curr_size + recv_size + 1);
     ts->data = new_data;
 
     memmove(&ts->data[ts->curr_size], recv_data, recv_size);
     ts->curr_size += recv_size;
     ts->data[ts->curr_size] = '\0';
+
+    if (ts->cache_ptr) {
+        pthread_cond_broadcast(&ts->cache_ptr->dl_cond);
+        PTHREAD_MUTEX_UNLOCK(&ts->cache_ptr->dl_lock);
+    }
 
     return recv_size;
 }

--- a/src/memcache.h
+++ b/src/memcache.h
@@ -21,6 +21,8 @@ struct TransferStruct {
     volatile int transferring;
     /** \brief The link associated with the transfer */
     Link *link;
+    /** \brief The Cache structure associated with the transfer */
+    Cache *cache_ptr;
 };
 
 /**


### PR DESCRIPTION
This PR implements asynchronous early-return downloads in the cache system of HTTPDirFS, drastically reducing FUSE latency by allowing reader threads to consume partial segments before full download completions.

### Key Changes:
1. **Async Early-Return Downloads**: Reader threads block on a conditional variable `dl_cond` and read memory directly from the background network buffer once enough bytes are received.
2. **Robust Concurrency**:
   - `cf->active_dl_ts` is safely set to `NULL` under lock whenever `cf->active_dl_offset` updates to a new segment. This ensures overlapping multithreaded readers do not read corrupted buffers from other parallel active segment transfers.
   - Extracts a thread-local copy of the download offset `dl_offset` in the background thread `Cache_bgdl` to prevent race conditions during updates.
3. **Memory and Mutex Safety**:
   - Zero-initializes all local stack structures (`ts` and `header`) in `src/link.c` (`Link_download` and `Link_download_full`) to prevent undefined behavior and invalid mutex lock/unlock operations during callbacks.

### Commits:
- `link: zero-initialize TransferStruct stack variables`
- `memcache: add cache_ptr to TransferStruct`
- `cache: implement async early-return downloads`

Each commit has been verified locally and compiles successfully while passing all pre-commit hooks and full integration/unit test suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced synchronization for concurrent background downloads to prevent race conditions and improve reliability.
  * Improved cache segment read operations with retry logic for better handling of concurrent access patterns.

* **Performance**
  * Optimized download coordination to reduce conflicts and improve efficiency during concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->