### PR TITLE
Optimize thread wakeup signaling in Cache module

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -635,7 +635,9 @@ static void ActiveDownload_add(Cache *cf, off_t offset)
 /**
  * \brief Decrements the reference count of the ActiveDownload tracker.
  * \details Destroys the condition variable and frees the structure when the
- * reference count reaches 0.
+ * reference count reaches 0. The reference count of 1 initially represents
+ * list ownership, while subsequent waiting threads increment it. When unlinked,
+ * the list drops its reference.
  * \param[in] ad The ActiveDownload tracker to unref.
  * \note Must be called while holding cf->dl_lock.
  */
@@ -692,11 +694,6 @@ static Cache *Cache_alloc(void)
  */
 static void Cache_free(Cache *cf)
 {
-    PTHREAD_MUTEX_DESTROY(&cf->seek_lock);
-    PTHREAD_MUTEX_DESTROY(&cf->w_lock);
-    PTHREAD_MUTEX_DESTROY(&cf->dl_lock);
-    SEM_DESTROY(&cf->bgt_sem);
-
     if (cf->path) {
         FREE(cf->path);
     }
@@ -705,13 +702,22 @@ static void Cache_free(Cache *cf)
         FREE(cf->seg);
     }
 
+    PTHREAD_MUTEX_LOCK(&cf->dl_lock);
     ActiveDownload *ad = cf->active_dls;
+    cf->active_dls = NULL;
     while (ad) {
         ActiveDownload *next = ad->next;
-        PTHREAD_COND_DESTROY(&ad->cond);
-        FREE(ad);
+        PTHREAD_COND_BROADCAST(&ad->cond);
+        ad->next = NULL;
+        ActiveDownload_unref(ad);
         ad = next;
     }
+    PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
+    PTHREAD_MUTEX_DESTROY(&cf->seek_lock);
+    PTHREAD_MUTEX_DESTROY(&cf->w_lock);
+    PTHREAD_MUTEX_DESTROY(&cf->dl_lock);
+    SEM_DESTROY(&cf->bgt_sem);
 
     FREE(cf);
 }
@@ -1317,18 +1323,18 @@ retry:
         ad->refcount++;
         ActiveDownload *orig_ad = ad;
 
