### PR TITLE
cache: optimize thread wakeup signaling

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -627,8 +627,31 @@ static void ActiveDownload_add(Cache *cf, off_t offset)
     ActiveDownload *ad = CALLOC(1, sizeof(ActiveDownload));
     ad->offset = offset;
     ad->ts = NULL;
+    PTHREAD_COND_INIT(&ad->cond, NULL);
+    ad->refcount = 1;
     ad->next = cf->active_dls;
     cf->active_dls = ad;
+}
+
+/**
+ * \brief Decrements the reference count of the ActiveDownload tracker.
+ * \details Destroys the condition variable and frees the structure when the
+ * reference count reaches 0. The reference count of 1 initially represents
+ * list ownership, while subsequent waiting threads increment it. When unlinked,
+ * the list drops its reference.
+ * \param[in] ad The ActiveDownload tracker to unref.
+ * \note Must be called while holding cf->dl_lock.
+ */
+static void ActiveDownload_unref(ActiveDownload *ad)
+{
+    if (ad == NULL) {
+        return;
+    }
+    ad->refcount--;
+    if (ad->refcount == 0) {
+        PTHREAD_COND_DESTROY(&ad->cond);
+        FREE(ad);
+    }
 }
 
 /**
@@ -644,7 +667,8 @@ static void ActiveDownload_remove(Cache *cf, off_t offset)
         if ((*curr)->offset == offset) {
             ActiveDownload *temp = *curr;
             *curr = (*curr)->next;
-            FREE(temp);
+            PTHREAD_COND_BROADCAST(&temp->cond);
+            ActiveDownload_unref(temp);
             return;
         }
         curr = &(*curr)->next;
@@ -660,7 +684,6 @@ static Cache *Cache_alloc(void)
     PTHREAD_MUTEX_INIT(&cf->seek_lock, NULL);
     PTHREAD_MUTEX_INIT(&cf->w_lock, NULL);
     PTHREAD_MUTEX_INIT(&cf->dl_lock, NULL);
-    PTHREAD_COND_INIT(&cf->dl_cond, NULL);
     cf->active_dls = NULL;
     cf->cache_opened = 1;
 
@@ -678,12 +701,6 @@ static Cache *Cache_alloc(void)
  */
 static void Cache_free(Cache *cf)
 {
-    PTHREAD_MUTEX_DESTROY(&cf->seek_lock);
-    PTHREAD_MUTEX_DESTROY(&cf->w_lock);
-    PTHREAD_MUTEX_DESTROY(&cf->dl_lock);
-    PTHREAD_COND_DESTROY(&cf->dl_cond);
-    SEM_DESTROY(&cf->bgt_sem);
-
     if (cf->path) {
         FREE(cf->path);
     }
@@ -692,12 +709,27 @@ static void Cache_free(Cache *cf)
         FREE(cf->seg);
     }
 
+    PTHREAD_MUTEX_LOCK(&cf->dl_lock);
     ActiveDownload *ad = cf->active_dls;
+    cf->active_dls = NULL;
     while (ad) {
         ActiveDownload *next = ad->next;
-        FREE(ad);
+        if (ad->refcount > 1) {
+            lprintf(warning,
+                    "Cache_free: ActiveDownload at offset %jd still has %d "
+                    "waiters/references!\n",
+                    (intmax_t)ad->offset, ad->refcount - 1);
+        }
+        ad->next = NULL;
+        ActiveDownload_unref(ad);
         ad = next;
     }
+    PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
+    PTHREAD_MUTEX_DESTROY(&cf->seek_lock);
+    PTHREAD_MUTEX_DESTROY(&cf->w_lock);
+    PTHREAD_MUTEX_DESTROY(&cf->dl_lock);
+    SEM_DESTROY(&cf->bgt_sem);
 
     FREE(cf);
 }
@@ -1167,7 +1199,6 @@ static void *Cache_bgdl(void *arg)
         FREE(recv_buf);
         PTHREAD_MUTEX_LOCK(&cf->dl_lock);
         ActiveDownload_remove(cf, dl_offset);
-        PTHREAD_COND_BROADCAST(&cf->dl_cond);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         SEM_POST(&cf->bgt_sem);
         pthread_exit(NULL);
