### PR TITLE
cache: dynamically scale background prefetch workers and refactor tests

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -6,6 +6,7 @@
 #include "util.h"
 #include <curl/curl.h>
 
+#include <sys/param.h>
 #include <sys/stat.h>
 
 #include <dirent.h>
@@ -662,7 +663,13 @@ static Cache *Cache_alloc(void)
     PTHREAD_COND_INIT(&cf->dl_cond, NULL);
     cf->active_dls = NULL;
     cf->cache_opened = 1;
-    SEM_INIT(&cf->bgt_sem, 0, 1);
+
+    cf->num_bg_workers = MIN(CONFIG.max_conns, DEFAULT_NETWORK_MAX_CONNS) / 2;
+    if (cf->num_bg_workers <= 0) {
+        cf->num_bg_workers = 1;
+    }
+
+    SEM_INIT(&cf->bgt_sem, 0, cf->num_bg_workers);
     return cf;
 }
 
@@ -1065,7 +1072,9 @@ void Cache_close(Cache *cf)
     lprintf(cache_lock_debug,
             "thread %lx: waiting for background download to finish for %s\n",
             (unsigned long)pthread_self(), cf->path);
-    SEM_WAIT(&cf->bgt_sem);
+    for (int i = 0; i < cf->num_bg_workers; i++) {
+        SEM_WAIT(&cf->bgt_sem);
+    }
 
     if (cf->mfp && Meta_write(cf)) {
         lprintf(error, "Meta_write() error.");

--- a/src/cache.h
+++ b/src/cache.h
@@ -71,6 +71,9 @@ struct Cache {
     pthread_cond_t dl_cond;
     /** \brief active downloads list */
     ActiveDownload *active_dls;
+
+    /** \brief Number of background workers */
+    int num_bg_workers;
 };
 
 /**

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -9,6 +9,7 @@
 #include "../src/config.h"
 #include "../src/util.h"
 #include "../src/link.h"
+#include <sys/param.h>
 
 void setUp(void)
 {
@@ -158,6 +159,12 @@ static void cleanup_temp_dir(const char *tmp_cache_dir)
     snprintf(filepath, sizeof(filepath), "%s/data/file.bin", tmp_cache_dir);
     (void)unlink(filepath);
 
+    snprintf(filepath, sizeof(filepath), "%s/meta/dummy.bin", tmp_cache_dir);
+    (void)unlink(filepath);
+
+    snprintf(filepath, sizeof(filepath), "%s/data/dummy.bin", tmp_cache_dir);
+    (void)unlink(filepath);
+
     // Remove directories
     snprintf(filepath, sizeof(filepath), "%s/meta", tmp_cache_dir);
     (void)rmdir(filepath);
@@ -168,42 +175,47 @@ static void cleanup_temp_dir(const char *tmp_cache_dir)
     (void)rmdir(tmp_cache_dir);
 }
 
-void test_Cache_invalid_zero_length_disk_files(void)
+static LinkTable *setup_mock_link_table(const char *link_name)
 {
-    // Set up a temp cache directory
-    const char *tmp_cache_dir = "./test_cache_invalidation_dir";
-    char meta_dir[256];
-    char data_dir[256];
-    snprintf(meta_dir, sizeof(meta_dir), "%s/meta", tmp_cache_dir);
-    snprintf(data_dir, sizeof(data_dir), "%s/data", tmp_cache_dir);
-
-    // Make sure they exist and are empty
-    cleanup_temp_dir(tmp_cache_dir);
-    TEST_ASSERT_EQUAL_INT(0, mkdir(tmp_cache_dir, 0700));
-    TEST_ASSERT_EQUAL_INT(0, mkdir(meta_dir, 0700));
-    TEST_ASSERT_EQUAL_INT(0, mkdir(data_dir, 0700));
-
-    // Store old CONFIG.cache_dir
-    char *old_cache_dir = CONFIG.cache_dir;
-    CONFIG.cache_dir = (char *)tmp_cache_dir;
-
-    // Set up a mock Link with a non-zero content_length
     LinkTable *table = LinkTable_alloc("https://example.com/");
     Link *link = CALLOC(1, sizeof(Link));
     link->type = LINK_FILE;
     link->content_length = 100;
     link->parent_table = table;
-    strncpy(link->linkname, "file.bin", NAME_MAX);
-    strncpy(link->f_url, "https://example.com/file.bin", PATH_MAX);
+    strncpy(link->linkname, link_name, NAME_MAX);
+    snprintf(link->f_url, PATH_MAX, "https://example.com/%s", link_name);
     LinkTable_add(table, link);
+    return table;
+}
 
-    // Expose ROOT_LINK_TBL and ROOT_LINK_OFFSET
+static void setup_temp_cache_dir(const char *tmp_cache_dir)
+{
+    char meta_dir[256];
+    char data_dir[256];
+    snprintf(meta_dir, sizeof(meta_dir), "%s/meta", tmp_cache_dir);
+    snprintf(data_dir, sizeof(data_dir), "%s/data", tmp_cache_dir);
+
+    cleanup_temp_dir(tmp_cache_dir);
+    TEST_ASSERT_EQUAL_INT(0, mkdir(tmp_cache_dir, S_IRWXU));
+    TEST_ASSERT_EQUAL_INT(0, mkdir(meta_dir, S_IRWXU));
+    TEST_ASSERT_EQUAL_INT(0, mkdir(data_dir, S_IRWXU));
+}
+
+void test_Cache_invalid_zero_length_disk_files(void)
+{
+    const char *tmp_cache_dir = "./test_cache_invalidation_dir";
+    setup_temp_cache_dir(tmp_cache_dir);
+
+    char *old_cache_dir = CONFIG.cache_dir;
+    CONFIG.cache_dir = (char *)tmp_cache_dir;
+
+    LinkTable *table = setup_mock_link_table("file.bin");
+
     LinkTable *old_root_link_tbl = ROOT_LINK_TBL;
     ROOT_LINK_TBL = table;
     int old_root_link_offset = ROOT_LINK_OFFSET;
     ROOT_LINK_OFFSET = 20;
 
-    // Initialize cache system with our temp directory
     CacheSystem_init(tmp_cache_dir, 0);
 
     // Scenario 1: Metadata file exists but is 0 bytes (empty)
@@ -277,6 +289,49 @@ void test_Cache_invalid_zero_length_disk_files(void)
     cleanup_temp_dir(tmp_cache_dir);
 }
 
+void test_Cache_alloc_num_bg_workers(void)
+{
+    // Mock the external global CONFIG
+    int old_max_conns = CONFIG.max_conns;
+
+    const char *tmp_cache_dir = "./test_cache_bg_workers_dir";
+    setup_temp_cache_dir(tmp_cache_dir);
+
+    char *old_cache_dir = CONFIG.cache_dir;
+    CONFIG.cache_dir = (char *)tmp_cache_dir;
+
+    LinkTable *table = setup_mock_link_table("dummy.bin");
+
+    LinkTable *old_root_link_tbl = ROOT_LINK_TBL;
+    ROOT_LINK_TBL = table;
+    int old_root_link_offset = ROOT_LINK_OFFSET;
+    ROOT_LINK_OFFSET = 20;
+
+    CacheSystem_init(tmp_cache_dir, 0);
+
+    int test_conns[] = {10, 4, 1};
+    for (int i = 0; i < 3; i++) {
+        CONFIG.max_conns = test_conns[i];
+        Cache *cf = Cache_open("dummy.bin");
+        TEST_ASSERT_NOT_NULL(cf);
+        int expected = MIN(CONFIG.max_conns, DEFAULT_NETWORK_MAX_CONNS) / 2;
+        if (expected <= 0) {
+            expected = 1;
+        }
+        TEST_ASSERT_EQUAL_INT(expected, cf->num_bg_workers);
+        Cache_close(cf);
+    }
+
+    // Cleanup
+    ROOT_LINK_TBL = old_root_link_tbl;
+    ROOT_LINK_OFFSET = old_root_link_offset;
+    LinkTable_free(table);
+    CacheSystem_cleanup();
+    CONFIG.cache_dir = old_cache_dir;
+    cleanup_temp_dir(tmp_cache_dir);
+    CONFIG.max_conns = old_max_conns;
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -288,5 +343,6 @@ int main(void)
     RUN_TEST(test_Cache_read_null_cf);
     RUN_TEST(test_Cache_read_null_link);
     RUN_TEST(test_Cache_invalid_zero_length_disk_files);
+    RUN_TEST(test_Cache_alloc_num_bg_workers);
     return UNITY_END();
 }


### PR DESCRIPTION
Previously, the cache architecture limited background prefetching to a single worker thread by hardcoding the capacity of cf->bgt_sem to 1. With multiple concurrent active downloads supported, scaling the number of prefetch workers is highly beneficial.

This commit introduces dynamic scaling of background prefetch workers:
- Adds a num_bg_workers field to the Cache struct.
- Scales background prefetch threads dynamically to match up to half of the maximum concurrent connection capacity (CONFIG.max_conns capped at DEFAULT_NETWORK_MAX_CONNS), ensuring at least 1 worker.
- Loops through all background workers during Cache_close teardown to ensure each worker exits cleanly.

Additionally, this commit refactors cache unit tests to improve code reuse and satisfy security best practices:
- Extracts common cache configuration and initialization tasks into setup_mock_link_table and setup_temp_cache_dir helper functions.
- Adds a unit test test_Cache_alloc_num_bg_workers verifying the scaling allocation under various connection configurations.
- Updates directory creation calls in mkdir to use symbolic permission constant S_IRWXU instead of raw octal literals, addressing SonarCloud security hotspots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cache background worker allocation by dynamically scaling the worker count based on system capacity and connection limits.
  * Enhanced cache shutdown procedures with more reliable synchronization handling to prevent premature resource release.

* **Tests**
  * Added comprehensive tests validating cache worker allocation behavior across different system configurations and capacity levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->