-        while ((ad = ActiveDownload_find(cf, dl_offset)) == orig_ad) {
-            if (ad->ts && ad->ts->data
-                && ad->ts->curr_size
+        while (ActiveDownload_find(cf, dl_offset) == orig_ad) {
+            if (orig_ad->ts && orig_ad->ts->data
+                && orig_ad->ts->curr_size
                        >= (size_t)(offset_start - dl_offset + len)) {
-                memcpy(output_buf, ad->ts->data + (offset_start - dl_offset),
-                       len);
+                memcpy(output_buf,
+                       orig_ad->ts->data + (offset_start - dl_offset), len);
                 ActiveDownload_unref(orig_ad);
                 PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
                 send = len;
                 goto bgdl;
             }
-            PTHREAD_COND_WAIT(&ad->cond, &cf->dl_lock);
+            PTHREAD_COND_WAIT(&orig_ad->cond, &cf->dl_lock);
         }
         ActiveDownload_unref(orig_ad);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);

--- a/src/cache.c
+++ b/src/cache.c
@@ -626,8 +626,29 @@ static void ActiveDownload_add(Cache *cf, off_t offset)
     ActiveDownload *ad = CALLOC(1, sizeof(ActiveDownload));
     ad->offset = offset;
     ad->ts = NULL;
+    PTHREAD_COND_INIT(&ad->cond, NULL);
+    ad->refcount = 1;
     ad->next = cf->active_dls;
     cf->active_dls = ad;
+}
+
+/**
+ * \brief Decrements the reference count of the ActiveDownload tracker.
+ * \details Destroys the condition variable and frees the structure when the
+ * reference count reaches 0.
+ * \param[in] ad The ActiveDownload tracker to unref.
+ * \note Must be called while holding cf->dl_lock.
+ */
+static void ActiveDownload_unref(ActiveDownload *ad)
+{
+    if (ad == NULL) {
+        return;
+    }
+    ad->refcount--;
+    if (ad->refcount == 0) {
+        PTHREAD_COND_DESTROY(&ad->cond);
+        FREE(ad);
+    }
 }
 
 /**
@@ -643,7 +664,8 @@ static void ActiveDownload_remove(Cache *cf, off_t offset)
         if ((*curr)->offset == offset) {
             ActiveDownload *temp = *curr;
             *curr = (*curr)->next;
-            FREE(temp);
+            PTHREAD_COND_BROADCAST(&temp->cond);
+            ActiveDownload_unref(temp);
             return;
         }
         curr = &(*curr)->next;
@@ -659,7 +681,6 @@ static Cache *Cache_alloc(void)
     PTHREAD_MUTEX_INIT(&cf->seek_lock, NULL);
     PTHREAD_MUTEX_INIT(&cf->w_lock, NULL);
     PTHREAD_MUTEX_INIT(&cf->dl_lock, NULL);
-    PTHREAD_COND_INIT(&cf->dl_cond, NULL);
     cf->active_dls = NULL;
     cf->cache_opened = 1;
     SEM_INIT(&cf->bgt_sem, 0, 1);
@@ -674,7 +695,6 @@ static void Cache_free(Cache *cf)
     PTHREAD_MUTEX_DESTROY(&cf->seek_lock);
     PTHREAD_MUTEX_DESTROY(&cf->w_lock);
     PTHREAD_MUTEX_DESTROY(&cf->dl_lock);
-    PTHREAD_COND_DESTROY(&cf->dl_cond);
     SEM_DESTROY(&cf->bgt_sem);
 
     if (cf->path) {
@@ -688,6 +708,7 @@ static void Cache_free(Cache *cf)
     ActiveDownload *ad = cf->active_dls;
     while (ad) {
         ActiveDownload *next = ad->next;
+        PTHREAD_COND_DESTROY(&ad->cond);
         FREE(ad);
         ad = next;
     }
@@ -1158,7 +1179,6 @@ static void *Cache_bgdl(void *arg)
         FREE(recv_buf);
         PTHREAD_MUTEX_LOCK(&cf->dl_lock);
         ActiveDownload_remove(cf, dl_offset);
-        PTHREAD_COND_BROADCAST(&cf->dl_cond);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         SEM_POST(&cf->bgt_sem);
         pthread_exit(NULL);
@@ -1184,7 +1204,6 @@ static void *Cache_bgdl(void *arg)
 
     PTHREAD_MUTEX_LOCK(&cf->dl_lock);
     ActiveDownload_remove(cf, dl_offset);
-    PTHREAD_COND_BROADCAST(&cf->dl_cond);
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
 
     SEM_POST(&cf->bgt_sem);
@@ -1252,7 +1271,7 @@ static void Cache_bgdl_launcher(Cache *cf, off_t dl_offset)
  * being downloaded.
  *    - If a segment is not cached but is already being downloaded by another
  * thread, subsequent FUSE threads will detect the node and wait via
- * `PTHREAD_COND_WAIT` on `dl_cond`.
+ * `PTHREAD_COND_WAIT` on `ad->cond`.
  *
  * 3. Early-Return Copy:
  *    - While waiting, threads can perform early returns by copying data
@@ -1295,19 +1314,23 @@ retry:
     ActiveDownload *ad = ActiveDownload_find(cf, dl_offset);
     if (ad != NULL) {
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+        ad->refcount++;
+        ActiveDownload *orig_ad = ad;
 
-        while ((ad = ActiveDownload_find(cf, dl_offset)) != NULL) {
+        while ((ad = ActiveDownload_find(cf, dl_offset)) == orig_ad) {
             if (ad->ts && ad->ts->data
                 && ad->ts->curr_size
                        >= (size_t)(offset_start - dl_offset + len)) {
                 memcpy(output_buf, ad->ts->data + (offset_start - dl_offset),
                        len);
+                ActiveDownload_unref(orig_ad);
                 PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
                 send = len;
                 goto bgdl;
             }
-            PTHREAD_COND_WAIT(&cf->dl_cond, &cf->dl_lock);
+            PTHREAD_COND_WAIT(&ad->cond, &cf->dl_lock);
         }
+        ActiveDownload_unref(orig_ad);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
         if (Seg_exist(cf, dl_offset)) {
@@ -1335,7 +1358,6 @@ retry:
         ActiveDownload *bg_ad = ActiveDownload_find(cf, dl_offset);
         if (bg_ad == NULL) {
             ActiveDownload_add(cf, dl_offset);
-            PTHREAD_COND_BROADCAST(&cf->dl_cond);
             PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
             Cache_bgdl_launcher(cf, dl_offset);
             PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1359,7 +1381,6 @@ sync_dl:
         goto retry;
     }
     ActiveDownload_add(cf, dl_offset);
-    PTHREAD_COND_BROADCAST(&cf->dl_cond);
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
 
     PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1373,7 +1394,6 @@ sync_dl:
     if (recv < 0) {
         PTHREAD_MUTEX_LOCK(&cf->dl_lock);
         ActiveDownload_remove(cf, dl_offset);
-        PTHREAD_COND_BROADCAST(&cf->dl_cond);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         FREE(recv_buf);
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1389,7 +1409,6 @@ sync_dl:
                     recv, (long)((offset_start - dl_offset) + len));
             PTHREAD_MUTEX_LOCK(&cf->dl_lock);
             ActiveDownload_remove(cf, dl_offset);
-            PTHREAD_COND_BROADCAST(&cf->dl_cond);
             PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
             FREE(recv_buf);
             PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1405,7 +1424,6 @@ sync_dl:
                 recv, cf->blksz);
         PTHREAD_MUTEX_LOCK(&cf->dl_lock);
         ActiveDownload_remove(cf, dl_offset);
-        PTHREAD_COND_BROADCAST(&cf->dl_cond);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         FREE(recv_buf);
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1414,7 +1432,6 @@ sync_dl:
 
     PTHREAD_MUTEX_LOCK(&cf->dl_lock);
     ActiveDownload_remove(cf, dl_offset);
-    PTHREAD_COND_BROADCAST(&cf->dl_cond);
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
     send = len;
     if (offset_start < dl_offset
@@ -1447,7 +1464,6 @@ bgdl: {
                 = ActiveDownload_find(cf, next_dl_offset);
             if (next_seg_missing && next_ad == NULL) {
                 ActiveDownload_add(cf, next_dl_offset);
-                PTHREAD_COND_BROADCAST(&cf->dl_cond);
                 PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
                 PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
                 Cache_bgdl_launcher(cf, next_dl_offset);

--- a/src/cache.h
+++ b/src/cache.h
@@ -23,6 +23,14 @@ typedef struct ActiveDownload {
     off_t offset;
     struct TransferStruct *ts;
     pthread_cond_t cond;
+    /**
+     * \brief Reference count for lifetime management.
+     * \details Starts at 1 when added to cf->active_dls.
+     * Each waiter thread increments the reference count before waiting.
+     * When unlinked from the list in ActiveDownload_remove, the list's
+     * reference is dropped. The structure is freed only when the reference
+     * count reaches 0.
+     */
     int refcount;
     struct ActiveDownload *next;
 } ActiveDownload;