@@ -1193,7 +1224,6 @@ static void *Cache_bgdl(void *arg)
 
     PTHREAD_MUTEX_LOCK(&cf->dl_lock);
     ActiveDownload_remove(cf, dl_offset);
-    PTHREAD_COND_BROADCAST(&cf->dl_cond);
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
 
     SEM_POST(&cf->bgt_sem);
@@ -1261,7 +1291,7 @@ static void Cache_bgdl_launcher(Cache *cf, off_t dl_offset)
  * being downloaded.
  *    - If a segment is not cached but is already being downloaded by another
  * thread, subsequent FUSE threads will detect the node and wait via
- * `PTHREAD_COND_WAIT` on `dl_cond`.
+ * `PTHREAD_COND_WAIT` on `ad->cond`.
  *
  * 3. Early-Return Copy:
  *    - While waiting, threads can perform early returns by copying data
@@ -1304,19 +1334,23 @@ retry:
     ActiveDownload *ad = ActiveDownload_find(cf, dl_offset);
     if (ad != NULL) {
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
+        ad->refcount++;
+        ActiveDownload *orig_ad = ad;
 
-        while ((ad = ActiveDownload_find(cf, dl_offset)) != NULL) {
-            if (ad->ts && ad->ts->data
-                && ad->ts->curr_size
+        while (ActiveDownload_find(cf, dl_offset) == orig_ad) {
+            if (orig_ad->ts && orig_ad->ts->data
+                && orig_ad->ts->curr_size
                        >= (size_t)(offset_start - dl_offset + len)) {
-                memcpy(output_buf, ad->ts->data + (offset_start - dl_offset),
-                       len);
+                memcpy(output_buf,
+                       orig_ad->ts->data + (offset_start - dl_offset), len);
+                ActiveDownload_unref(orig_ad);
                 PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
                 send = len;
                 goto bgdl;
             }
-            PTHREAD_COND_WAIT(&cf->dl_cond, &cf->dl_lock);
+            PTHREAD_COND_WAIT(&orig_ad->cond, &cf->dl_lock);
         }
+        ActiveDownload_unref(orig_ad);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
         if (Seg_exist(cf, dl_offset)) {
@@ -1344,7 +1378,6 @@ retry:
         ActiveDownload *bg_ad = ActiveDownload_find(cf, dl_offset);
         if (bg_ad == NULL) {
             ActiveDownload_add(cf, dl_offset);
-            PTHREAD_COND_BROADCAST(&cf->dl_cond);
             PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
             Cache_bgdl_launcher(cf, dl_offset);
             PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1368,7 +1401,6 @@ sync_dl:
         goto retry;
     }
     ActiveDownload_add(cf, dl_offset);
-    PTHREAD_COND_BROADCAST(&cf->dl_cond);
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
 
     PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1382,7 +1414,6 @@ sync_dl:
     if (recv < 0) {
         PTHREAD_MUTEX_LOCK(&cf->dl_lock);
         ActiveDownload_remove(cf, dl_offset);
-        PTHREAD_COND_BROADCAST(&cf->dl_cond);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         FREE(recv_buf);
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1398,7 +1429,6 @@ sync_dl:
                     recv, (long)((offset_start - dl_offset) + len));
             PTHREAD_MUTEX_LOCK(&cf->dl_lock);
             ActiveDownload_remove(cf, dl_offset);
-            PTHREAD_COND_BROADCAST(&cf->dl_cond);
             PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
             FREE(recv_buf);
             PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1414,7 +1444,6 @@ sync_dl:
                 recv, cf->blksz);
         PTHREAD_MUTEX_LOCK(&cf->dl_lock);
         ActiveDownload_remove(cf, dl_offset);
-        PTHREAD_COND_BROADCAST(&cf->dl_cond);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         FREE(recv_buf);
         PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
@@ -1423,7 +1452,6 @@ sync_dl:
 
     PTHREAD_MUTEX_LOCK(&cf->dl_lock);
     ActiveDownload_remove(cf, dl_offset);
-    PTHREAD_COND_BROADCAST(&cf->dl_cond);
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
     send = len;
     if (offset_start < dl_offset
@@ -1456,7 +1484,6 @@ bgdl: {
                 = ActiveDownload_find(cf, next_dl_offset);
             if (next_seg_missing && next_ad == NULL) {
                 ActiveDownload_add(cf, next_dl_offset);
-                PTHREAD_COND_BROADCAST(&cf->dl_cond);
                 PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
                 PTHREAD_MUTEX_UNLOCK(&cf->w_lock);
                 Cache_bgdl_launcher(cf, next_dl_offset);

--- a/src/cache.c
+++ b/src/cache.c
@@ -686,6 +686,9 @@ static Cache *Cache_alloc(void)
     PTHREAD_MUTEX_INIT(&cf->dl_lock, NULL);
     cf->active_dls = NULL;
     cf->cache_opened = 1;
+    cf->waiters = 0;
+    PTHREAD_COND_INIT(&cf->shutdown_cond, NULL);
+    cf->shutting_down = 0;
 
     cf->num_bg_workers = MIN(CONFIG.max_conns, DEFAULT_NETWORK_MAX_CONNS) / 2;
     if (cf->num_bg_workers <= 0) {
@@ -710,6 +713,7 @@ static void Cache_free(Cache *cf)
     }
 
     PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+    cf->shutting_down = 1;
     ActiveDownload *ad = cf->active_dls;
     cf->active_dls = NULL;
     while (ad) {
@@ -721,14 +725,19 @@ static void Cache_free(Cache *cf)
                     (intmax_t)ad->offset, ad->refcount - 1);
         }
         ad->next = NULL;
+        PTHREAD_COND_BROADCAST(&ad->cond);
         ActiveDownload_unref(ad);
         ad = next;
+    }
+    while (cf->waiters > 0) {
+        PTHREAD_COND_WAIT(&cf->shutdown_cond, &cf->dl_lock);
     }
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
 
     PTHREAD_MUTEX_DESTROY(&cf->seek_lock);
     PTHREAD_MUTEX_DESTROY(&cf->w_lock);
     PTHREAD_MUTEX_DESTROY(&cf->dl_lock);
+    PTHREAD_COND_DESTROY(&cf->shutdown_cond);
     SEM_DESTROY(&cf->bgt_sem);
 
     FREE(cf);
@@ -1337,12 +1346,21 @@ retry:
         ad->refcount++;
         ActiveDownload *orig_ad = ad;
 
-        while (ActiveDownload_find(cf, dl_offset) == orig_ad) {
+        cf->waiters++;
+
+        while (!cf->shutting_down
+               && ActiveDownload_find(cf, dl_offset) == orig_ad) {
             if (orig_ad->ts && orig_ad->ts->data
                 && orig_ad->ts->curr_size
                        >= (size_t)(offset_start - dl_offset + len)) {
                 memcpy(output_buf,
                        orig_ad->ts->data + (offset_start - dl_offset), len);
+
+                cf->waiters--;
+                if (cf->shutting_down && cf->waiters == 0) {
+                    PTHREAD_COND_BROADCAST(&cf->shutdown_cond);
+                }
+
                 ActiveDownload_unref(orig_ad);
                 PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
                 send = len;
@@ -1350,8 +1368,20 @@ retry:
             }
             PTHREAD_COND_WAIT(&orig_ad->cond, &cf->dl_lock);
         }
+
+        cf->waiters--;
+        int was_shutdown = cf->shutting_down;
+        if (cf->shutting_down && cf->waiters == 0) {
+            PTHREAD_COND_BROADCAST(&cf->shutdown_cond);
+        }
+
         ActiveDownload_unref(orig_ad);
         PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
+        if (was_shutdown) {
+            return -EIO;
+        }
+
         PTHREAD_MUTEX_LOCK(&cf->w_lock);
         if (Seg_exist(cf, dl_offset)) {
             send = Data_read(cf, (uint8_t *)output_buf, len, offset_start);

--- a/src/cache.h
+++ b/src/cache.h
@@ -79,6 +79,13 @@ struct Cache {
     /** \brief active downloads list */
     ActiveDownload *active_dls;
 
+    /** \brief Count of active waiters on download segments */
+    int waiters;
+    /** \brief Condition variable for cache shutdown synchronization */
+    pthread_cond_t shutdown_cond;
+    /** \brief Flag indicating that cache shutdown is in progress */
+    int shutting_down;
+
     /** \brief Number of background workers */
     int num_bg_workers;
 };

--- a/src/cache.h
+++ b/src/cache.h
@@ -1,6 +1,10 @@
 #ifndef CACHE_H
 #define CACHE_H
 #include <sys/types.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <semaphore.h>
 
 /**
  * \file cache.h
@@ -22,13 +26,18 @@ struct TransferStruct;
 typedef struct ActiveDownload {
     off_t offset;
     struct TransferStruct *ts;
+    pthread_cond_t cond;
+    /**
+     * \brief Reference count for lifetime management.
+     * \details Starts at 1 when added to cf->active_dls.
+     * Each waiter thread increments the reference count before waiting.
+     * When unlinked from the list in ActiveDownload_remove, the list's
+     * reference is dropped. The structure is freed only when the reference
+     * count reaches 0.
+     */
+    int refcount;
     struct ActiveDownload *next;
 } ActiveDownload;
-
-#include <stdio.h>
-#include <stdint.h>
-#include <pthread.h>
-#include <semaphore.h>
 
 /**
  * \brief Type definition for a cache segment
@@ -67,8 +76,6 @@ struct Cache {
 
     /** \brief mutex lock for background download progress */
     pthread_mutex_t dl_lock;
-    /** \brief condition variable for background download progress */
-    pthread_cond_t dl_cond;
     /** \brief active downloads list */
     ActiveDownload *active_dls;
 

--- a/src/link.c
+++ b/src/link.c
@@ -1271,8 +1271,14 @@ static void Link_download_finish_transfer(Cache *cf, off_t offset,
     ActiveDownload *ad = ActiveDownload_find(cf, offset);
     if (ad && ad->ts == ts) {
         ad->ts = NULL;
+        /* Broadcast to wake waiters so they observe that the transfer is done.
+         * Although the waiter loop will see ad->ts == NULL and temporarily
+         * block on cond wait again, the subsequent ActiveDownload_remove call
+         * will unlink the node and perform a second broadcast to let them
+         * exit the wait loop entirely. */
+        PTHREAD_COND_BROADCAST(&ad->cond);
     }
-    PTHREAD_COND_BROADCAST(&cf->dl_cond);
+    ts->ad_ptr = NULL;
     PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
 }
 
@@ -1308,7 +1314,8 @@ long Link_download(Link *link, char *output_buf, size_t req_size, off_t offset,
             ActiveDownload *ad = ActiveDownload_find(cf, offset);
             if (ad) {
                 ad->ts = &ts;
-                PTHREAD_COND_BROADCAST(&cf->dl_cond);
+                ts.ad_ptr = ad;
+                PTHREAD_COND_BROADCAST(&ad->cond);
             }
             PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
         }

--- a/src/memcache.c
+++ b/src/memcache.c
@@ -1,5 +1,6 @@
 #include "memcache.h"
 
+#include "cache.h"
 #include "log.h"
 #include "util.h"
 
@@ -28,7 +29,9 @@ size_t write_memory_callback(void *recv_data, size_t size, size_t nmemb,
     ts->data[ts->curr_size] = '\0';
 
     if (ts->cache_ptr) {
-        PTHREAD_COND_BROADCAST(&ts->cache_ptr->dl_cond);
+        if (ts->ad_ptr) {
+            PTHREAD_COND_BROADCAST(&ts->ad_ptr->cond);
+        }
         PTHREAD_MUTEX_UNLOCK(&ts->cache_ptr->dl_lock);
     }
 

--- a/src/memcache.h
+++ b/src/memcache.h
@@ -23,6 +23,8 @@ struct TransferStruct {
     Link *link;
     /** \brief The Cache structure associated with the transfer */
     Cache *cache_ptr;
+    /** \brief The ActiveDownload structure associated with the transfer */
+    struct ActiveDownload *ad_ptr;
 };
 
 /**

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -332,6 +332,65 @@ void test_Cache_alloc_num_bg_workers(void)
     CONFIG.max_conns = old_max_conns;
 }
 
+void test_Cache_free_active_downloads(void)
+{
+    const char *tmp_cache_dir = "./test_cache_free_ad_dir";
+    setup_temp_cache_dir(tmp_cache_dir);
+
+    char *old_cache_dir = CONFIG.cache_dir;
+    CONFIG.cache_dir = (char *)tmp_cache_dir;
+
+    LinkTable *table = setup_mock_link_table("dummy.bin");
+
+    LinkTable *old_root_link_tbl = ROOT_LINK_TBL;
+    ROOT_LINK_TBL = table;
+    int old_root_link_offset = ROOT_LINK_OFFSET;
+    ROOT_LINK_OFFSET = 20;
+
+    CacheSystem_init(tmp_cache_dir, 0);
+
+    Cache *cf = Cache_open("dummy.bin");
+    TEST_ASSERT_NOT_NULL(cf);
+
+    // Under the dl_lock, manually add mock ActiveDownload nodes to test
+    // Cache_free's teardown path
+    PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+
+    ActiveDownload *ad1 = CALLOC(1, sizeof(ActiveDownload));
+    ad1->offset = 1024;
+    ad1->refcount = 1;
+    PTHREAD_COND_INIT(&ad1->cond, NULL);
+
+    ActiveDownload *ad2 = CALLOC(1, sizeof(ActiveDownload));
+    ad2->offset = 2048;
+    ad2->refcount = 2; // Extra reference to trigger the warning/no-free path
+    PTHREAD_COND_INIT(&ad2->cond, NULL);
+
+    ad2->next = ad1;
+    cf->active_dls = ad2;
+
+    PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
+    // Call Cache_close to trigger Cache_free
+    Cache_close(cf);
+
+    // Verify ad2's refcount drops from 2 to 1 (due to dl list reference
+    // dropping)
+    TEST_ASSERT_EQUAL_INT(1, ad2->refcount);
+
+    // Clean up ad2 manually to prevent leak warnings
+    PTHREAD_COND_DESTROY(&ad2->cond);
+    FREE(ad2);
+
+    // Cleanup
+    ROOT_LINK_TBL = old_root_link_tbl;
+    ROOT_LINK_OFFSET = old_root_link_offset;
+    LinkTable_free(table);
+    CacheSystem_cleanup();
+    CONFIG.cache_dir = old_cache_dir;
+    cleanup_temp_dir(tmp_cache_dir);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -344,5 +403,6 @@ int main(void)
     RUN_TEST(test_Cache_read_null_link);
     RUN_TEST(test_Cache_invalid_zero_length_disk_files);
     RUN_TEST(test_Cache_alloc_num_bg_workers);
+    RUN_TEST(test_Cache_free_active_downloads);
     return UNITY_END();
 }

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -391,6 +391,93 @@ void test_Cache_free_active_downloads(void)
     cleanup_temp_dir(tmp_cache_dir);
 }
 
+struct WaiterThreadArgs {
+    Cache *cf;
+    char *buf;
+    off_t len;
+    off_t offset;
+    long expected_res;
+};
+
+static void *waiter_thread_func(void *arg)
+{
+    struct WaiterThreadArgs *args = (struct WaiterThreadArgs *)arg;
+    long res = Cache_read(args->cf, args->buf, args->len, args->offset);
+    args->expected_res = res;
+    return NULL;
+}
+
+void test_Cache_free_active_downloads_with_waiters(void)
+{
+    const char *tmp_cache_dir = "./test_cache_free_ad_wait_dir";
+    setup_temp_cache_dir(tmp_cache_dir);
+
+    char *old_cache_dir = CONFIG.cache_dir;
+    CONFIG.cache_dir = (char *)tmp_cache_dir;
+
+    LinkTable *table = setup_mock_link_table("dummy.bin");
+
+    LinkTable *old_root_link_tbl = ROOT_LINK_TBL;
+    ROOT_LINK_TBL = table;
+    int old_root_link_offset = ROOT_LINK_OFFSET;
+    ROOT_LINK_OFFSET = 20;
+
+    CacheSystem_init(tmp_cache_dir, 0);
+
+    Cache *cf = Cache_open("dummy.bin");
+    TEST_ASSERT_NOT_NULL(cf);
+
+    // Manually inject an active download so any reader will block
+    PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+    ActiveDownload *ad = CALLOC(1, sizeof(ActiveDownload));
+    ad->offset = 0;
+    ad->refcount = 1;
+    PTHREAD_COND_INIT(&ad->cond, NULL);
+    cf->active_dls = ad;
+    PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+
+    // Spawn waiter thread
+    pthread_t thread;
+    char buf[64];
+    struct WaiterThreadArgs args = {.cf = cf,
+                                    .buf = buf,
+                                    .len = sizeof(buf),
+                                    .offset = 0,
+                                    .expected_res = 0};
+
+    TEST_ASSERT_EQUAL_INT(
+        0, pthread_create(&thread, NULL, waiter_thread_func, &args));
+
+    // Wait until the reader thread registers as a waiter
+    while (1) {
+        PTHREAD_MUTEX_LOCK(&cf->dl_lock);
+        int has_waiter = (cf->waiters == 1);
+        PTHREAD_MUTEX_UNLOCK(&cf->dl_lock);
+        if (has_waiter) {
+            break;
+        }
+        usleep(1000);
+    }
+
+    // Call Cache_close which triggers Cache_free, setting shutting_down to 1,
+    // waking all waiters and joining them before tearing down
+    Cache_close(cf);
+
+    // Join the helper thread
+    TEST_ASSERT_EQUAL_INT(0, pthread_join(thread, NULL));
+
+    // The read must have been aborted with -EIO due to shutdown
+    TEST_ASSERT_EQUAL_INT(-EIO, args.expected_res);
+
+    // Cleanup
+    ROOT_LINK_TBL = old_root_link_tbl;
+    ROOT_LINK_OFFSET = old_root_link_offset;
+    LinkTable_free(table);
+    CacheSystem_cleanup();
+    CONFIG.cache_dir = old_cache_dir;
+    cleanup_temp_dir(tmp_cache_dir);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -404,5 +491,6 @@ int main(void)
     RUN_TEST(test_Cache_invalid_zero_length_disk_files);
     RUN_TEST(test_Cache_alloc_num_bg_workers);
     RUN_TEST(test_Cache_free_active_downloads);
+    RUN_TEST(test_Cache_free_active_downloads_with_waiters);
     return UNITY_END();
 }


### PR DESCRIPTION
cache: optimize thread wakeup signaling

    Optimize Cache thread scheduling by replacing the global condition
    variable (dl_cond) in the Cache structure with segment-specific
    condition variables (cond) inside ActiveDownload tracker nodes. This
    prevents waking up all waiting FUSE threads when a download segment
    finishes or updates, significantly reducing thread scheduling overhead.

    Implement a reference-counting mechanism (refcount) on ActiveDownload
    nodes to prevent Use-After-Free (UAF) vulnerabilities where waiting
    FUSE threads access freed ActiveDownload nodes after wakeups.

    Detailed changes:
    - Add a per-segment condition variable and reference counter to
      ActiveDownload.
    - Implement ActiveDownload_unref to safely destroy condition
      variables and free nodes when the reference count reaches zero.
    - Update Cache_read_segment to track active waiters by incrementing the
      refcount, waiting on the per-segment condition variable, and safely
      handling early returns and post-wait cleanup.
    - Safe-guard Cache_free by unlinking, broadcasting, and unrefing all
      remaining active downloads under dl_lock to prevent UAF on shutdown.
    - Store the ActiveDownload pointer in TransferStruct (ad_ptr) to
      allow O(1) condition variable broadcasts inside
      write_memory_callback.
    - Document refcounting semantics and double-broadcast behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to per-download signaling with reference-counted download objects to reduce contention and better manage lifecycle.
* **Bug Fixes**
  * Improved waiter wakeups and shutdown handling to avoid missed signals, premature frees, and stalled readers during in-progress downloads.
* **Tests**
  * Added unit tests covering cache teardown, active-download cleanup, and shutdown behavior with blocked readers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->