### PR TITLE
refactor: prioritize Link structure in cache metadata, improve macOS support, and harden cache boundary checks

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -758,11 +758,11 @@ void Cache_delete(const char *fn)
 
     char *metafn = path_append(META_DIR, fn);
     char *datafn = path_append(DATA_DIR, fn);
-    if (!access(metafn, F_OK) && unlink(metafn)) {
+    if (unlink(metafn) && errno != ENOENT) {
         lprintf(error, "unlink(): %s\n", strerror(errno));
     }
 
-    if (!access(datafn, F_OK) && unlink(datafn)) {
+    if (unlink(datafn) && errno != ENOENT) {
         lprintf(error, "unlink(): %s\n", strerror(errno));
     }
     FREE(metafn);

--- a/src/cache.c
+++ b/src/cache.c
@@ -358,7 +358,7 @@ static int Meta_write(Cache *cf)
      * cf->segbc must be strictly positive.
      */
     off_t write_content_length = (off_t)cf->link->content_length;
-    long expected_segbc = 0;
+    off_t expected_segbc = 0;
     if (cf->blksz > 0 && write_content_length > 0) {
         expected_segbc = write_content_length / cf->blksz;
         if (expected_segbc >= INT_MAX) {
@@ -866,11 +866,14 @@ int Cache_create(const char *path)
     cf->path = STRNDUP(fn, PATH_MAX);
     cf->link = this_link;
     cf->blksz = CONFIG.data_blksz;
-    cf->segbc = this_link->content_length / cf->blksz;
-    if (cf->segbc >= INT_MAX) {
+    size_t calculated_segbc = this_link->content_length / cf->blksz;
+    if (calculated_segbc >= INT_MAX) {
         cf->segbc = INT_MAX;
-    } else if (this_link->content_length % cf->blksz != 0) {
-        cf->segbc += 1;
+    } else {
+        cf->segbc = (long)calculated_segbc;
+        if (this_link->content_length % cf->blksz != 0) {
+            cf->segbc += 1;
+        }
     }
     cf->seg = CALLOC(cf->segbc, sizeof(Seg));
 
@@ -1464,6 +1467,12 @@ long Cache_read(Cache *cf, char *const output_buf, off_t len,
 {
     if (!cf || !cf->link) {
         lprintf(error, "Invalid cache or link in Cache_read\n");
+        return -EINVAL;
+    }
+
+    if (len < 0) {
+        lprintf(error, "requested to read negative bytes: %jd\n",
+                (intmax_t)len);
         return -EINVAL;
     }
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -277,12 +277,10 @@ static int Meta_read(Cache *cf)
 
     off_t max_segbc = disk_content_length / cf->blksz;
 
-    if ((disk_content_length % cf->blksz) != 0) {
-        max_segbc += 1;
-    }
-
-    if (max_segbc > INT_MAX) {
+    if (max_segbc >= INT_MAX) {
         max_segbc = INT_MAX;
+    } else if ((disk_content_length % cf->blksz) != 0) {
+        max_segbc += 1;
     }
 
     if (cf->segbc != max_segbc) {
@@ -363,11 +361,10 @@ static int Meta_write(Cache *cf)
     long expected_segbc = 0;
     if (cf->blksz > 0 && write_content_length > 0) {
         expected_segbc = write_content_length / cf->blksz;
-        if (write_content_length % cf->blksz != 0) {
-            expected_segbc += 1;
-        }
-        if (expected_segbc > INT_MAX) {
+        if (expected_segbc >= INT_MAX) {
             expected_segbc = INT_MAX;
+        } else if (write_content_length % cf->blksz != 0) {
+            expected_segbc += 1;
         }
     }
     if (write_content_length <= 0
@@ -489,10 +486,10 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
 
     long byte_read = 0;
 
-    if (offset < 0 || offset >= (off_t)cf->link->content_length) {
+    if (offset < 0 || offset >= total_len) {
         goto end;
-    } else if (len > (off_t)cf->link->content_length - offset) {
-        len = (off_t)cf->link->content_length - offset;
+    } else if (len > total_len - offset) {
+        len = total_len - offset;
     }
 
     /*
@@ -870,11 +867,10 @@ int Cache_create(const char *path)
     cf->link = this_link;
     cf->blksz = CONFIG.data_blksz;
     cf->segbc = this_link->content_length / cf->blksz;
-    if (this_link->content_length % cf->blksz != 0) {
-        cf->segbc += 1;
-    }
-    if (cf->segbc > INT_MAX) {
+    if (cf->segbc >= INT_MAX) {
         cf->segbc = INT_MAX;
+    } else if (this_link->content_length % cf->blksz != 0) {
+        cf->segbc += 1;
     }
     cf->seg = CALLOC(cf->segbc, sizeof(Seg));
 
@@ -1097,7 +1093,13 @@ void Cache_close(Cache *cf)
  */
 static int Seg_exist(Cache *cf, off_t offset)
 {
+    if (cf->segbc <= 0 || cf->blksz <= 0) {
+        return 0;
+    }
     off_t byte = offset / cf->blksz;
+    if (byte < 0 || byte >= cf->segbc) {
+        return 0;
+    }
     return cf->seg[byte];
 }
 
@@ -1110,7 +1112,13 @@ static int Seg_exist(Cache *cf, off_t offset)
  */
 static void Seg_set(Cache *cf, off_t offset, int i)
 {
+    if (cf->segbc <= 0 || cf->blksz <= 0) {
+        return;
+    }
     off_t byte = offset / cf->blksz;
+    if (byte < 0 || byte >= cf->segbc) {
+        return;
+    }
     cf->seg[byte] = i;
 }
 
@@ -1264,7 +1272,7 @@ static long Cache_read_segment(Cache *cf, char *const output_buf,
     }
 
     if (cf->link->content_length <= 0 || offset_start < 0
-        || offset_start >= (off_t)cf->link->content_length) {
+        || (size_t)offset_start >= cf->link->content_length) {
         return 0;
     }
 
@@ -1459,12 +1467,13 @@ long Cache_read(Cache *cf, char *const output_buf, off_t len,
         return -EINVAL;
     }
 
-    if (offset_start < 0 || offset_start >= (off_t)cf->link->content_length) {
+    if (offset_start < 0 || (size_t)offset_start >= cf->link->content_length) {
         return 0;
     }
 
-    if (len > (off_t)cf->link->content_length - offset_start) {
-        len = (off_t)cf->link->content_length - offset_start;
+    size_t remaining = cf->link->content_length - (size_t)offset_start;
+    if ((size_t)len > remaining) {
+        len = (off_t)remaining;
     }
 
     if (len <= 0) {

--- a/src/cache.c
+++ b/src/cache.c
@@ -225,8 +225,11 @@ static int Meta_read(Cache *cf)
         return EIO;
     }
 
-    if (1 != fread(&cf->time, sizeof(long), 1, fp)
-        || 1 != fread(&cf->content_length, sizeof(off_t), 1, fp)
+    long disk_time;
+    off_t disk_content_length;
+
+    if (1 != fread(&disk_time, sizeof(long), 1, fp)
+        || 1 != fread(&disk_content_length, sizeof(off_t), 1, fp)
         || 1 != fread(&cf->blksz, sizeof(int), 1, fp)
         || 1 != fread(&cf->segbc, sizeof(long), 1, fp) || ferror(fp)) {
         lprintf(error, "error reading core metadata %s!\n", cf->path);
@@ -234,10 +237,10 @@ static int Meta_read(Cache *cf)
     }
 
     /* These things really should not be zero! */
-    if (!cf->content_length || !cf->blksz || !cf->segbc) {
+    if (!disk_content_length || !cf->blksz || !cf->segbc) {
         lprintf(error,
                 "corruption: content_length: %jd, blksz: %d, segbc: %jd\n",
-                (intmax_t)cf->content_length, cf->blksz, (intmax_t)cf->segbc);
+                (intmax_t)disk_content_length, cf->blksz, (intmax_t)cf->segbc);
         return EBADMSG;
     }
 
@@ -245,19 +248,33 @@ static int Meta_read(Cache *cf)
         lprintf(warning, "Warning: cf->blksz != CONFIG.data_blksz\n");
     }
 
-    if (cf->content_length <= 0 || cf->blksz <= 0) {
+    if (disk_content_length <= 0 || cf->blksz <= 0) {
         lprintf(error, "Error: invalid metadata sizes\n");
         return EBADMSG;
     }
 
-    if (cf->content_length > INT64_MAX - cf->blksz) {
+    if (disk_content_length > INT64_MAX - cf->blksz) {
         lprintf(error, "Error: segbc upper bound overflow\n");
         return EBADMSG;
     }
 
-    off_t max_segbc = cf->content_length / cf->blksz;
+    /* Verify cached metadata matches the live Link metadata */
+    if (disk_time != cf->link->time) {
+        lprintf(warning, "outdated cache file: %s (disk: %ld, link: %ld)\n",
+                cf->path, disk_time, cf->link->time);
+        return EBADMSG;
+    }
 
-    if ((cf->content_length % cf->blksz) != 0) {
+    if (disk_content_length != (off_t)cf->link->content_length) {
+        lprintf(warning, "cache size mismatch: %s (disk: %jd, link: %zu)\n",
+                cf->path, (intmax_t)disk_content_length,
+                cf->link->content_length);
+        return EBADMSG;
+    }
+
+    off_t max_segbc = disk_content_length / cf->blksz;
+
+    if ((disk_content_length % cf->blksz) != 0) {
         max_segbc += 1;
     }
 
@@ -332,13 +349,14 @@ static int Meta_write(Cache *cf)
     /*
      * These things really should not be zero!
      */
-    if (!cf->content_length || !cf->blksz || !cf->segbc) {
+    off_t write_content_length = (off_t)cf->link->content_length;
+    if (!write_content_length || !cf->blksz || !cf->segbc) {
         lprintf(error, "content_length: %jd, blksz: %d, segbc: %jd\n",
-                (intmax_t)cf->content_length, cf->blksz, (intmax_t)cf->segbc);
+                (intmax_t)write_content_length, cf->blksz, (intmax_t)cf->segbc);
     }
 
-    fwrite(&cf->time, sizeof(long), 1, fp);
-    fwrite(&cf->content_length, sizeof(off_t), 1, fp);
+    fwrite(&cf->link->time, sizeof(long), 1, fp);
+    fwrite(&write_content_length, sizeof(off_t), 1, fp);
     fwrite(&cf->blksz, sizeof(int), 1, fp);
     fwrite(&cf->segbc, sizeof(long), 1, fp);
     fwrite(cf->seg, sizeof(Seg), cf->segbc, fp);
@@ -371,7 +389,7 @@ static void Data_create(Cache *cf)
     if (fd == -1) {
         lprintf(fatal, "open(): %s\n", strerror(errno));
     }
-    if (ftruncate(fd, cf->content_length)) {
+    if (ftruncate(fd, (off_t)cf->link->content_length)) {
         lprintf(warning, "ftruncate(): %s\n", strerror(errno));
     }
     if (close(fd)) {
@@ -434,8 +452,8 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
     /*
      * Calculate how much to read
      */
-    if (offset + len > cf->content_length) {
-        len -= offset + len - cf->content_length;
+    if (offset + len > (off_t)cf->link->content_length) {
+        len -= offset + len - (off_t)cf->link->content_length;
         if (len < 0) {
             goto end;
         }
@@ -623,10 +641,6 @@ static void Cache_free(Cache *cf)
         FREE(cf->seg);
     }
 
-    if (cf->fs_path) {
-        FREE(cf->fs_path);
-    }
-
     ActiveDownload *ad = cf->active_dls;
     while (ad) {
         ActiveDownload *next = ad->next;
@@ -792,11 +806,10 @@ int Cache_create(const char *path)
     }
     Cache *cf = Cache_alloc();
     cf->path = STRNDUP(fn, PATH_MAX);
-    cf->time = this_link->time;
-    cf->content_length = this_link->content_length;
+    cf->link = this_link;
     cf->blksz = CONFIG.data_blksz;
-    cf->segbc = cf->content_length / cf->blksz;
-    if (cf->content_length % cf->blksz != 0) {
+    cf->segbc = this_link->content_length / cf->blksz;
+    if (this_link->content_length % cf->blksz != 0) {
         cf->segbc += 1;
     }
     cf->seg = CALLOC(cf->segbc, sizeof(Seg));
@@ -891,12 +904,6 @@ Cache *Cache_open(const char *fn)
          */
         Cache *cf = Cache_alloc();
 
-        /*
-         * Fill in the fs_path
-         */
-        cf->fs_path = CALLOC(PATH_MAX + 1, sizeof(char));
-        snprintf(cf->fs_path, PATH_MAX + 1, "%s", fn);
-
         cf->path = STRNDUP(actual_fn, PATH_MAX);
 
         /*
@@ -916,15 +923,12 @@ Cache *Cache_open(const char *fn)
             if (d_size < 0) {
                 lprintf(error, "cannot stat data file %s.\n", actual_fn);
                 ok = 0;
-            } else if (cf->content_length > d_size) {
+            } else if ((off_t)cf->link->content_length > d_size) {
                 lprintf(error,
                         "metadata inconsistency %s, "
-                        "cf->content_length: %jd, Data_size(fn): %jd.\n",
-                        actual_fn, (intmax_t)cf->content_length,
+                        "cf->link->content_length: %jd, Data_size(fn): %jd.\n",
+                        actual_fn, (intmax_t)cf->link->content_length,
                         (intmax_t)d_size);
-                ok = 0;
-            } else if (cf->time != cf->link->time) {
-                lprintf(warning, "outdated cache file: %s.\n", actual_fn);
                 ok = 0;
             } else if (Data_open(cf)) {
                 lprintf(error, "cannot open data file %s.\n", actual_fn);
@@ -1077,7 +1081,8 @@ static void *Cache_bgdl(void *arg)
 
     PTHREAD_MUTEX_LOCK(&cf->w_lock);
     if ((recv == cf->blksz)
-        || (dl_offset == (cf->content_length / cf->blksz * cf->blksz))) {
+        || (dl_offset
+            == ((off_t)cf->link->content_length / cf->blksz * cf->blksz))) {
         if (Data_write(cf, recv_buf, recv, dl_offset) == recv) {
             Seg_set(cf, dl_offset, 1);
         }
@@ -1279,7 +1284,8 @@ sync_dl:
         return recv;
     }
     if ((recv == cf->blksz)
-        || (dl_offset == (cf->content_length / cf->blksz * cf->blksz))) {
+        || (dl_offset
+            == ((off_t)cf->link->content_length / cf->blksz * cf->blksz))) {
         if (recv < (offset_start - dl_offset) + len) {
             lprintf(error,
                     "received %ld bytes, but required at least %ld bytes\n",
@@ -1329,7 +1335,7 @@ bgdl: {
 }
     off_t next_dl_offset = dl_offset + cf->blksz;
     int next_seg_missing = 0;
-    if (next_dl_offset < cf->content_length) {
+    if (next_dl_offset < (off_t)cf->link->content_length) {
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
         next_seg_missing = !Seg_exist(cf, next_dl_offset);
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);

--- a/src/cache.c
+++ b/src/cache.c
@@ -1223,7 +1223,7 @@ retry:
      * slot is available (bgt_sem > 0). This acts as a throttle on concurrent
      * background prefetches.
      */
-    ret = sem_trywait(&cf->bgt_sem);
+    ret = SEM_TRYWAIT(&cf->bgt_sem);
     if (ret == 0) {
         PTHREAD_MUTEX_LOCK(&cf->dl_lock);
         /*
@@ -1335,7 +1335,7 @@ bgdl: {
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
     }
     if (next_seg_missing) {
-        ret = sem_trywait(&cf->bgt_sem);
+        ret = SEM_TRYWAIT(&cf->bgt_sem);
         if (!ret) {
             PTHREAD_MUTEX_LOCK(&cf->w_lock);
             next_seg_missing = !Seg_exist(cf, next_dl_offset);

--- a/src/cache.c
+++ b/src/cache.c
@@ -225,6 +225,11 @@ static int Meta_read(Cache *cf)
         return EIO;
     }
 
+    if (!cf->link) {
+        lprintf(error, "cf->link is NULL in Meta_read\n");
+        return EINVAL;
+    }
+
     long disk_time;
     off_t disk_content_length;
 
@@ -236,8 +241,11 @@ static int Meta_read(Cache *cf)
         return EIO;
     }
 
-    /* These things really should not be zero! */
-    if (!disk_content_length || !cf->blksz || !cf->segbc) {
+    /*
+     * We do not support zero-byte files in the on-disk cache files.
+     * Both disk_content_length and cf->segbc must be strictly positive.
+     */
+    if (disk_content_length <= 0 || cf->blksz <= 0 || cf->segbc <= 0) {
         lprintf(error,
                 "corruption: content_length: %jd, blksz: %d, segbc: %jd\n",
                 (intmax_t)disk_content_length, cf->blksz, (intmax_t)cf->segbc);
@@ -246,11 +254,6 @@ static int Meta_read(Cache *cf)
 
     if (cf->blksz != CONFIG.data_blksz) {
         lprintf(warning, "Warning: cf->blksz != CONFIG.data_blksz\n");
-    }
-
-    if (disk_content_length <= 0 || cf->blksz <= 0) {
-        lprintf(error, "Error: invalid metadata sizes\n");
-        return EBADMSG;
     }
 
     if (disk_content_length > INT64_MAX - cf->blksz) {
@@ -265,7 +268,7 @@ static int Meta_read(Cache *cf)
         return EBADMSG;
     }
 
-    if (disk_content_length != (off_t)cf->link->content_length) {
+    if ((uintmax_t)disk_content_length != (uintmax_t)cf->link->content_length) {
         lprintf(warning, "cache size mismatch: %s (disk: %jd, link: %zu)\n",
                 cf->path, (intmax_t)disk_content_length,
                 cf->link->content_length);
@@ -282,8 +285,9 @@ static int Meta_read(Cache *cf)
         max_segbc = INT_MAX;
     }
 
-    if (cf->segbc <= 0 || cf->segbc > max_segbc) {
-        lprintf(error, "Error: invalid segbc size: %ld\n", cf->segbc);
+    if (cf->segbc != max_segbc) {
+        lprintf(error, "Error: invalid segbc size: %ld (expected: %ld)\n",
+                cf->segbc, (long)max_segbc);
         return EBADMSG;
     }
 
@@ -346,13 +350,35 @@ static int Meta_write(Cache *cf)
         return -1;
     }
 
+    if (!cf->link) {
+        lprintf(error, "cf->link is NULL in Meta_write\n");
+        return -1;
+    }
+
     /*
-     * These things really should not be zero!
+     * We do not support zero-byte files. Both write_content_length and
+     * cf->segbc must be strictly positive.
      */
     off_t write_content_length = (off_t)cf->link->content_length;
-    if (!write_content_length || !cf->blksz || !cf->segbc) {
-        lprintf(error, "content_length: %jd, blksz: %d, segbc: %jd\n",
-                (intmax_t)write_content_length, cf->blksz, (intmax_t)cf->segbc);
+    long expected_segbc = 0;
+    if (cf->blksz > 0 && write_content_length > 0) {
+        expected_segbc = write_content_length / cf->blksz;
+        if (write_content_length % cf->blksz != 0) {
+            expected_segbc += 1;
+        }
+        if (expected_segbc > INT_MAX) {
+            expected_segbc = INT_MAX;
+        }
+    }
+    if (write_content_length <= 0
+        || (size_t)write_content_length != cf->link->content_length
+        || cf->blksz <= 0 || cf->segbc != expected_segbc || cf->segbc <= 0) {
+        lprintf(error,
+                "invalid metadata for write: content_length: %jd, blksz: %d, "
+                "segbc: %ld (expected: %ld)\n",
+                (intmax_t)write_content_length, cf->blksz, cf->segbc,
+                expected_segbc);
+        return -1;
     }
 
     fwrite(&cf->link->time, sizeof(long), 1, fp);
@@ -389,7 +415,16 @@ static void Data_create(Cache *cf)
     if (fd == -1) {
         lprintf(fatal, "open(): %s\n", strerror(errno));
     }
-    if (ftruncate(fd, (off_t)cf->link->content_length)) {
+    if (!cf->link) {
+        lprintf(fatal, "cf->link is NULL in Data_create\n");
+    }
+    off_t truncate_size = (off_t)cf->link->content_length;
+    if (truncate_size < 0
+        || (size_t)truncate_size != cf->link->content_length) {
+        lprintf(fatal, "File size too large for system off_t: %zu\n",
+                cf->link->content_length);
+    }
+    if (ftruncate(fd, truncate_size)) {
         lprintf(warning, "ftruncate(): %s\n", strerror(errno));
     }
     if (close(fd)) {
@@ -426,6 +461,23 @@ static off_t Data_size(const char *fn)
  */
 static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
 {
+    if (!cf->link) {
+        lprintf(error, "cf->link is NULL in Data_read\n");
+        return -EINVAL;
+    }
+
+    off_t total_len = (off_t)cf->link->content_length;
+    if (total_len < 0 || (size_t)total_len != cf->link->content_length) {
+        lprintf(error, "content_length overflow in Data_read\n");
+        return -EINVAL;
+    }
+
+    if (len < 0) {
+        lprintf(error, "requested to read negative bytes: %jd\n",
+                (intmax_t)len);
+        return -EINVAL;
+    }
+
     if (len == 0) {
         lprintf(error, "requested to read 0 byte!\n");
         return -EINVAL;
@@ -437,6 +489,12 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
 
     long byte_read = 0;
 
+    if (offset < 0 || offset >= (off_t)cf->link->content_length) {
+        goto end;
+    } else if (len > (off_t)cf->link->content_length - offset) {
+        len = (off_t)cf->link->content_length - offset;
+    }
+
     /*
      * Seek to the right location
      */
@@ -447,16 +505,6 @@ static long Data_read(Cache *cf, uint8_t *buf, off_t len, off_t offset)
         lprintf(error, "fseeko(): %s\n", strerror(errno));
         byte_read = -EIO;
         goto end;
-    }
-
-    /*
-     * Calculate how much to read
-     */
-    if (offset + len > (off_t)cf->link->content_length) {
-        len -= offset + len - (off_t)cf->link->content_length;
-        if (len < 0) {
-            goto end;
-        }
     }
 
     byte_read = fread(buf, sizeof(uint8_t), len, cf->dfp);
@@ -495,11 +543,10 @@ end:
  */
 static long Data_write(Cache *cf, const uint8_t *buf, off_t len, off_t offset)
 {
-    if (len == 0) {
-        /*
-         * We should permit empty files
-         */
-        return 0;
+    if (len <= 0) {
+        lprintf(error, "requested to write 0 or negative bytes: %jd\n",
+                (intmax_t)len);
+        return -EINVAL;
     }
 
     lprintf(cache_lock_debug, "thread %lx: locking seek_lock;\n",
@@ -665,21 +712,29 @@ static int Cache_exist(const char *fn)
 {
     char *metafn = path_append(META_DIR, fn);
     char *datafn = path_append(DATA_DIR, fn);
-    /*
-     * access() returns 0 on success
-     */
-    int no_meta = access(metafn, F_OK);
-    int no_data = access(datafn, F_OK);
 
-    if (no_meta ^ no_data) {
-        lprintf(warning, "Cache file partially missing.\n");
-        if (no_meta) {
-            if (unlink(datafn)) {
+    struct stat metast;
+    struct stat datast;
+    int no_meta = stat(metafn, &metast);
+    int no_data = stat(datafn, &datast);
+
+    if (no_meta == 0 && metast.st_size == 0) {
+        no_meta = -1;
+    }
+    if (no_data == 0 && datast.st_size == 0) {
+        no_data = -1;
+    }
+
+    if ((no_meta == 0) != (no_data == 0)) {
+        lprintf(warning,
+                "Cache file partially missing or invalid (zero-length).\n");
+        if (no_meta != 0) {
+            if (unlink(datafn) && errno != ENOENT) {
                 lprintf(fatal, "unlink(): %s\n", strerror(errno));
             }
         }
-        if (no_data) {
-            if (unlink(metafn)) {
+        if (no_data != 0) {
+            if (unlink(metafn) && errno != ENOENT) {
                 lprintf(fatal, "unlink(): %s\n", strerror(errno));
             }
         }
@@ -688,7 +743,7 @@ static int Cache_exist(const char *fn)
     FREE(metafn);
     FREE(datafn);
 
-    return no_meta | no_data;
+    return (no_meta != 0) || (no_data != 0);
 }
 
 /**
@@ -792,6 +847,12 @@ int Cache_create(const char *path)
         return 1;
     }
 
+    if (this_link->content_length <= 0) {
+        lprintf(error, "Zero-length files are not supported in cache system\n");
+        LinkTable_unref(this_link->parent_table);
+        return 1;
+    }
+
     char *fn;
 
     if (CONFIG.mode == NORMAL) {
@@ -811,6 +872,9 @@ int Cache_create(const char *path)
     cf->segbc = this_link->content_length / cf->blksz;
     if (this_link->content_length % cf->blksz != 0) {
         cf->segbc += 1;
+    }
+    if (cf->segbc > INT_MAX) {
+        cf->segbc = INT_MAX;
     }
     cf->seg = CALLOC(cf->segbc, sizeof(Seg));
 
@@ -884,6 +948,15 @@ Cache *Cache_open(const char *fn)
         actual_fn = link->sonic.id;
     }
 
+    if (link->content_length <= 0) {
+        lprintf(error, "Zero-length files are not supported in cache system\n");
+        lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
+                (unsigned long)pthread_self());
+        PTHREAD_MUTEX_UNLOCK(&cf_lock);
+        LinkTable_unref(link->parent_table);
+        return NULL;
+    }
+
     // Try up to 2 times. If opening fails on the first attempt (outdated,
     // corrupt, etc.), we delete the cache and try creating and opening a fresh
     // one.
@@ -923,7 +996,8 @@ Cache *Cache_open(const char *fn)
             if (d_size < 0) {
                 lprintf(error, "cannot stat data file %s.\n", actual_fn);
                 ok = 0;
-            } else if ((off_t)cf->link->content_length > d_size) {
+            } else if ((uintmax_t)cf->link->content_length
+                       > (uintmax_t)d_size) {
                 lprintf(error,
                         "metadata inconsistency %s, "
                         "cf->link->content_length: %jd, Data_size(fn): %jd.\n",
@@ -994,15 +1068,15 @@ void Cache_close(Cache *cf)
             (unsigned long)pthread_self(), cf->path);
     SEM_WAIT(&cf->bgt_sem);
 
-    if (Meta_write(cf)) {
+    if (cf->mfp && Meta_write(cf)) {
         lprintf(error, "Meta_write() error.");
     }
 
-    if (fclose(cf->mfp)) {
+    if (cf->mfp && fclose(cf->mfp)) {
         lprintf(error, "cannot close metadata: %s.\n", strerror(errno));
     }
 
-    if (fclose(cf->dfp)) {
+    if (cf->dfp && fclose(cf->dfp)) {
         lprintf(error, "cannot close data file %s.\n", strerror(errno));
     }
 
@@ -1081,8 +1155,9 @@ static void *Cache_bgdl(void *arg)
 
     PTHREAD_MUTEX_LOCK(&cf->w_lock);
     if ((recv == cf->blksz)
-        || (dl_offset
-            == ((off_t)cf->link->content_length / cf->blksz * cf->blksz))) {
+        || ((uintmax_t)dl_offset
+            == (cf->link->content_length / (size_t)cf->blksz
+                * (size_t)cf->blksz))) {
         if (Data_write(cf, recv_buf, recv, dl_offset) == recv) {
             Seg_set(cf, dl_offset, 1);
         }
@@ -1183,6 +1258,16 @@ static void Cache_bgdl_launcher(Cache *cf, off_t dl_offset)
 static long Cache_read_segment(Cache *cf, char *const output_buf,
                                const off_t len, const off_t offset_start)
 {
+    if (!cf->link) {
+        lprintf(error, "cf->link is NULL in Cache_read_segment\n");
+        return -EINVAL;
+    }
+
+    if (cf->link->content_length <= 0 || offset_start < 0
+        || offset_start >= (off_t)cf->link->content_length) {
+        return 0;
+    }
+
     long send;
     off_t dl_offset = offset_start / cf->blksz * cf->blksz;
     int ret;
@@ -1284,8 +1369,9 @@ sync_dl:
         return recv;
     }
     if ((recv == cf->blksz)
-        || (dl_offset
-            == ((off_t)cf->link->content_length / cf->blksz * cf->blksz))) {
+        || ((uintmax_t)dl_offset
+            == (cf->link->content_length / (size_t)cf->blksz
+                * (size_t)cf->blksz))) {
         if (recv < (offset_start - dl_offset) + len) {
             lprintf(error,
                     "received %ld bytes, but required at least %ld bytes\n",
@@ -1335,7 +1421,7 @@ bgdl: {
 }
     off_t next_dl_offset = dl_offset + cf->blksz;
     int next_seg_missing = 0;
-    if (next_dl_offset < (off_t)cf->link->content_length) {
+    if ((uintmax_t)next_dl_offset < (uintmax_t)cf->link->content_length) {
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
         next_seg_missing = !Seg_exist(cf, next_dl_offset);
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1368,6 +1454,23 @@ bgdl: {
 long Cache_read(Cache *cf, char *const output_buf, off_t len,
                 const off_t offset_start)
 {
+    if (!cf || !cf->link) {
+        lprintf(error, "Invalid cache or link in Cache_read\n");
+        return -EINVAL;
+    }
+
+    if (offset_start < 0 || offset_start >= (off_t)cf->link->content_length) {
+        return 0;
+    }
+
+    if (len > (off_t)cf->link->content_length - offset_start) {
+        len = (off_t)cf->link->content_length - offset_start;
+    }
+
+    if (len <= 0) {
+        return 0;
+    }
+
     off_t send = 0;
     for (off_t start = offset_start, end; len > 0;
          len -= end - start, start = end) {
@@ -1381,6 +1484,9 @@ long Cache_read(Cache *cf, char *const output_buf, off_t len,
             return seg_send;
         }
         send += seg_send;
+        if (seg_send < end - start) {
+            break;
+        }
     }
     return send;
 }

--- a/src/cache.h
+++ b/src/cache.h
@@ -50,10 +50,6 @@ struct Cache {
     char *path;
     /** \brief the Link associated with this cache data set */
     Link *link;
-    /** \brief the modified time of the file */
-    long time;
-    /** \brief the size of the file */
-    off_t content_length;
     /** \brief the block size of the data file */
     int blksz;
     /** \brief segment array byte count */
@@ -75,9 +71,6 @@ struct Cache {
     pthread_cond_t dl_cond;
     /** \brief active downloads list */
     ActiveDownload *active_dls;
-
-    /** \brief the FUSE filesystem path to the remote file*/
-    char *fs_path;
 };
 
 /**

--- a/src/cache.h
+++ b/src/cache.h
@@ -15,6 +15,8 @@ typedef struct Cache Cache;
 #include "link.h"
 #include "network.h"
 
+#include "util.h"
+
 struct TransferStruct;
 
 typedef struct ActiveDownload {
@@ -65,7 +67,7 @@ struct Cache {
     pthread_mutex_t w_lock;
 
     /** \brief semaphore for the background thread */
-    sem_t bgt_sem;
+    sys_sem_t bgt_sem;
 
     /** \brief mutex lock for background download progress */
     pthread_mutex_t dl_lock;

--- a/src/fuse_local.c
+++ b/src/fuse_local.c
@@ -89,8 +89,13 @@ static int fs_read(const char *path, char *buf, size_t size, off_t offset,
                    struct fuse_file_info *fi)
 {
     long received;
-    if (CACHE_SYSTEM_INIT && fi->fh) {
-        received = Cache_read((Cache *)fi->fh, buf, size, offset);
+    if (CACHE_SYSTEM_INIT) {
+        if (fi->fh) {
+            received = Cache_read((Cache *)fi->fh, buf, size, offset);
+        } else {
+            /* zero-length file: fi->fh was set to 0 in fs_open; return EOF */
+            received = 0;
+        }
     } else {
         received = path_download(path, buf, size, offset);
     }

--- a/src/fuse_local.c
+++ b/src/fuse_local.c
@@ -29,7 +29,7 @@ static int fs_release(const char *path, struct fuse_file_info *fi)
 {
     lprintf(info, "%s\n", path);
     (void)path;
-    if (CACHE_SYSTEM_INIT) {
+    if (CACHE_SYSTEM_INIT && fi->fh) {
         Cache_close((Cache *)fi->fh);
     }
     return 0;
@@ -89,7 +89,7 @@ static int fs_read(const char *path, char *buf, size_t size, off_t offset,
                    struct fuse_file_info *fi)
 {
     long received;
-    if (CACHE_SYSTEM_INIT) {
+    if (CACHE_SYSTEM_INIT && fi->fh) {
         received = Cache_read((Cache *)fi->fh, buf, size, offset);
     } else {
         received = path_download(path, buf, size, offset);
@@ -110,6 +110,11 @@ static int fs_open(const char *path, struct fuse_file_info *fi)
         return -EROFS;
     }
     if (CACHE_SYSTEM_INIT) {
+        if (link->content_length == 0) {
+            fi->fh = 0; /* valid empty file: bypass cache creation */
+            LinkTable_unref(link->parent_table);
+            return 0;
+        }
         fi->fh = (uint64_t)Cache_open(path);
         /*
          * The cache definitely cannot be opened for some reason.

--- a/src/link.c
+++ b/src/link.c
@@ -1280,12 +1280,12 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
     TransferStruct header = {0};
     curl_off_t recv_sz;
 
-    size_t request_end = offset + req_size;
-    if (request_end > link->content_length) {
-        lprintf(info, "requested size larger than remaining size, request_end: \
-%lu, content-length: %ld\n",
-                request_end, link->content_length);
-        req_size = link->content_length - offset;
+    size_t remaining = link->content_length - (size_t)offset;
+    if (req_size > remaining) {
+        lprintf(info, "requested size larger than remaining size, req_size: \
+%zu, remaining: %zu\n",
+                req_size, remaining);
+        req_size = remaining;
     }
 
     do {

--- a/src/link.c
+++ b/src/link.c
@@ -27,7 +27,7 @@ int ROOT_LINK_OFFSET = 0;
  * \details This allows LinkTable generation to be run exclusively. This
  * effectively gives LinkTable generation priority over file transfer.
  */
-static pthread_mutex_t link_lock;
+static pthread_mutex_t link_lock = PTHREAD_MUTEX_INITIALIZER;
 static void make_link_relative(const char *page_url, char *link_url);
 
 /**
@@ -316,7 +316,6 @@ static LinkTable *single_LinkTable_new(const char *url)
 
 LinkTable *LinkSystem_init(const char *url)
 {
-    PTHREAD_MUTEX_INIT(&link_lock, NULL);
     size_t len = strnlen(url, PATH_MAX);
     /*
      * --------- Set the length of the root link -----------

--- a/src/link.c
+++ b/src/link.c
@@ -1271,6 +1271,11 @@ static void Link_download_finish_transfer(Cache *cf, off_t offset,
 long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
                    Cache *cf)
 {
+    if (req_size == 0 || link->content_length == 0 || offset < 0
+        || (size_t)offset >= link->content_length) {
+        return 0;
+    }
+
     TransferStruct ts = {0};
     TransferStruct header = {0};
     curl_off_t recv_sz;

--- a/src/util.c
+++ b/src/util.c
@@ -134,7 +134,138 @@ void pthread_mutex_lock_wrapper(const char *file, const char *func, int line,
     }
 }
 
-void sem_init_wrapper(sem_t *sem, int pshared, unsigned int value,
+#ifdef __APPLE__
+
+void sem_init_wrapper(sys_sem_t *sem, int pshared, unsigned int value,
+                      const char *file, const char *func, int line)
+{
+    (void)pshared;
+    int ret = pthread_mutex_init(&sem->mutex, NULL);
+    if (ret) {
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_mutex_init for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), ret, strerror(ret));
+    }
+    ret = pthread_cond_init(&sem->cond, NULL);
+    if (ret) {
+        pthread_mutex_destroy(&sem->mutex);
+        fatal_log_printf(file, func, line,
+                         "%lx pthread_cond_init for semaphore failed: %d, %s\n",
+                         (unsigned long)pthread_self(), ret, strerror(ret));
+    }
+    sem->count = (int)value;
+}
+
+void sem_destroy_wrapper(sys_sem_t *sem, const char *file, const char *func,
+                         int line)
+{
+    int ret = pthread_mutex_destroy(&sem->mutex);
+    if (ret) {
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_mutex_destroy for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), ret, strerror(ret));
+    }
+    ret = pthread_cond_destroy(&sem->cond);
+    if (ret) {
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_cond_destroy for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), ret, strerror(ret));
+    }
+}
+
+void sem_wait_wrapper(const char *file, const char *func, int line,
+                      sys_sem_t *sem)
+{
+    int ret = pthread_mutex_lock(&sem->mutex);
+    if (ret) {
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_mutex_lock for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), ret, strerror(ret));
+    }
+    while (sem->count <= 0) {
+        ret = pthread_cond_wait(&sem->cond, &sem->mutex);
+        if (ret) {
+            pthread_mutex_unlock(&sem->mutex);
+            fatal_log_printf(
+                file, func, line,
+                "%lx pthread_cond_wait for semaphore failed: %d, %s\n",
+                (unsigned long)pthread_self(), ret, strerror(ret));
+        }
+    }
+    sem->count--;
+    ret = pthread_mutex_unlock(&sem->mutex);
+    if (ret) {
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_mutex_unlock for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), ret, strerror(ret));
+    }
+}
+
+void sem_post_wrapper(const char *file, const char *func, int line,
+                      sys_sem_t *sem)
+{
+    int ret = pthread_mutex_lock(&sem->mutex);
+    if (ret) {
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_mutex_lock for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), ret, strerror(ret));
+    }
+    sem->count++;
+    ret = pthread_cond_signal(&sem->cond);
+    if (ret) {
+        pthread_mutex_unlock(&sem->mutex);
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_cond_signal for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), ret, strerror(ret));
+    }
+    ret = pthread_mutex_unlock(&sem->mutex);
+    if (ret) {
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_mutex_unlock for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), ret, strerror(ret));
+    }
+}
+
+int sys_sem_trywait_wrapper(const char *file, const char *func, int line,
+                            sys_sem_t *sem)
+{
+    int ret = 0;
+    int err = pthread_mutex_lock(&sem->mutex);
+    if (err) {
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_mutex_lock for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), err, strerror(err));
+    }
+    if (sem->count > 0) {
+        sem->count--;
+    } else {
+        ret = -1;
+    }
+    err = pthread_mutex_unlock(&sem->mutex);
+    if (err) {
+        fatal_log_printf(
+            file, func, line,
+            "%lx pthread_mutex_unlock for semaphore failed: %d, %s\n",
+            (unsigned long)pthread_self(), err, strerror(err));
+    }
+    if (ret == -1) {
+        errno = EAGAIN;
+    }
+    return ret;
+}
+
+#else
+
+void sem_init_wrapper(sys_sem_t *sem, int pshared, unsigned int value,
                       const char *file, const char *func, int line)
 {
     int i;
@@ -147,7 +278,7 @@ void sem_init_wrapper(sem_t *sem, int pshared, unsigned int value,
     }
 }
 
-void sem_destroy_wrapper(sem_t *sem, const char *file, const char *func,
+void sem_destroy_wrapper(sys_sem_t *sem, const char *file, const char *func,
                          int line)
 {
     int i;
@@ -160,7 +291,8 @@ void sem_destroy_wrapper(sem_t *sem, const char *file, const char *func,
     }
 }
 
-void sem_wait_wrapper(const char *file, const char *func, int line, sem_t *sem)
+void sem_wait_wrapper(const char *file, const char *func, int line,
+                      sys_sem_t *sem)
 {
     int i;
     i = sem_wait(sem);
@@ -172,7 +304,8 @@ void sem_wait_wrapper(const char *file, const char *func, int line, sem_t *sem)
     }
 }
 
-void sem_post_wrapper(const char *file, const char *func, int line, sem_t *sem)
+void sem_post_wrapper(const char *file, const char *func, int line,
+                      sys_sem_t *sem)
 {
     int i;
     i = sem_post(sem);
@@ -183,6 +316,23 @@ void sem_post_wrapper(const char *file, const char *func, int line, sem_t *sem)
                          strerror(saved_errno));
     }
 }
+
+int sys_sem_trywait_wrapper(const char *file, const char *func, int line,
+                            sys_sem_t *sem)
+{
+    int i = sem_trywait(sem);
+    if (i) {
+        int saved_errno = errno;
+        if (saved_errno != EAGAIN) {
+            fatal_log_printf(file, func, line, "%lx sem_trywait: %d, %s\n",
+                             (unsigned long)pthread_self(), saved_errno,
+                             strerror(saved_errno));
+        }
+    }
+    return i;
+}
+
+#endif
 
 void pthread_cond_init_wrapper(pthread_cond_t *cond,
                                const pthread_condattr_t *attr, const char *file,

--- a/src/util.h
+++ b/src/util.h
@@ -8,6 +8,16 @@
 #include <pthread.h>
 #include <semaphore.h>
 #include <stdint.h>
+
+#ifdef __APPLE__
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int count;
+} sys_sem_t;
+#else
+typedef sem_t sys_sem_t;
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -56,7 +66,7 @@ void pthread_mutex_unlock_wrapper(const char *file, const char *func, int line,
 /**
  * \brief wrapper for sem_init(), with error handling
  * */
-void sem_init_wrapper(sem_t *sem, int pshared, unsigned int value,
+void sem_init_wrapper(sys_sem_t *sem, int pshared, unsigned int value,
                       const char *file, const char *func, int line);
 #define SEM_INIT(sem, pshared, value)                                          \
     sem_init_wrapper(sem, pshared, value, __FILE__, __func__, __LINE__)
@@ -64,21 +74,32 @@ void sem_init_wrapper(sem_t *sem, int pshared, unsigned int value,
 /**
  * \brief wrapper for sem_destroy(), with error handling
  */
-void sem_destroy_wrapper(sem_t *sem, const char *file, const char *func,
+void sem_destroy_wrapper(sys_sem_t *sem, const char *file, const char *func,
                          int line);
 #define SEM_DESTROY(sem) sem_destroy_wrapper(sem, __FILE__, __func__, __LINE__)
 
 /**
  * \brief wrapper for sem_wait(), with error handling
  */
-void sem_wait_wrapper(const char *file, const char *func, int line, sem_t *sem);
+void sem_wait_wrapper(const char *file, const char *func, int line,
+                      sys_sem_t *sem);
 #define SEM_WAIT(sem) sem_wait_wrapper(__FILE__, __func__, __LINE__, sem)
 
 /**
  * \brief wrapper for sem_post(), with error handling
  */
-void sem_post_wrapper(const char *file, const char *func, int line, sem_t *sem);
+void sem_post_wrapper(const char *file, const char *func, int line,
+                      sys_sem_t *sem);
 #define SEM_POST(sem) sem_post_wrapper(__FILE__, __func__, __LINE__, sem)
+
+/**
+ * \brief wrapper for sem_trywait(), with cross-platform support and error
+ * handling
+ */
+int sys_sem_trywait_wrapper(const char *file, const char *func, int line,
+                            sys_sem_t *sem);
+#define SEM_TRYWAIT(sem)                                                       \
+    sys_sem_trywait_wrapper(__FILE__, __func__, __LINE__, sem)
 
 /**
  * \brief wrapper for pthread_cond_init(), with error handling

--- a/tests/integration/generate_test_files.py
+++ b/tests/integration/generate_test_files.py
@@ -138,6 +138,22 @@ def main():
         test_files.append(("empty_file.txt", 0))
         test_files.append(("tiny.txt", 1))
 
+        # Zero-length files with varied names to exercise the fi->fh=0 bypass
+        # path through every special-character category.
+        zero_length_names = [
+            "zero_basic.txt",
+            "zero file with spaces.txt",
+            "zero-dashes.bin",
+            "zero_underscores.bin",
+            "zero.multiple.dots.bin",
+            "zero(parens).txt",
+            "zero[brackets].txt",
+            "zero@at.txt",
+            "zero" + "a" * 50 + ".txt",   # moderately long name
+        ]
+        for name in zero_length_names:
+            test_files.append((name, 0))
+
     # Add the 1 GB file for cache system testing when is_large is given
     if is_large:
         test_files.append(("large_1g.bin", 1024 * 1024 * 1024))

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -347,6 +347,63 @@ else
     skip "Tiny file not found"
 fi
 
+# 4f-extra. Test: Zero-length files with varied special-character names
+log_info "Test group: Zero-length files (varied names)"
+
+# Build the list from the manifest: all files whose size is 0
+ZERO_FILES_LIST=$(python3 -c "
+import json
+with open('${MANIFEST}') as f:
+    m = json.load(f)
+for name, info in sorted(m.items()):
+    if info['size'] == 0:
+        print(name)
+")
+
+ZERO_FILE_COUNT=0
+while IFS= read -r zf_name; do
+    [[ -z "${zf_name}" ]] && continue
+    ZERO_FILE_COUNT=$((ZERO_FILE_COUNT + 1))
+    target="${MOUNT_DIR}/${zf_name}"
+
+    # Existence
+    if [[ ! -e "${target}" ]]; then
+        fail "Zero-length file missing: ${zf_name}"
+        continue
+    fi
+
+    # Size must be 0
+    zf_size=$(stat -c%s "${target}" 2>/dev/null || echo "-1")
+    if [[ "${zf_size}" == "0" ]]; then
+        pass "Zero-length size correct: ${zf_name}"
+    else
+        fail "Zero-length size wrong (got ${zf_size}): ${zf_name}"
+    fi
+
+    # Reading must yield empty content (no hang, no error)
+    zf_content=$(cat "${target}" 2>/dev/null)
+    if [[ -z "${zf_content}" ]]; then
+        pass "Zero-length content empty: ${zf_name}"
+    else
+        fail "Zero-length file has unexpected content: ${zf_name}"
+    fi
+
+    # SHA-256 of an empty file is the well-known constant
+    EMPTY_SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    zf_sha=$(sha256sum "${target}" 2>/dev/null | awk '{print $1}')
+    if [[ "${zf_sha}" == "${EMPTY_SHA256}" ]]; then
+        pass "Zero-length checksum OK: ${zf_name}"
+    else
+        fail "Zero-length checksum mismatch: ${zf_name} (got ${zf_sha})"
+    fi
+done <<< "${ZERO_FILES_LIST}"
+
+if [[ "${ZERO_FILE_COUNT}" -eq 0 ]]; then
+    skip "No zero-length files found in manifest"
+else
+    log_info "Tested ${ZERO_FILE_COUNT} zero-length file(s)."
+fi
+
 # 4f. Test: Subdirectory is readable
 SUBDIR="${MOUNT_DIR}/subdir with spaces"
 if [[ -d "${SUBDIR}" ]]; then
@@ -465,10 +522,64 @@ else
             log_error "  actual:   ${actual_sha256}"
         fi
 
+        # Test: Zero-length files in cache mode (run once — not block-size
+        # dependent, but checked here to confirm the fi->fh=0 bypass works
+        # when the cache system is active).
+        if [[ "${BLKSZ}" == "8" ]]; then
+            log_info "Test group: Zero-length files in cache mode"
+            CACHE_ZERO_FILES_LIST=$(python3 -c "
+import json
+with open('${MANIFEST}') as f:
+    m = json.load(f)
+for name, info in sorted(m.items()):
+    if info['size'] == 0:
+        print(name)
+")
+            CACHE_ZERO_COUNT=0
+            EMPTY_SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            while IFS= read -r czf_name; do
+                [[ -z "${czf_name}" ]] && continue
+                CACHE_ZERO_COUNT=$((CACHE_ZERO_COUNT + 1))
+                czf_target="${CACHE_MOUNT_DIR}/${czf_name}"
+
+                if [[ ! -e "${czf_target}" ]]; then
+                    fail "Cache: zero-length file missing: ${czf_name}"
+                    continue
+                fi
+
+                czf_size=$(stat -c%s "${czf_target}" 2>/dev/null || echo "-1")
+                if [[ "${czf_size}" == "0" ]]; then
+                    pass "Cache: zero-length size correct: ${czf_name}"
+                else
+                    fail "Cache: zero-length size wrong (${czf_size}): ${czf_name}"
+                fi
+
+                czf_content=$(cat "${czf_target}" 2>/dev/null)
+                if [[ -z "${czf_content}" ]]; then
+                    pass "Cache: zero-length content empty: ${czf_name}"
+                else
+                    fail "Cache: zero-length has unexpected content: ${czf_name}"
+                fi
+
+                czf_sha=$(sha256sum "${czf_target}" 2>/dev/null | awk '{print $1}')
+                if [[ "${czf_sha}" == "${EMPTY_SHA256}" ]]; then
+                    pass "Cache: zero-length checksum OK: ${czf_name}"
+                else
+                    fail "Cache: zero-length checksum mismatch: ${czf_name}"
+                fi
+            done <<< "${CACHE_ZERO_FILES_LIST}"
+            if [[ "${CACHE_ZERO_COUNT}" -eq 0 ]]; then
+                skip "Cache: no zero-length files in manifest"
+            else
+                log_info "Cache: tested ${CACHE_ZERO_COUNT} zero-length file(s)."
+            fi
+        fi
+
         # Unmount
         do_unmount "${CACHE_MOUNT_DIR}"
         wait "${CACHE_HTTPDIRFS_PID}" 2>/dev/null || true
         log_info "Cache mount (blksz=${BLKSZ}M) unmounted."
+
     done
 fi
 fi

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -1,4 +1,5 @@
 #include <unity.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -107,6 +108,43 @@ void test_Cache_read_past_eof(void)
 
     res = Cache_read(&cf, buf, sizeof(buf), 150);
     TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+void test_Cache_read_negative_len(void)
+{
+    /* The new len < 0 guard must reject negative lengths with -EINVAL
+     * rather than wrapping the value to a huge size_t. */
+    Cache cf = {0};
+    Link link = {0};
+    link.content_length = 1024;
+    cf.link = &link;
+    cf.blksz = 4096;
+
+    char buf[64];
+    long res = Cache_read(&cf, buf, (off_t)-1, 0);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, res);
+
+    res = Cache_read(&cf, buf, (off_t)-1024, 0);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, res);
+}
+
+void test_Cache_read_null_cf(void)
+{
+    /* Cache_read must return -EINVAL when passed a NULL cf pointer. */
+    char buf[16];
+    long res = Cache_read(NULL, buf, sizeof(buf), 0);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, res);
+}
+
+void test_Cache_read_null_link(void)
+{
+    /* Cache_read must return -EINVAL when cf->link is NULL. */
+    Cache cf = {0};
+    cf.link = NULL;
+
+    char buf[16];
+    long res = Cache_read(&cf, buf, sizeof(buf), 0);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, res);
 }
 
 static void cleanup_temp_dir(const char *tmp_cache_dir)
@@ -246,6 +284,9 @@ int main(void)
     RUN_TEST(test_ActiveDownload_find);
     RUN_TEST(test_Cache_read_zero_length);
     RUN_TEST(test_Cache_read_past_eof);
+    RUN_TEST(test_Cache_read_negative_len);
+    RUN_TEST(test_Cache_read_null_cf);
+    RUN_TEST(test_Cache_read_null_link);
     RUN_TEST(test_Cache_invalid_zero_length_disk_files);
     return UNITY_END();
 }

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -93,6 +93,22 @@ void test_Cache_read_zero_length(void)
     TEST_ASSERT_EQUAL_INT(0, res);
 }
 
+void test_Cache_read_past_eof(void)
+{
+    Cache cf = {0};
+    Link link = {0};
+    link.content_length = 100;
+    cf.link = &link;
+    cf.blksz = 4096;
+
+    char buf[10];
+    long res = Cache_read(&cf, buf, sizeof(buf), 100);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = Cache_read(&cf, buf, sizeof(buf), 150);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
 static void cleanup_temp_dir(const char *tmp_cache_dir)
 {
     char filepath[512];
@@ -229,6 +245,7 @@ int main(void)
     RUN_TEST(test_CacheSystem_get_cache_dir);
     RUN_TEST(test_ActiveDownload_find);
     RUN_TEST(test_Cache_read_zero_length);
+    RUN_TEST(test_Cache_read_past_eof);
     RUN_TEST(test_Cache_invalid_zero_length_disk_files);
     return UNITY_END();
 }

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -197,7 +197,7 @@ void test_Cache_invalid_zero_length_disk_files(void)
     // Verify that the recreated meta file is now not empty (it has valid
     // metadata written)
     struct stat st;
-    TEST_ASSERT_EQUAL_INT(0, stat(meta_filepath, &st));
+    TEST_ASSERT_EQUAL_INT(0, fstat(fileno(cf->mfp), &st));
     TEST_ASSERT_TRUE(st.st_size > 0);
 
     // Close the cache
@@ -225,7 +225,7 @@ void test_Cache_invalid_zero_length_disk_files(void)
 
     // Verify it was again invalidated, recreated, and now has a valid non-zero
     // content_length
-    TEST_ASSERT_EQUAL_INT(0, stat(meta_filepath, &st));
+    TEST_ASSERT_EQUAL_INT(0, fstat(fileno(cf->mfp), &st));
     TEST_ASSERT_TRUE(st.st_size > 0);
 
     Cache_close(cf);

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -1,9 +1,13 @@
 #include <unity.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include "../src/cache.h"
 #include "../src/config.h"
 #include "../src/util.h"
+#include "../src/link.h"
 
 void setUp(void)
 {
@@ -76,10 +80,155 @@ void test_ActiveDownload_find(void)
     TEST_ASSERT_NULL(ActiveDownload_find(&cf, 4096));
 }
 
+void test_Cache_read_zero_length(void)
+{
+    Cache cf = {0};
+    Link link = {0};
+    link.content_length = 0;
+    cf.link = &link;
+    cf.blksz = 4096;
+
+    char buf[10];
+    long res = Cache_read(&cf, buf, sizeof(buf), 0);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+static void cleanup_temp_dir(const char *tmp_cache_dir)
+{
+    char filepath[512];
+
+    // Remove files
+    snprintf(filepath, sizeof(filepath), "%s/meta/file.bin", tmp_cache_dir);
+    (void)unlink(filepath);
+
+    snprintf(filepath, sizeof(filepath), "%s/data/file.bin", tmp_cache_dir);
+    (void)unlink(filepath);
+
+    // Remove directories
+    snprintf(filepath, sizeof(filepath), "%s/meta", tmp_cache_dir);
+    (void)rmdir(filepath);
+
+    snprintf(filepath, sizeof(filepath), "%s/data", tmp_cache_dir);
+    (void)rmdir(filepath);
+
+    (void)rmdir(tmp_cache_dir);
+}
+
+void test_Cache_invalid_zero_length_disk_files(void)
+{
+    // Set up a temp cache directory
+    const char *tmp_cache_dir = "./test_cache_invalidation_dir";
+    char meta_dir[256];
+    char data_dir[256];
+    snprintf(meta_dir, sizeof(meta_dir), "%s/meta", tmp_cache_dir);
+    snprintf(data_dir, sizeof(data_dir), "%s/data", tmp_cache_dir);
+
+    // Make sure they exist and are empty
+    cleanup_temp_dir(tmp_cache_dir);
+    TEST_ASSERT_EQUAL_INT(0, mkdir(tmp_cache_dir, 0700));
+    TEST_ASSERT_EQUAL_INT(0, mkdir(meta_dir, 0700));
+    TEST_ASSERT_EQUAL_INT(0, mkdir(data_dir, 0700));
+
+    // Store old CONFIG.cache_dir
+    char *old_cache_dir = CONFIG.cache_dir;
+    CONFIG.cache_dir = (char *)tmp_cache_dir;
+
+    // Set up a mock Link with a non-zero content_length
+    LinkTable *table = LinkTable_alloc("https://example.com/");
+    Link *link = CALLOC(1, sizeof(Link));
+    link->type = LINK_FILE;
+    link->content_length = 100;
+    link->parent_table = table;
+    strncpy(link->linkname, "file.bin", NAME_MAX);
+    strncpy(link->f_url, "https://example.com/file.bin", PATH_MAX);
+    LinkTable_add(table, link);
+
+    // Expose ROOT_LINK_TBL and ROOT_LINK_OFFSET
+    LinkTable *old_root_link_tbl = ROOT_LINK_TBL;
+    ROOT_LINK_TBL = table;
+    int old_root_link_offset = ROOT_LINK_OFFSET;
+    ROOT_LINK_OFFSET = 20;
+
+    // Initialize cache system with our temp directory
+    CacheSystem_init(tmp_cache_dir, 0);
+
+    // Scenario 1: Metadata file exists but is 0 bytes (empty)
+    char meta_filepath[512];
+    char data_filepath[512];
+    snprintf(meta_filepath, sizeof(meta_filepath), "%s/meta/file.bin",
+             tmp_cache_dir);
+    snprintf(data_filepath, sizeof(data_filepath), "%s/data/file.bin",
+             tmp_cache_dir);
+
+    // Touch both files to make them exist, meta is 0 bytes
+    FILE *f_meta = fopen(meta_filepath, "w");
+    TEST_ASSERT_NOT_NULL(f_meta);
+    fclose(f_meta);
+
+    FILE *f_data = fopen(data_filepath, "w");
+    TEST_ASSERT_NOT_NULL(f_data);
+    fclose(f_data);
+
+    // Now, call Cache_open. Since meta is empty, it is invalid.
+    // Cache_open should detect this invalid/corrupted cache, delete it,
+    // and recreate a fresh cache which should succeed and have a correct
+    // non-zero size.
+    Cache *cf = Cache_open("file.bin");
+    TEST_ASSERT_NOT_NULL(cf);
+    TEST_ASSERT_NOT_NULL(cf->mfp);
+    TEST_ASSERT_NOT_NULL(cf->dfp);
+
+    // Verify that the recreated meta file is now not empty (it has valid
+    // metadata written)
+    struct stat st;
+    TEST_ASSERT_EQUAL_INT(0, stat(meta_filepath, &st));
+    TEST_ASSERT_TRUE(st.st_size > 0);
+
+    // Close the cache
+    Cache_close(cf);
+
+    // Scenario 2: Metadata file contains invalid zero-length/negative size
+    // Create invalid metadata file with disk_content_length = 0
+    f_meta = fopen(meta_filepath, "w");
+    TEST_ASSERT_NOT_NULL(f_meta);
+    long bad_time = 0;
+    off_t bad_len = 0;
+    int bad_blksz = 4096;
+    long bad_segbc = 0;
+    fwrite(&bad_time, sizeof(long), 1, f_meta);
+    fwrite(&bad_len, sizeof(off_t), 1, f_meta);
+    fwrite(&bad_blksz, sizeof(int), 1, f_meta);
+    fwrite(&bad_segbc, sizeof(long), 1, f_meta);
+    fclose(f_meta);
+
+    // Re-open
+    cf = Cache_open("file.bin");
+    TEST_ASSERT_NOT_NULL(cf);
+    TEST_ASSERT_NOT_NULL(cf->mfp);
+    TEST_ASSERT_NOT_NULL(cf->dfp);
+
+    // Verify it was again invalidated, recreated, and now has a valid non-zero
+    // content_length
+    TEST_ASSERT_EQUAL_INT(0, stat(meta_filepath, &st));
+    TEST_ASSERT_TRUE(st.st_size > 0);
+
+    Cache_close(cf);
+
+    // Cleanup
+    ROOT_LINK_TBL = old_root_link_tbl;
+    ROOT_LINK_OFFSET = old_root_link_offset;
+    LinkTable_free(table);
+    CacheSystem_cleanup();
+    CONFIG.cache_dir = old_cache_dir;
+    cleanup_temp_dir(tmp_cache_dir);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_CacheSystem_get_cache_dir);
     RUN_TEST(test_ActiveDownload_find);
+    RUN_TEST(test_Cache_read_zero_length);
+    RUN_TEST(test_Cache_invalid_zero_length_disk_files);
     return UNITY_END();
 }

--- a/tests/test_link.c
+++ b/tests/test_link.c
@@ -17,19 +17,20 @@ void tearDown(void)
 
 void test_LinkTable_alloc(void)
 {
-    LinkTable *table = LinkTable_alloc("http://example.com/dir/");
+    LinkTable *table = LinkTable_alloc("https://example.com/dir/");
     TEST_ASSERT_NOT_NULL(table);
     TEST_ASSERT_EQUAL_INT(1, table->size); // Alloc adds the head link
     TEST_ASSERT_NOT_NULL(table->links);
     TEST_ASSERT_NOT_NULL(table->links[0]);
-    TEST_ASSERT_EQUAL_STRING("http://example.com/dir/", table->links[0]->f_url);
+    TEST_ASSERT_EQUAL_STRING("https://example.com/dir/",
+                             table->links[0]->f_url);
     TEST_ASSERT_EQUAL_STRING("", table->links[0]->linkname);
     LinkTable_free(table);
 }
 
 void test_LinkTable_add(void)
 {
-    LinkTable *table = LinkTable_alloc("http://example.com/dir/");
+    LinkTable *table = LinkTable_alloc("https://example.com/dir/");
     TEST_ASSERT_NOT_NULL(table);
     TEST_ASSERT_EQUAL_INT(1, table->size);
 
@@ -46,10 +47,29 @@ void test_LinkTable_add(void)
     LinkTable_free(table);
 }
 
+void test_Link_download_zero_length(void)
+{
+    Link link = {0};
+    link.content_length = 0;
+    link.type = LINK_FILE;
+    strncpy(link.linkname, "empty.txt", NAME_MAX);
+    strncpy(link.f_url, "https://example.com/empty.txt", PATH_MAX);
+
+    char buf[10];
+    memset(buf, 0xff, sizeof(buf));
+    long res = Link_download(&link, buf, sizeof(buf), 0, NULL);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    for (size_t i = 0; i < sizeof(buf); i++) {
+        TEST_ASSERT_EQUAL_HEX8(0xff, (unsigned char)buf[i]);
+    }
+}
+
 int main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_LinkTable_alloc);
     RUN_TEST(test_LinkTable_add);
+    RUN_TEST(test_Link_download_zero_length);
     return UNITY_END();
 }


### PR DESCRIPTION
This pull request rewrites and consolidates the cache and link handling refactoring branch. It addresses recent security, performance, and cross-platform reviews by organizing the work into clean, modular, and self-contained commits:

1. **Apple Platform Compatibility**: Emulates unnamed POSIX semaphores using standard mutexes and condition variables on macOS to prevent SIGABRT crashes. Statically initializes `link_lock`.
2. **Prioritize `struct Link`**: Removes duplicate/redundant cache state variables (`time`, `content_length`, `fs_path`) from `struct Cache` and uses `cf->link` as the authoritative source of truth.
3. **Zero-Length File Handling**: Optimizes and bypasses the cache for zero-length and empty files, validating cache integrity and avoiding network overhead.
4. **Defensive Hardening**: Strengthens the cache read/write and download systems with boundary checks, bounds validation, and clamping to eliminate negative offset overflows and EOF reading errors.
5. **TOCTOU Improvements**: Replaces race-prone `access()` checks with direct POSIX `unlink()` operations, and converts test validation from `stat` to `fstat` to avoid race conditions.

All changes successfully pass the complete suite of unit and integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation of on-disk cache metadata/data; corrupt or inconsistent files are rejected and cleaned up
  * Rejected invalid reads/writes (zero/negative lengths, out-of-range offsets, overflow) and tightened file-size/truncation handling
  * Improved handling of zero-length content and reads past EOF; out-of-range reads return zero

* **Refactor**
  * Hardened cache lifecycle, segment/prefetch and concurrency logic; safer background/synchronous download boundaries
  * Cross-platform semaphore/locking improvements for more robust background work

* **Tests**
  * Added coverage for zero-length scenarios, out-of-range reads, and corrupted metadata detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->