--- a/src/cache.h
+++ b/src/cache.h
@@ -22,6 +22,8 @@ struct TransferStruct;
 typedef struct ActiveDownload {
     off_t offset;
     struct TransferStruct *ts;
+    pthread_cond_t cond;
+    int refcount;
     struct ActiveDownload *next;
 } ActiveDownload;
 
@@ -67,8 +69,6 @@ struct Cache {
 
     /** \brief mutex lock for background download progress */
     pthread_mutex_t dl_lock;
-    /** \brief condition variable for background download progress */
-    pthread_cond_t dl_cond;
     /** \brief active downloads list */
     ActiveDownload *active_dls;
 };

--- a/src/link.c
+++ b/src/link.c
@@ -1271,8 +1271,8 @@ static void Link_download_finish_transfer(Cache *cf, off_t offset,
     ActiveDownload *ad = ActiveDownload_find(cf, offset);
     if (ad && ad->ts == ts) {
         ad->ts = NULL;
+        PTHREAD_COND_BROADCAST(&ad->cond);
     }
-    PTHREAD_COND_BROADCAST(&cf->dl_cond);
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
 }
 
@@ -1308,7 +1308,7 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
             ActiveDownload *ad = ActiveDownload_find(cf, offset);
             if (ad) {
                 ad->ts = &ts;
-                PTHREAD_COND_BROADCAST(&cf->dl_cond);
+                PTHREAD_COND_BROADCAST(&ad->cond);
             }
             PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         }

