### PR TITLE
Optimize HTTP/2 multiplexing and enable HTTP/3 support

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -10,7 +10,7 @@
 /**
  * \brief The default maximum number of network connections
  */
-#define DEFAULT_NETWORK_MAX_CONNS 10
+#define DEFAULT_NETWORK_MAX_CONNS 6
 
 /**
  * \brief The default refresh_timeout

--- a/src/link.c
+++ b/src/link.c
@@ -87,6 +87,14 @@ static CURL *Link_to_curl(Link *link)
     if (ret) {
         lprintf(error, "%s", curl_easy_strerror(ret));
     }
+    ret = curl_easy_setopt(curl, CURLOPT_PIPEWAIT, 1L);
+    if (ret) {
+        lprintf(error, "%s", curl_easy_strerror(ret));
+    }
+    ret = curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3);
+    if (ret) {
+        lprintf(error, "%s", curl_easy_strerror(ret));
+    }
     ret = curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 15);
     if (ret) {
         lprintf(error, "%s", curl_easy_strerror(ret));

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -19,7 +19,7 @@ void test_Config_init(void)
     Config_init();
 
     // Check some defaults defined in config.h and config.c
-    TEST_ASSERT_EQUAL_INT(10, CONFIG.max_conns);
+    TEST_ASSERT_EQUAL_INT(DEFAULT_NETWORK_MAX_CONNS, CONFIG.max_conns);
     TEST_ASSERT_EQUAL_INT(3600, CONFIG.refresh_timeout);
     TEST_ASSERT_EQUAL_INT(NORMAL, CONFIG.mode);
     TEST_ASSERT_EQUAL_INT(0, CONFIG.cache_enabled);


### PR DESCRIPTION
### Description

This pull request implements key network and protocol optimizations by maximizing HTTP/2 multiplexing efficiency, enabling support for HTTP/3 (QUIC), and aligning the default maximum connection limit with industry browser standards within `httpdirfs`.

---

### What we are trying to achieve

#### 1. Optimize HTTP/2 Multiplexing via `CURLOPT_PIPEWAIT`
* **Problem:** When `httpdirfs` starts up or initiates concurrent block reads, multiple parallel curl easy handles are queued up. Without `CURLOPT_PIPEWAIT` enabled, if libcurl is in the middle of a connection handshake, it does not yet know if the server supports HTTP/2 multiplexing. Rather than waiting for the handshake to conclude, it eagerly spins up brand new TCP connections (up to the maximum connection limit) in parallel.
* **Solution:** Added `CURLOPT_PIPEWAIT` set to `1L`. This tells libcurl to briefly pause/wait for any ongoing connection handshakes to complete so it can multiplex the concurrent transfers over a single HTTP/2 connection, drastically reducing the number of TCP handshakes and parallel connections.

#### 2. Enable HTTP/3 (QUIC) Support
* **Problem:** Even if the client's `libcurl` installation supports HTTP/3, libcurl never requests it by default.
* **Solution:** Configured `CURLOPT_HTTP_VERSION` to `CURL_HTTP_VERSION_3` on all curl easy handles. If the server supports HTTP/3, the library, and the network allow it, connections will automatically upgrade to HTTP/3 (QUIC / UDP). If HTTP/3 is unsupported or blocked, libcurl will automatically and seamlessly fall back to HTTP/2 or HTTP/1.1 over TCP.

#### 3. Align Maximum Network Connections Default to `6`
* **Change:** Set `DEFAULT_NETWORK_MAX_CONNS` in `src/config.h` from `10` to `6`.
* **Rationale:** A limit of `6` persistent TCP connections per host is the industry standard agreed upon and enforced by all major modern web browsers (Chrome, Firefox, Safari, Edge). Setting it to `6` ensures `httpdirfs` does not aggressively open more parallel TCP connections than a standard browser, which avoids triggering rate-limiters / anti-DDoS protections on standard web servers while keeping resource utilization optimal.
* **Updates:** Updated `tests/test_config.c` to assert against `DEFAULT_NETWORK_MAX_CONNS` instead of a hardcoded value of `10`.

---

### Verification and Testing
* Fully compiled locally with `meson` and `ninja`.
* Passed all pre-commit formatting and linting hooks (`clang-format`, `clang-tidy`, `codespell`).
* Successfully executed and passed the entire test suite (`test_link`, `test_util`, `test_cache`, `test_config`, and `integration_short`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Compatibility**
  * Enables HTTP/3 support and improves pipelined request handling for more reliable connections.  
* **Behavior Change**
  * Default maximum concurrent network connections reduced (lower default concurrency).  
* **Tests**
  * Test updated to align with the new default connection limit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->