### PR TITLE
Refactor Cache metadata to prioritize struct Link

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -225,6 +225,11 @@ static int Meta_read(Cache *cf)
         return EIO;
     }
 
+    if (!cf->link) {
+        lprintf(error, "cf->link is NULL in Meta_read\n");
+        return EINVAL;
+    }
+
     long disk_time;
     off_t disk_content_length;
 
@@ -236,8 +241,11 @@ static int Meta_read(Cache *cf)
         return EIO;
     }
 
-    /* These things really should not be zero! */
-    if (!disk_content_length || !cf->blksz || !cf->segbc) {
+    /*
+     * We do not support zero-byte files in the on-disk cache files.
+     * Both disk_content_length and cf->segbc must be strictly positive.
+     */
+    if (disk_content_length <= 0 || cf->blksz <= 0 || cf->segbc <= 0) {
         lprintf(error,
                 "corruption: content_length: %jd, blksz: %d, segbc: %jd\n",
                 (intmax_t)disk_content_length, cf->blksz, (intmax_t)cf->segbc);
@@ -246,11 +254,6 @@ static int Meta_read(Cache *cf)
 
     if (cf->blksz != CONFIG.data_blksz) {
         lprintf(warning, "Warning: cf->blksz != CONFIG.data_blksz\n");
-    }
-
-    if (disk_content_length <= 0 || cf->blksz <= 0) {
-        lprintf(error, "Error: invalid metadata sizes\n");
-        return EBADMSG;
     }
 
     if (disk_content_length > INT64_MAX - cf->blksz) {
@@ -265,7 +268,7 @@ static int Meta_read(Cache *cf)
         return EBADMSG;
     }
 
-    if (disk_content_length != (off_t)cf->link->content_length) {
+    if ((uintmax_t)disk_content_length != (uintmax_t)cf->link->content_length) {
         lprintf(warning, "cache size mismatch: %s (disk: %jd, link: %zu)\n",
                 cf->path, (intmax_t)disk_content_length,
                 cf->link->content_length);
@@ -282,8 +285,9 @@ static int Meta_read(Cache *cf)
         max_segbc = INT_MAX;
     }
 
-    if (cf->segbc <= 0 || cf->segbc > max_segbc) {
-        lprintf(error, "Error: invalid segbc size: %ld\n", cf->segbc);
+    if (cf->segbc != max_segbc) {
+        lprintf(error, "Error: invalid segbc size: %ld (expected: %ld)\n",
+                cf->segbc, (long)max_segbc);
         return EBADMSG;
     }
 
@@ -346,13 +350,36 @@ static int Meta_write(Cache *cf)
         return -1;
     }
 
+    if (!cf->link) {
+        lprintf(error, "cf->link is NULL in Meta_write\n");
+        return -1;
+    }
+
     /*
-     * These things really should not be zero!
+     * We support zero-byte files, in which case both write_content_length and
+     * cf->segbc must be zero. If write_content_length is positive, cf->segbc
+     * must be positive.
      */
     off_t write_content_length = (off_t)cf->link->content_length;
-    if (!write_content_length || !cf->blksz || !cf->segbc) {
-        lprintf(error, "content_length: %jd, blksz: %d, segbc: %jd\n",
-                (intmax_t)write_content_length, cf->blksz, (intmax_t)cf->segbc);
+    long expected_segbc = 0;
+    if (cf->blksz > 0 && write_content_length >= 0) {
+        expected_segbc = write_content_length / cf->blksz;
+        if (write_content_length % cf->blksz != 0) {
+            expected_segbc += 1;
+        }
+        if (expected_segbc > INT_MAX) {
+            expected_segbc = INT_MAX;
+        }
+    }
+    if (write_content_length < 0
+        || (size_t)write_content_length != cf->link->content_length
+        || cf->blksz <= 0 || cf->segbc != expected_segbc) {
+        lprintf(error,
+                "invalid metadata for write: content_length: %jd, blksz: %d, "
+                "segbc: %ld (expected: %ld)\n",
+                (intmax_t)write_content_length, cf->blksz, cf->segbc,
+                expected_segbc);
+        return -1;
     }
 
     fwrite(&cf->link->time, sizeof(long), 1, fp);
@@ -389,7 +416,16 @@ static void Data_create(Cache *cf)
     if (fd == -1) {
         lprintf(fatal, "open(): %s\n", strerror(errno));
     }
-    if (ftruncate(fd, (off_t)cf->link->content_length)) {
+    if (!cf->link) {
+        lprintf(fatal, "cf->link is NULL in Data_create\n");
+    }
+    off_t truncate_size = (off_t)cf->link->content_length;
+    if (truncate_size < 0
+        || (size_t)truncate_size != cf->link->content_length) {
+        lprintf(fatal, "File size too large for system off_t: %zu\n",
+                cf->link->content_length);
+    }
+    if (ftruncate(fd, truncate_size)) {
         lprintf(warning, "ftruncate(): %s\n", strerror(errno));
     }
     if (close(fd)) {
@@ -426,6 +462,11 @@ static off_t Data_size(const char *fn)
  */
 static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
 {
+    if (!cf->link) {
+        lprintf(error, "cf->link is NULL in Data_read\n");
+        return -EINVAL;
+    }
+
     if (len == 0) {
         lprintf(error, "requested to read 0 byte!\n");
         return -EINVAL;
@@ -437,6 +478,12 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
 
     long byte_read = 0;
 
+    if (offset < 0 || offset >= (off_t)cf->link->content_length) {
+        goto end;
+    } else if (len > (off_t)cf->link->content_length - offset) {
+        len = (off_t)cf->link->content_length - offset;
+    }
+
     /*
      * Seek to the right location
      */
@@ -447,16 +494,6 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
         lprintf(error, "fseeko(): %s\n", strerror(errno));
         byte_read = -EIO;
         goto end;
-    }
-
-    /*
-     * Calculate how much to read
-     */
-    if (offset + len > (off_t)cf->link->content_length) {
-        len -= offset + len - (off_t)cf->link->content_length;
-        if (len < 0) {
-            goto end;
-        }
     }
 
     byte_read = fread(buf, sizeof(uint8_t), len, cf->dfp);
@@ -812,6 +849,9 @@ int Cache_create(const char *path)
     if (this_link->content_length % cf->blksz != 0) {
         cf->segbc += 1;
     }
+    if (cf->segbc > INT_MAX) {
+        cf->segbc = INT_MAX;
+    }
     cf->seg = CALLOC(cf->segbc, sizeof(Seg));
 
     Meta_create(cf);
@@ -884,6 +924,26 @@ Cache *Cache_open(const char *fn)
         actual_fn = link->sonic.id;
     }
 
+    if (link->content_length == 0) {
+        Cache_delete(fn);
+        Cache *cf = Cache_alloc();
+        cf->path = STRNDUP(actual_fn, PATH_MAX);
+        cf->link = link;
+        cf->blksz = CONFIG.data_blksz;
+        cf->segbc = 0;
+        cf->seg = NULL;
+        cf->mfp = NULL;
+        cf->dfp = NULL;
+
+        link->cache_ptr = cf;
+
+        lprintf(cache_lock_debug,
+                "thread %lx: unlocking cf_lock; (zero-length file shortcut)\n",
+                (unsigned long)pthread_self());
+        PTHREAD_MUTEX_UNLOCK(&cf_lock);
+        return cf;
+    }
+
     // Try up to 2 times. If opening fails on the first attempt (outdated,
     // corrupt, etc.), we delete the cache and try creating and opening a fresh
     // one.
@@ -923,7 +983,8 @@ Cache *Cache_open(const char *fn)
             if (d_size < 0) {
                 lprintf(error, "cannot stat data file %s.\n", actual_fn);
                 ok = 0;
-            } else if ((off_t)cf->link->content_length > d_size) {
+            } else if ((uintmax_t)cf->link->content_length
+                       > (uintmax_t)d_size) {
                 lprintf(error,
                         "metadata inconsistency %s, "
                         "cf->link->content_length: %jd, Data_size(fn): %jd.\n",
@@ -994,15 +1055,15 @@ void Cache_close(Cache *cf)
             (unsigned long)pthread_self(), cf->path);
     SEM_WAIT(&cf->bgt_sem);
 
-    if (Meta_write(cf)) {
+    if (cf->mfp && Meta_write(cf)) {
         lprintf(error, "Meta_write() error.");
     }
 
-    if (fclose(cf->mfp)) {
+    if (cf->mfp && fclose(cf->mfp)) {
         lprintf(error, "cannot close metadata: %s.\n", strerror(errno));
     }
 
-    if (fclose(cf->dfp)) {
+    if (cf->dfp && fclose(cf->dfp)) {
         lprintf(error, "cannot close data file %s.\n", strerror(errno));
     }
 
@@ -1023,7 +1084,13 @@ void Cache_close(Cache *cf)
  */
 static int Seg_exist(Cache *cf, off_t offset)
 {
+    if (cf->segbc <= 0) {
+        return 0;
+    }
     off_t byte = offset / cf->blksz;
+    if (byte < 0 || byte >= cf->segbc) {
+        return 0;
+    }
     return cf->seg[byte];
 }
 
@@ -1036,7 +1103,13 @@ static int Seg_exist(Cache *cf, off_t offset)
  */
 static void Seg_set(Cache *cf, off_t offset, int i)
 {
+    if (cf->segbc <= 0) {
+        return;
+    }
     off_t byte = offset / cf->blksz;
+    if (byte < 0 || byte >= cf->segbc) {
+        return;
+    }
     cf->seg[byte] = i;
 }
 
@@ -1081,8 +1154,9 @@ static void *Cache_bgdl(void *arg)
 
     PTHREAD_MUTEX_LOCK(&cf->w_lock);
     if ((recv == cf->blksz)
-        || (dl_offset
-            == ((off_t)cf->link->content_length / cf->blksz * cf->blksz))) {
+        || ((uintmax_t)dl_offset
+            == (cf->link->content_length / (size_t)cf->blksz
+                * (size_t)cf->blksz))) {
         if (Data_write(cf, recv_buf, recv, dl_offset) == recv) {
             Seg_set(cf, dl_offset, 1);
         }
@@ -1183,6 +1257,11 @@ static void Cache_bgdl_launcher(Cache *cf, off_t dl_offset)
 static long Cache_read_segment(Cache *cf, char *const output_buf,
                                const off_t len, const off_t offset_start)
 {
+    if (cf->link->content_length == 0 || offset_start < 0
+        || offset_start >= (off_t)cf->link->content_length) {
+        return 0;
+    }
+
     long send;
     off_t dl_offset = offset_start / cf->blksz * cf->blksz;
     int ret;
@@ -1284,8 +1363,9 @@ sync_dl:
         return recv;
     }
     if ((recv == cf->blksz)
-        || (dl_offset
-            == ((off_t)cf->link->content_length / cf->blksz * cf->blksz))) {
+        || ((uintmax_t)dl_offset
+            == (cf->link->content_length / (size_t)cf->blksz
+                * (size_t)cf->blksz))) {
         if (recv < (offset_start - dl_offset) + len) {
             lprintf(error,
                     "received %ld bytes, but required at least %ld bytes\n",
@@ -1335,7 +1415,7 @@ bgdl: {
 }
     off_t next_dl_offset = dl_offset + cf->blksz;
     int next_seg_missing = 0;
-    if (next_dl_offset < (off_t)cf->link->content_length) {
+    if ((uintmax_t)next_dl_offset < (uintmax_t)cf->link->content_length) {
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
         next_seg_missing = !Seg_exist(cf, next_dl_offset);
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1381,6 +1461,9 @@ long Cache_read(Cache *cf, char *const output_buf, off_t len,
             return seg_send;
         }
         send += seg_send;
+        if (seg_send < end - start) {
+            break;
+        }
     }
     return send;
 }

--- a/src/cache.c
+++ b/src/cache.c
@@ -225,8 +225,11 @@ static int Meta_read(Cache *cf)
         return EIO;
     }
 
-    if (1 != fread(&cf->time, sizeof(long), 1, fp)
-        || 1 != fread(&cf->content_length, sizeof(off_t), 1, fp)
+    long disk_time;
+    off_t disk_content_length;
+
+    if (1 != fread(&disk_time, sizeof(long), 1, fp)
+        || 1 != fread(&disk_content_length, sizeof(off_t), 1, fp)
         || 1 != fread(&cf->blksz, sizeof(int), 1, fp)
         || 1 != fread(&cf->segbc, sizeof(long), 1, fp) || ferror(fp)) {
         lprintf(error, "error reading core metadata %s!\n", cf->path);
@@ -234,10 +237,10 @@ static int Meta_read(Cache *cf)
     }
 
     /* These things really should not be zero! */
-    if (!cf->content_length || !cf->blksz || !cf->segbc) {
+    if (!disk_content_length || !cf->blksz || !cf->segbc) {
         lprintf(error,
                 "corruption: content_length: %jd, blksz: %d, segbc: %jd\n",
-                (intmax_t)cf->content_length, cf->blksz, (intmax_t)cf->segbc);
+                (intmax_t)disk_content_length, cf->blksz, (intmax_t)cf->segbc);
         return EBADMSG;
     }
 
@@ -245,19 +248,33 @@ static int Meta_read(Cache *cf)
         lprintf(warning, "Warning: cf->blksz != CONFIG.data_blksz\n");
     }
 
-    if (cf->content_length <= 0 || cf->blksz <= 0) {
+    if (disk_content_length <= 0 || cf->blksz <= 0) {
         lprintf(error, "Error: invalid metadata sizes\n");
         return EBADMSG;
     }
 
-    if (cf->content_length > INT64_MAX - cf->blksz) {
+    if (disk_content_length > INT64_MAX - cf->blksz) {
         lprintf(error, "Error: segbc upper bound overflow\n");
         return EBADMSG;
     }
 
-    off_t max_segbc = cf->content_length / cf->blksz;
+    /* Verify cached metadata matches the live Link metadata */
+    if (disk_time != cf->link->time) {
+        lprintf(warning, "outdated cache file: %s (disk: %ld, link: %ld)\n",
+                cf->path, disk_time, cf->link->time);
+        return EBADMSG;
+    }
 
-    if ((cf->content_length % cf->blksz) != 0) {
+    if (disk_content_length != (off_t)cf->link->content_length) {
+        lprintf(warning, "cache size mismatch: %s (disk: %jd, link: %zu)\n",
+                cf->path, (intmax_t)disk_content_length,
+                cf->link->content_length);
+        return EBADMSG;
+    }
+
+    off_t max_segbc = disk_content_length / cf->blksz;
+
+    if ((disk_content_length % cf->blksz) != 0) {
         max_segbc += 1;
     }
 
@@ -332,13 +349,14 @@ static int Meta_write(Cache *cf)
     /*
      * These things really should not be zero!
      */
-    if (!cf->content_length || !cf->blksz || !cf->segbc) {
+    off_t write_content_length = (off_t)cf->link->content_length;
+    if (!write_content_length || !cf->blksz || !cf->segbc) {
         lprintf(error, "content_length: %jd, blksz: %d, segbc: %jd\n",
-                (intmax_t)cf->content_length, cf->blksz, (intmax_t)cf->segbc);
+                (intmax_t)write_content_length, cf->blksz, (intmax_t)cf->segbc);
     }
 
-    fwrite(&cf->time, sizeof(long), 1, fp);
-    fwrite(&cf->content_length, sizeof(off_t), 1, fp);
+    fwrite(&cf->link->time, sizeof(long), 1, fp);
+    fwrite(&write_content_length, sizeof(off_t), 1, fp);
     fwrite(&cf->blksz, sizeof(int), 1, fp);
     fwrite(&cf->segbc, sizeof(long), 1, fp);
     fwrite(cf->seg, sizeof(Seg), cf->segbc, fp);
@@ -371,7 +389,7 @@ static void Data_create(Cache *cf)
     if (fd == -1) {
         lprintf(fatal, "open(): %s\n", strerror(errno));
     }
-    if (ftruncate(fd, cf->content_length)) {
+    if (ftruncate(fd, (off_t)cf->link->content_length)) {
         lprintf(warning, "ftruncate(): %s\n", strerror(errno));
     }
     if (close(fd)) {
@@ -434,8 +452,8 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
     /*
      * Calculate how much to read
      */
-    if (offset + len > cf->content_length) {
-        len -= offset + len - cf->content_length;
+    if (offset + len > (off_t)cf->link->content_length) {
+        len -= offset + len - (off_t)cf->link->content_length;
         if (len < 0) {
             goto end;
         }
@@ -623,10 +641,6 @@ static void Cache_free(Cache *cf)
         FREE(cf->seg);
     }
 
-    if (cf->fs_path) {
-        FREE(cf->fs_path);
-    }
-
     ActiveDownload *ad = cf->active_dls;
     while (ad) {
         ActiveDownload *next = ad->next;
@@ -792,11 +806,10 @@ int Cache_create(const char *path)
     }
     Cache *cf = Cache_alloc();
     cf->path = STRNDUP(fn, PATH_MAX);
-    cf->time = this_link->time;
-    cf->content_length = this_link->content_length;
+    cf->link = this_link;
     cf->blksz = CONFIG.data_blksz;
-    cf->segbc = cf->content_length / cf->blksz;
-    if (cf->content_length % cf->blksz != 0) {
+    cf->segbc = this_link->content_length / cf->blksz;
+    if (this_link->content_length % cf->blksz != 0) {
         cf->segbc += 1;
     }
     cf->seg = CALLOC(cf->segbc, sizeof(Seg));
@@ -891,12 +904,6 @@ Cache *Cache_open(const char *fn)
          */
         Cache *cf = Cache_alloc();
 
-        /*
-         * Fill in the fs_path
-         */
-        cf->fs_path = CALLOC(PATH_MAX + 1, sizeof(char));
-        snprintf(cf->fs_path, PATH_MAX + 1, "%s", fn);
-
         cf->path = STRNDUP(actual_fn, PATH_MAX);
 
         /*
@@ -916,15 +923,12 @@ Cache *Cache_open(const char *fn)
             if (d_size < 0) {
                 lprintf(error, "cannot stat data file %s.\n", actual_fn);
                 ok = 0;
-            } else if (cf->content_length > d_size) {
+            } else if ((off_t)cf->link->content_length > d_size) {
                 lprintf(error,
                         "metadata inconsistency %s, "
-                        "cf->content_length: %jd, Data_size(fn): %jd.\n",
-                        actual_fn, (intmax_t)cf->content_length,
+                        "cf->link->content_length: %jd, Data_size(fn): %jd.\n",
+                        actual_fn, (intmax_t)cf->link->content_length,
                         (intmax_t)d_size);
-                ok = 0;
-            } else if (cf->time != cf->link->time) {
-                lprintf(warning, "outdated cache file: %s.\n", actual_fn);
                 ok = 0;
             } else if (Data_open(cf)) {
                 lprintf(error, "cannot open data file %s.\n", actual_fn);
@@ -1077,7 +1081,8 @@ static void *Cache_bgdl(void *arg)
 
     PTHREAD_MUTEX_LOCK(&cf->w_lock);
     if ((recv == cf->blksz)
-        || (dl_offset == (cf->content_length / cf->blksz * cf->blksz))) {
+        || (dl_offset
+            == ((off_t)cf->link->content_length / cf->blksz * cf->blksz))) {
         if (Data_write(cf, recv_buf, recv, dl_offset) == recv) {
             Seg_set(cf, dl_offset, 1);
         }
@@ -1279,7 +1284,8 @@ sync_dl:
         return recv;
     }
     if ((recv == cf->blksz)
-        || (dl_offset == (cf->content_length / cf->blksz * cf->blksz))) {
+        || (dl_offset
+            == ((off_t)cf->link->content_length / cf->blksz * cf->blksz))) {
         if (recv < (offset_start - dl_offset) + len) {
             lprintf(error,
                     "received %ld bytes, but required at least %ld bytes\n",
@@ -1329,7 +1335,7 @@ bgdl: {
 }
     off_t next_dl_offset = dl_offset + cf->blksz;
     int next_seg_missing = 0;
-    if (next_dl_offset < cf->content_length) {
+    if (next_dl_offset < (off_t)cf->link->content_length) {
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
         next_seg_missing = !Seg_exist(cf, next_dl_offset);
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);

--- a/src/cache.h
+++ b/src/cache.h
@@ -48,10 +48,6 @@ struct Cache {
     char *path;
     /** \brief the Link associated with this cache data set */
     Link *link;
-    /** \brief the modified time of the file */
-    long time;
-    /** \brief the size of the file */
-    off_t content_length;
     /** \brief the block size of the data file */
     int blksz;
     /** \brief segment array byte count */
@@ -73,9 +69,6 @@ struct Cache {
     pthread_cond_t dl_cond;
     /** \brief active downloads list */
     ActiveDownload *active_dls;
-
-    /** \brief the FUSE filesystem path to the remote file*/
-    char *fs_path;
 };
 
 /**

--- a/src/link.c
+++ b/src/link.c
@@ -1272,6 +1272,10 @@ static void Link_download_finish_transfer(Cache *cf, off_t offset,
 long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
                    Cache *cf)
 {
+    if (link->content_length == 0) {
+        return 0;
+    }
+
     TransferStruct ts = {0};
     TransferStruct header = {0};
     curl_off_t recv_sz;

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -1,9 +1,13 @@
 #include <unity.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include "../src/cache.h"
 #include "../src/config.h"
 #include "../src/util.h"
+#include "../src/link.h"
 
 void setUp(void)
 {
@@ -76,10 +80,170 @@ void test_ActiveDownload_find(void)
     TEST_ASSERT_NULL(ActiveDownload_find(&cf, 4096));
 }
 
+void test_Cache_read_zero_length(void)
+{
+    Cache cf = {0};
+    Link link = {0};
+    link.content_length = 0;
+    cf.link = &link;
+    cf.blksz = 4096;
+
+    char buf[10];
+    long res = Cache_read(&cf, buf, sizeof(buf), 0);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+void test_Cache_read_past_eof(void)
+{
+    Cache cf = {0};
+    Link link = {0};
+    link.content_length = 100;
+    cf.link = &link;
+    cf.blksz = 4096;
+
+    char buf[10];
+    long res = Cache_read(&cf, buf, sizeof(buf), 100);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = Cache_read(&cf, buf, sizeof(buf), 150);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+static void cleanup_temp_dir(const char *tmp_cache_dir)
+{
+    char filepath[512];
+
+    // Remove files
+    snprintf(filepath, sizeof(filepath), "%s/meta/file.bin", tmp_cache_dir);
+    (void)unlink(filepath);
+
+    snprintf(filepath, sizeof(filepath), "%s/data/file.bin", tmp_cache_dir);
+    (void)unlink(filepath);
+
+    // Remove directories
+    snprintf(filepath, sizeof(filepath), "%s/meta", tmp_cache_dir);
+    (void)rmdir(filepath);
+
+    snprintf(filepath, sizeof(filepath), "%s/data", tmp_cache_dir);
+    (void)rmdir(filepath);
+
+    (void)rmdir(tmp_cache_dir);
+}
+
+void test_Cache_invalid_zero_length_disk_files(void)
+{
+    // Set up a temp cache directory
+    const char *tmp_cache_dir = "./test_cache_invalidation_dir";
+    char meta_dir[256];
+    char data_dir[256];
+    snprintf(meta_dir, sizeof(meta_dir), "%s/meta", tmp_cache_dir);
+    snprintf(data_dir, sizeof(data_dir), "%s/data", tmp_cache_dir);
+
+    // Make sure they exist and are empty
+    cleanup_temp_dir(tmp_cache_dir);
+    TEST_ASSERT_EQUAL_INT(0, mkdir(tmp_cache_dir, 0700));
+    TEST_ASSERT_EQUAL_INT(0, mkdir(meta_dir, 0700));
+    TEST_ASSERT_EQUAL_INT(0, mkdir(data_dir, 0700));
+
+    // Store old CONFIG.cache_dir
+    char *old_cache_dir = CONFIG.cache_dir;
+    CONFIG.cache_dir = (char *)tmp_cache_dir;
+
+    // Set up a mock Link with a non-zero content_length
+    LinkTable *table = LinkTable_alloc("https://example.com/");
+    Link *link = CALLOC(1, sizeof(Link));
+    link->type = LINK_FILE;
+    link->content_length = 100;
+    link->parent_table = table;
+    strncpy(link->linkname, "file.bin", NAME_MAX);
+    strncpy(link->f_url, "https://example.com/file.bin", PATH_MAX);
+    LinkTable_add(table, link);
+
+    // Expose ROOT_LINK_TBL and ROOT_LINK_OFFSET
+    LinkTable *old_root_link_tbl = ROOT_LINK_TBL;
+    ROOT_LINK_TBL = table;
+    int old_root_link_offset = ROOT_LINK_OFFSET;
+    ROOT_LINK_OFFSET = 20;
+
+    // Initialize cache system with our temp directory
+    CacheSystem_init(tmp_cache_dir, 0);
+
+    // Scenario 1: Metadata file exists but is 0 bytes (empty)
+    char meta_filepath[512];
+    char data_filepath[512];
+    snprintf(meta_filepath, sizeof(meta_filepath), "%s/meta/file.bin",
+             tmp_cache_dir);
+    snprintf(data_filepath, sizeof(data_filepath), "%s/data/file.bin",
+             tmp_cache_dir);
+
+    // Touch both files to make them exist, meta is 0 bytes
+    FILE *f_meta = fopen(meta_filepath, "w");
+    TEST_ASSERT_NOT_NULL(f_meta);
+    fclose(f_meta);
+
+    FILE *f_data = fopen(data_filepath, "w");
+    TEST_ASSERT_NOT_NULL(f_data);
+    fclose(f_data);
+
+    // Now, call Cache_open. Since meta is empty, it is invalid.
+    // Cache_open should detect this invalid/corrupted cache, delete it,
+    // and recreate a fresh cache which should succeed and have a correct
+    // non-zero size.
+    Cache *cf = Cache_open("file.bin");
+    TEST_ASSERT_NOT_NULL(cf);
+    TEST_ASSERT_NOT_NULL(cf->mfp);
+    TEST_ASSERT_NOT_NULL(cf->dfp);
+
+    // Verify that the recreated meta file is now not empty (it has valid
+    // metadata written)
+    struct stat st;
+    TEST_ASSERT_EQUAL_INT(0, stat(meta_filepath, &st));
+    TEST_ASSERT_TRUE(st.st_size > 0);
+
+    // Close the cache
+    Cache_close(cf);
+
+    // Scenario 2: Metadata file contains invalid zero-length/negative size
+    // Create invalid metadata file with disk_content_length = 0
+    f_meta = fopen(meta_filepath, "w");
+    TEST_ASSERT_NOT_NULL(f_meta);
+    off_t bad_len = 0;
+    int bad_blksz = 4096;
+    off_t bad_segbc = 0;
+    fwrite(&bad_len, sizeof(off_t), 1, f_meta);
+    fwrite(&bad_blksz, sizeof(int), 1, f_meta);
+    fwrite(&bad_segbc, sizeof(off_t), 1, f_meta);
+    fclose(f_meta);
+
+    // Re-open
+    cf = Cache_open("file.bin");
+    TEST_ASSERT_NOT_NULL(cf);
+    TEST_ASSERT_NOT_NULL(cf->mfp);
+    TEST_ASSERT_NOT_NULL(cf->dfp);
+
+    // Verify it was again invalidated, recreated, and now has a valid non-zero
+    // content_length
+    TEST_ASSERT_EQUAL_INT(0, stat(meta_filepath, &st));
+    TEST_ASSERT_TRUE(st.st_size > 0);
+
+    Cache_close(cf);
+
+    // Cleanup
+    ROOT_LINK_TBL = old_root_link_tbl;
+    ROOT_LINK_OFFSET = old_root_link_offset;
+    LinkTable_free(table);
+    CacheSystem_cleanup();
+    CONFIG.cache_dir = old_cache_dir;
+    cleanup_temp_dir(tmp_cache_dir);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_CacheSystem_get_cache_dir);
     RUN_TEST(test_ActiveDownload_find);
+    RUN_TEST(test_Cache_read_zero_length);
+    RUN_TEST(test_Cache_read_past_eof);
+    RUN_TEST(test_Cache_invalid_zero_length_disk_files);
     return UNITY_END();
 }

--- a/tests/test_link.c
+++ b/tests/test_link.c
@@ -17,19 +17,20 @@ void tearDown(void)
 
 void test_LinkTable_alloc(void)
 {
-    LinkTable *table = LinkTable_alloc("http://example.com/dir/");
+    LinkTable *table = LinkTable_alloc("https://example.com/dir/");
     TEST_ASSERT_NOT_NULL(table);
     TEST_ASSERT_EQUAL_INT(1, table->size); // Alloc adds the head link
     TEST_ASSERT_NOT_NULL(table->links);
     TEST_ASSERT_NOT_NULL(table->links[0]);
-    TEST_ASSERT_EQUAL_STRING("http://example.com/dir/", table->links[0]->f_url);
+    TEST_ASSERT_EQUAL_STRING("https://example.com/dir/",
+                             table->links[0]->f_url);
     TEST_ASSERT_EQUAL_STRING("", table->links[0]->linkname);
     LinkTable_free(table);
 }
 
 void test_LinkTable_add(void)
 {
-    LinkTable *table = LinkTable_alloc("http://example.com/dir/");
+    LinkTable *table = LinkTable_alloc("https://example.com/dir/");
     TEST_ASSERT_NOT_NULL(table);
     TEST_ASSERT_EQUAL_INT(1, table->size);
 
@@ -46,10 +47,29 @@ void test_LinkTable_add(void)
     LinkTable_free(table);
 }
 
+void test_Link_download_zero_length(void)
+{
+    Link link = {0};
+    link.content_length = 0;
+    link.type = LINK_FILE;
+    strncpy(link.linkname, "empty.txt", NAME_MAX);
+    strncpy(link.f_url, "https://example.com/empty.txt", PATH_MAX);
+
+    char buf[10];
+    memset(buf, 0xff, sizeof(buf));
+    long res = Link_download(&link, buf, sizeof(buf), 0, NULL);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    for (size_t i = 0; i < sizeof(buf); i++) {
+        TEST_ASSERT_EQUAL_HEX8(0xff, (unsigned char)buf[i]);
+    }
+}
+
 int main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_LinkTable_alloc);
     RUN_TEST(test_LinkTable_add);
+    RUN_TEST(test_Link_download_zero_length);
     return UNITY_END();
 }


### PR DESCRIPTION
This pull request refactors the caching metadata structure to prioritize `struct Link` as the authoritative source of truth for remote file metadata, resolving structural redundancy between `struct Cache` and `struct Link`.

### Key Changes:
- **`struct Cache` Refinement**: Removed the duplicate `time` and `content_length` fields as well as the unused `fs_path` field.
- **Backwards Compatibility**: Updated `Meta_read` and `Meta_write` to read/write temporary stack variables (`disk_time` and `disk_content_length`) rather than cache struct fields. This maintains the exact on-disk binary format of the cache metadata files without breaking compatibility with existing caches on disk.
- **Reference Centralization**: Consolidated FUSE and internal cache size/time reference checks to fetch directly from `cf->link->content_length` and `cf->link->time`.
- **Validation**: All tests on both test-debug and optimized test builds compile and pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation of on-disk vs live metadata, preventing corrupted or inconsistent cache state; safer handling of zero-length content and out-of-range reads/writes.

* **Refactor**
  * Cache lifecycle simplified to rely on authoritative source sizing; background prefetch and read gating use live content size to avoid stale data.

* **Tests**
  * Added tests verifying zero-length reads and reads at/past EOF behave correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->