--- a/src/link.c
+++ b/src/link.c
@@ -1271,8 +1271,14 @@ static void Link_download_finish_transfer(Cache *cf, off_t offset,
     ActiveDownload *ad = ActiveDownload_find(cf, offset);
     if (ad && ad->ts == ts) {
         ad->ts = NULL;
+        /* Broadcast to wake waiters so they observe that the transfer is done.
+         * Although the waiter loop will see ad->ts == NULL and temporarily
+         * block on cond wait again, the subsequent ActiveDownload_remove call
+         * will unlink the node and perform a second broadcast to let them
+         * exit the wait loop entirely. */
         PTHREAD_COND_BROADCAST(&ad->cond);
     }
+    ts->ad_ptr = NULL;
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
 }
 
@@ -1308,6 +1314,7 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
             ActiveDownload *ad = ActiveDownload_find(cf, offset);
             if (ad) {
                 ad->ts = &ts;
+                ts.ad_ptr = ad;
                 PTHREAD_COND_BROADCAST(&ad->cond);
             }
             PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);

--- a/src/memcache.c
+++ b/src/memcache.c
@@ -1,5 +1,6 @@
 #include "memcache.h"
 
+#include "cache.h"
 #include "log.h"
 #include "util.h"
 
@@ -28,7 +29,14 @@ size_t write_memory_callback(void *recv_data, size_t size, size_t nmemb,
     ts->data[ts->curr_size] = '\0';
 
     if (ts->cache_ptr) {
-        PTHREAD_COND_BROADCAST(&ts->cache_ptr->dl_cond);
+        ActiveDownload *ad = ts->cache_ptr->active_dls;
+        while (ad) {
+            if (ad->ts == ts) {
+                PTHREAD_COND_BROADCAST(&ad->cond);
+                break;
+            }
+            ad = ad->next;
+        }
         PTHREAD_MUTEX_UNLOCK(&ts->cache_ptr->dl_lock);
     }
 

--- a/src/memcache.c
+++ b/src/memcache.c
@@ -29,13 +29,8 @@ size_t write_memory_callback(void *recv_data, size_t size, size_t nmemb,
     ts->data[ts->curr_size] = '\0';
 
     if (ts->cache_ptr) {
-        ActiveDownload *ad = ts->cache_ptr->active_dls;
-        while (ad) {
-            if (ad->ts == ts) {
-                PTHREAD_COND_BROADCAST(&ad->cond);
-                break;
-            }
-            ad = ad->next;
+        if (ts->ad_ptr) {
+            PTHREAD_COND_BROADCAST(&ts->ad_ptr->cond);
         }
         PTHREAD_MUTEX_UNLOCK(&ts->cache_ptr->dl_lock);
     }

--- a/src/memcache.h
+++ b/src/memcache.h
@@ -23,6 +23,8 @@ struct TransferStruct {
     Link *link;
     /** \brief The Cache structure associated with the transfer */
     Cache *cache_ptr;
+    /** \brief The ActiveDownload structure associated with the transfer */
+    struct ActiveDownload *ad_ptr;
 };
 
 /**


### PR DESCRIPTION
Replace the global cf->dl_cond condition variable with per-block condition variables (ad->cond) inside ActiveDownload nodes. This avoids waking up all FUSE threads when a download segment finishes or updates, resolving Issue #266.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched from a single global notifier to per-download notifications to reduce unnecessary wakeups and lower contention.
  * Added per-download lifetime management (refcounting) to improve cleanup and stability for concurrent reads and background transfers.
  * Transfers now associate with their active download so waiters are signaled precisely; waiting threads can return early once enough data arrives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->