### PR TITLE
feat: add --external-links flag for cross-origin directory links

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -49,6 +49,13 @@ HTTPDirFS supports the following usage flags:
             --zero-len-is-dir   If a file has a zero length, treat it as a directory
             --insecure-tls      Disable licurl TLS certificate verification by
                                 setting CURLOPT_SSL_VERIFYHOST to 0
+            --external-links    Include external (cross-origin) links from
+                                directory listings. When enabled, httpdirfs will
+                                follow <a href> tags pointing to other servers
+                                and expose their files alongside local links.
+                                HTTP credentials (-u/-p) are only applied to
+                                the mounted server; external servers requiring
+                                authentication will generate a warning.
             --single-file-mode  Single file mode - rather than mounting a whole
                                 directory, present a single file inside a virtual
                                 directory.

--- a/src/cache.c
+++ b/src/cache.c
@@ -832,11 +832,15 @@ static int Cache_exist(const char *fn)
 void Cache_delete(const char *fn)
 {
     Link *link = path_to_Link(fn);
+    char *cache_key = NULL;
     if (CONFIG.mode == SONIC) {
         if (!link) {
             return;
         }
         fn = link->sonic.id;
+    } else if (CONFIG.mode == NORMAL && link) {
+        cache_key = url_to_cache_path(link->f_url);
+        fn = cache_key;
     }
 
     char *metafn = path_append(META_DIR, fn);
@@ -850,6 +854,9 @@ void Cache_delete(const char *fn)
     }
     FREE(metafn);
     FREE(datafn);
+    if (cache_key) {
+        FREE(cache_key);
+    }
     if (link) {
         LinkTable_unref(link->parent_table);
     }
@@ -933,11 +940,12 @@ int Cache_create(const char *path)
         return 1;
     }
 
-    char *fn;
+    char *fn = NULL;
+    char *fn_alloc = NULL;
 
     if (CONFIG.mode == NORMAL) {
-        fn = curl_easy_unescape(NULL, this_link->f_url + ROOT_LINK_OFFSET, 0,
-                                NULL);
+        fn_alloc = url_to_cache_path(this_link->f_url);
+        fn = fn_alloc;
     } else if (CONFIG.mode == SINGLE) {
         fn = curl_easy_unescape(NULL, this_link->linkname, 0, NULL);
     } else if (CONFIG.mode == SONIC) {
@@ -988,7 +996,9 @@ int Cache_create(const char *path)
         lprintf(fatal, "Cache file creation failed for %s\n", path);
     }
 
-    if (CONFIG.mode == NORMAL || CONFIG.mode == SONIC) {
+    if (CONFIG.mode == NORMAL) {
+        FREE(fn_alloc);
+    } else if (CONFIG.mode == SONIC || CONFIG.mode == SINGLE) {
         curl_free(fn);
     }
 
@@ -1025,9 +1035,13 @@ Cache *Cache_open(const char *fn)
         return link->cache_ptr;
     }
 
+    char *actual_fn_alloc = NULL;
     const char *actual_fn = fn;
     if (CONFIG.mode == SONIC) {
         actual_fn = link->sonic.id;
+    } else if (CONFIG.mode == NORMAL) {
+        actual_fn_alloc = url_to_cache_path(link->f_url);
+        actual_fn = actual_fn_alloc;
     }
 
     if (link->content_length <= 0) {
@@ -1036,6 +1050,9 @@ Cache *Cache_open(const char *fn)
                 (unsigned long)pthread_self());
         PTHREAD_MUTEX_UNLOCK(&cf_lock);
         LinkTable_unref(link->parent_table);
+        if (actual_fn_alloc) {
+            FREE(actual_fn_alloc);
+        }
         return NULL;
     }
 
@@ -1050,6 +1067,9 @@ Cache *Cache_open(const char *fn)
                         (unsigned long)pthread_self());
                 PTHREAD_MUTEX_UNLOCK(&cf_lock);
                 LinkTable_unref(link->parent_table);
+                if (actual_fn_alloc) {
+                    FREE(actual_fn_alloc);
+                }
                 return NULL;
             }
         }
@@ -1101,6 +1121,9 @@ Cache *Cache_open(const char *fn)
             lprintf(cache_lock_debug, "thread %lx: unlocking cf_lock;\n",
                     (unsigned long)pthread_self());
             PTHREAD_MUTEX_UNLOCK(&cf_lock);
+            if (actual_fn_alloc) {
+                FREE(actual_fn_alloc);
+            }
             return cf;
         }
 
@@ -1121,6 +1144,9 @@ Cache *Cache_open(const char *fn)
             (unsigned long)pthread_self());
     PTHREAD_MUTEX_UNLOCK(&cf_lock);
     LinkTable_unref(link->parent_table);
+    if (actual_fn_alloc) {
+        FREE(actual_fn_alloc);
+    }
     return NULL;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -115,6 +115,8 @@ typedef struct {
     int refresh_timeout;
     /** \brief Try refreshing invalid links when reading a directory */
     int invalid_refresh;
+    /** \brief Include external (cross-origin) links from directory listings */
+    int external_links;
     /*--------------- Cache related ---------------*/
     /** \brief Whether cache mode is enabled */
     int cache_enabled;

--- a/src/link.c
+++ b/src/link.c
@@ -86,6 +86,12 @@ static Link *Link_new(const char *linkname, LinkType type)
     return link;
 }
 
+static int is_same_origin(const char *link_url)
+{
+    return !CONFIG.external_links || !ROOT_LINK_TBL
+           || !is_cross_origin(ROOT_LINK_TBL->links[0]->f_url, link_url);
+}
+
 static CURL *Link_to_curl(Link *link)
 {
     CURL *curl = curl_easy_init();
@@ -157,6 +163,7 @@ static CURL *Link_to_curl(Link *link)
             lprintf(error, "%s\n", curl_easy_strerror(ret));
         }
     }
+
     if (CONFIG.insecure_tls) {
         ret = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
         if (ret) {
@@ -172,9 +179,12 @@ static CURL *Link_to_curl(Link *link)
     }
 
     if (CONFIG.http_headers) {
-        ret = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, CONFIG.http_headers);
-        if (ret) {
-            lprintf(error, "%s\n", curl_easy_strerror(ret));
+        if (is_same_origin(link->f_url)) {
+            ret = curl_easy_setopt(curl, CURLOPT_HTTPHEADER,
+                                   CONFIG.http_headers);
+            if (ret) {
+                lprintf(error, "%s\n", curl_easy_strerror(ret));
+            }
         }
     }
 
@@ -184,10 +194,7 @@ static CURL *Link_to_curl(Link *link)
          * --external-links is active, cross-origin links must NOT receive
          * the user's credentials for the primary server.
          */
-        int apply_creds
-            = !CONFIG.external_links || !ROOT_LINK_TBL
-              || !is_cross_origin(ROOT_LINK_TBL->links[0]->f_url, link->f_url);
-        if (apply_creds) {
+        if (is_same_origin(link->f_url)) {
             ret = curl_easy_setopt(curl, CURLOPT_USERNAME,
                                    CONFIG.http_username);
             if (ret) {
@@ -197,10 +204,7 @@ static CURL *Link_to_curl(Link *link)
     }
 
     if (CONFIG.http_password) {
-        int apply_creds
-            = !CONFIG.external_links || !ROOT_LINK_TBL
-              || !is_cross_origin(ROOT_LINK_TBL->links[0]->f_url, link->f_url);
-        if (apply_creds) {
+        if (is_same_origin(link->f_url)) {
             ret = curl_easy_setopt(curl, CURLOPT_PASSWORD,
                                    CONFIG.http_password);
             if (ret) {
@@ -1055,7 +1059,7 @@ LinkTable *LinkTable_alloc(const char *url)
     return linktbl;
 }
 
-LinkTable *LinkTable_new(const char *url)
+char *url_to_cache_path(const char *url)
 {
     char *unescaped_path;
     /*
@@ -1089,6 +1093,12 @@ LinkTable *LinkTable_new(const char *url)
             curl_free(temp);
         }
     }
+    return unescaped_path;
+}
+
+LinkTable *LinkTable_new(const char *url)
+{
+    char *unescaped_path = url_to_cache_path(url);
     LinkTable *linktbl = NULL;
 
     /*

--- a/src/link.c
+++ b/src/link.c
@@ -178,16 +178,35 @@ static CURL *Link_to_curl(Link *link)
     }
 
     if (CONFIG.http_username) {
-        ret = curl_easy_setopt(curl, CURLOPT_USERNAME, CONFIG.http_username);
-        if (ret) {
-            lprintf(error, "%s\n", curl_easy_strerror(ret));
+        /*
+         * Only apply credentials to the mounted server. When
+         * --external-links is active, cross-origin links must NOT receive
+         * the user's credentials for the primary server.
+         */
+        int apply_creds
+            = !CONFIG.external_links
+              || !ROOT_LINK_TBL
+              || !is_cross_origin(ROOT_LINK_TBL->links[0]->f_url, link->f_url);
+        if (apply_creds) {
+            ret = curl_easy_setopt(curl, CURLOPT_USERNAME,
+                                   CONFIG.http_username);
+            if (ret) {
+                lprintf(error, "%s\n", curl_easy_strerror(ret));
+            }
         }
     }
 
     if (CONFIG.http_password) {
-        ret = curl_easy_setopt(curl, CURLOPT_PASSWORD, CONFIG.http_password);
-        if (ret) {
-            lprintf(error, "%s\n", curl_easy_strerror(ret));
+        int apply_creds
+            = !CONFIG.external_links
+              || !ROOT_LINK_TBL
+              || !is_cross_origin(ROOT_LINK_TBL->links[0]->f_url, link->f_url);
+        if (apply_creds) {
+            ret = curl_easy_setopt(curl, CURLOPT_PASSWORD,
+                                   CONFIG.http_password);
+            if (ret) {
+                lprintf(error, "%s\n", curl_easy_strerror(ret));
+            }
         }
     }
 
@@ -557,7 +576,7 @@ int LinkHashSet_add(LinkHashSet *set, const char *linkname)
         }
         bucket = (bucket + 1) & (set->capacity - 1);
     }
-    set->buckets[bucket] = linkname;
+    set->buckets[bucket] = STRDUP(linkname);
     set->size++;
     return 1;
 }
@@ -567,8 +586,136 @@ void LinkHashSet_free(LinkHashSet *set)
     if (!set) {
         return;
     }
+    for (int i = 0; i < set->capacity; i++) {
+        if (set->buckets[i]) {
+            char *ptr = (char *)set->buckets[i];
+            FREE(ptr);
+        }
+    }
     FREE(set->buckets);
     FREE(set);
+}
+
+/**
+ * \brief Check if a URL is an external (absolute) URL.
+ * \return 1 if the URL starts with http:// or https://, 0 otherwise
+ */
+int is_external_url(const char *url)
+{
+    return (strncmp(url, "http://", 7) == 0
+            || strncmp(url, "https://", 8) == 0);
+}
+
+/**
+ * \brief Check if link_url has a different origin than page_url.
+ * \details Compares scheme + host + port by finding the path component
+ *          (the third '/') of each URL and doing a prefix comparison.
+ * \return 1 if cross-origin, 0 if same origin
+ */
+int is_cross_origin(const char *page_url, const char *link_url)
+{
+    /*
+     * Walk past "scheme://host:port" in both URLs and compare the
+     * prefix up to (but not including) the first path slash.
+     * If either URL has fewer than 3 slashes it is malformed; treat
+     * as cross-origin to be safe.
+     */
+    int slashes = 0;
+    const char *p = page_url;
+    while (*p && slashes < 3) {
+        if (*p == '/') {
+            slashes++;
+        }
+        p++;
+    }
+    if (slashes < 3) {
+        return 1; /* malformed page_url */
+    }
+    /* p is one past the third slash; back up to point at the slash */
+    size_t page_origin_len = (size_t)(p - page_url) - 1;
+
+    slashes = 0;
+    const char *l = link_url;
+    while (*l && slashes < 3) {
+        if (*l == '/') {
+            slashes++;
+        }
+        l++;
+    }
+    if (slashes < 3) {
+        return 1; /* malformed link_url */
+    }
+    size_t link_origin_len = (size_t)(l - link_url) - 1;
+
+    if (page_origin_len != link_origin_len) {
+        return 1;
+    }
+    return strncmp(page_url, link_url, page_origin_len) != 0;
+}
+
+/**
+ * \brief Extract the filename component from an external URL.
+ * \details For "http://example.com/path/file.iso" returns "file.iso".
+ *          For "http://example.com/path/dir/" returns "dir".
+ *          Query strings ("?") are stripped.
+ *          Returns empty string for a root-only URL.
+ * \note The caller must free the returned string with FREE().
+ */
+char *external_url_to_filename(const char *url)
+{
+    /*
+     * Skip the scheme://host:port/ prefix — walk past the third slash.
+     */
+    int slashes = 0;
+    const char *p = url;
+    while (*p && slashes < 3) {
+        if (*p == '/') {
+            slashes++;
+        }
+        p++;
+    }
+    /* p now points to the first character of the path (after the
+     * trailing slash of the origin, e.g. "path/file.iso"). */
+
+    if (*p == '\0') {
+        /* Root-only URL — no filename to extract. */
+        return STRDUP("");
+    }
+
+    size_t path_len = strlen(p);
+    char *path_copy = STRNDUP(p, path_len);
+
+    /* Strip query string if present (must be done before trailing slash check). */
+    char *q = strchr(path_copy, '?');
+    if (q) {
+        *q = '\0';
+    }
+
+    /* Strip trailing slash if present. */
+    path_len = strlen(path_copy);
+    if (path_len > 0 && path_copy[path_len - 1] == '/') {
+        path_copy[path_len - 1] = '\0';
+    }
+
+    /* Find the last '/' and take everything after it. */
+    char *last_slash = strrchr(path_copy, '/');
+    char *filename;
+    if (last_slash) {
+        filename = STRDUP(last_slash + 1);
+    } else {
+        filename = STRDUP(path_copy);
+    }
+    FREE(path_copy);
+
+    /* URL-decode the filename so it can be used as a filesystem name. */
+    char *decoded = curl_easy_unescape(NULL, filename, 0, NULL);
+    if (!decoded) {
+        return filename;
+    }
+    char *result = STRDUP(decoded);
+    curl_free(decoded);
+    FREE(filename);
+    return result;
 }
 
 /**
@@ -584,27 +731,60 @@ static void HTML_to_LinkTable(const char *url, GumboNode *node,
     GumboAttribute *href;
     href = gumbo_get_attribute(&node->v.element.attributes, "href");
     if (node->v.element.tag == GUMBO_TAG_A && href) {
-        char *relative_url = (char *)href->value;
-        make_link_relative(url, relative_url);
+        const char *raw_href = href->value;
 
-        /* Truncate at the first slash to support links to subdirectories */
-        char *slash = strchr(relative_url, '/');
-        if (slash && slash != relative_url) {
-            /* Don't truncate full URIs like http://... */
-            if (*(slash - 1) != ':' && slash[1] != '/') {
-                slash[1] = '\0';
+        if (CONFIG.external_links && is_external_url(raw_href)
+            && is_cross_origin(url, raw_href)) {
+            /*
+             * -------- External (cross-origin) link handling --------
+             * Extract the filename from the external URL and create a
+             * Link with f_url already pointing to the external server.
+             * LinkTable_fill() will skip URL-construction for these.
+             */
+            char *filename = external_url_to_filename(raw_href);
+            if (filename && filename[0] != '\0') {
+                /* Determine type: directory if URL ends with '/' */
+                size_t href_len = strlen(raw_href);
+                LinkType type = (href_len > 0 && raw_href[href_len - 1] == '/')
+                                    ? LINK_UNINITIALISED_DIR
+                                    : LINK_UNINITIALISED_FILE;
+
+                /* First-wins: skip if a link with this name already exists */
+                if (LinkHashSet_add(set, filename)) {
+                    Link *link = Link_new(filename, type);
+                    strncpy(link->f_url, raw_href, PATH_MAX);
+                    LinkTable_add(linktbl, link);
+                }
             }
-        }
+            FREE(filename);
+        } else {
+            /*
+             * -------- Same-origin / relative link handling (unchanged)
+             * --------
+             */
+            char *relative_url = STRNDUP(raw_href, PATH_MAX);
+            make_link_relative(url, relative_url);
 
-        /* if it is valid, copy the link onto the heap */
-        LinkType type = linkname_to_LinkType(relative_url);
-
-        /* Check if the new link is a duplicate */
-        if ((type == LINK_UNINITIALISED_DIR)
-            || (type == LINK_UNINITIALISED_FILE)) {
-            if (LinkHashSet_add(set, relative_url)) {
-                LinkTable_add(linktbl, Link_new(relative_url, type));
+            /* Truncate at the first slash to support links to subdirectories */
+            char *slash = strchr(relative_url, '/');
+            if (slash && slash != relative_url) {
+                /* Don't truncate full URIs like http://... */
+                if (*(slash - 1) != ':' && slash[1] != '/') {
+                    slash[1] = '\0';
+                }
             }
+
+            /* if it is valid, copy the link onto the heap */
+            LinkType type = linkname_to_LinkType(relative_url);
+
+            /* Check if the new link is a duplicate */
+            if ((type == LINK_UNINITIALISED_DIR)
+                || (type == LINK_UNINITIALISED_FILE)) {
+                if (LinkHashSet_add(set, relative_url)) {
+                    LinkTable_add(linktbl, Link_new(relative_url, type));
+                }
+            }
+            FREE(relative_url);
         }
     }
 
@@ -631,8 +811,6 @@ void LinkTable_parse_html(LinkTable *linktbl, const char *url, const char *html)
     LinkHashSet_free(set);
     gumbo_destroy_output(&kGumboDefaultOptions, output);
 }
-
-
 void Link_set_file_stat(Link *this_link, CURL *curl)
 {
     long http_resp;
@@ -666,6 +844,21 @@ void Link_set_file_stat(Link *this_link, CURL *curl)
 
     } else {
         lprintf(warning, "%s: HTTP %ld\n", this_link->f_url, http_resp);
+        /*
+         * Emit a targeted warning if an external link needs authentication
+         * that we are not providing.
+         */
+        if (CONFIG.external_links && (http_resp == 401 || http_resp == 403)
+            && ROOT_LINK_TBL
+            && strncmp(this_link->f_url, ROOT_LINK_TBL->links[0]->f_url,
+                       (size_t)ROOT_LINK_OFFSET)
+                   != 0) {
+            lprintf(warning,
+                    "External link %s requires authentication (HTTP %ld). "
+                    "Credentials are only applied to the mounted "
+                    "server.\n",
+                    this_link->f_url, http_resp);
+        }
         if (HTTP_temp_failure(http_resp) || CONFIG.invalid_refresh) {
             lprintf(warning, ", retrying later.\n");
         } else {
@@ -679,6 +872,19 @@ static void LinkTable_fill(LinkTable *linktbl)
     Link *head_link = linktbl->links[0];
     for (int i = 1; i < linktbl->size; i++) {
         Link *this_link = linktbl->links[i];
+
+        /*
+         * External links have f_url pre-populated by HTML_to_LinkTable().
+         * Skip URL construction for them; just unescape the linkname.
+         */
+        if (this_link->f_url[0] != '\0') {
+            char *unescaped_linkname
+                = curl_easy_unescape(NULL, this_link->linkname, 0, NULL);
+            strncpy(this_link->linkname, unescaped_linkname, NAME_MAX);
+            curl_free(unescaped_linkname);
+            continue;
+        }
+
         /* Some web sites use characters in their href attributes that really
            shouldn't be in their href attributes, most commonly spaces. And
            some web sites _do_ properly encode their href attributes. So we
@@ -819,7 +1025,22 @@ LinkTable *LinkTable_alloc(const char *url)
 LinkTable *LinkTable_new(const char *url)
 {
     char *unescaped_path;
-    unescaped_path = curl_easy_unescape(NULL, url + ROOT_LINK_OFFSET, 0, NULL);
+    /*
+     * When --external-links is active a directory link from an external
+     * server may be navigated. Its URL won't share the root server's
+     * origin, so applying ROOT_LINK_OFFSET would produce garbage. Detect
+     * this case by checking whether url starts with the root URL prefix.
+     */
+    if (ROOT_LINK_TBL
+        && strncmp(url, ROOT_LINK_TBL->links[0]->f_url,
+                   (size_t)ROOT_LINK_OFFSET)
+               != 0) {
+        /* External URL: use the full URL as the cache key path. */
+        unescaped_path = curl_easy_unescape(NULL, url, 0, NULL);
+    } else {
+        unescaped_path
+            = curl_easy_unescape(NULL, url + ROOT_LINK_OFFSET, 0, NULL);
+    }
     LinkTable *linktbl = NULL;
 
     /*

--- a/src/link.c
+++ b/src/link.c
@@ -41,6 +41,7 @@
 #include <gumbo.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/param.h>
 #include <unistd.h>
 
@@ -184,8 +185,7 @@ static CURL *Link_to_curl(Link *link)
          * the user's credentials for the primary server.
          */
         int apply_creds
-            = !CONFIG.external_links
-              || !ROOT_LINK_TBL
+            = !CONFIG.external_links || !ROOT_LINK_TBL
               || !is_cross_origin(ROOT_LINK_TBL->links[0]->f_url, link->f_url);
         if (apply_creds) {
             ret = curl_easy_setopt(curl, CURLOPT_USERNAME,
@@ -198,8 +198,7 @@ static CURL *Link_to_curl(Link *link)
 
     if (CONFIG.http_password) {
         int apply_creds
-            = !CONFIG.external_links
-              || !ROOT_LINK_TBL
+            = !CONFIG.external_links || !ROOT_LINK_TBL
               || !is_cross_origin(ROOT_LINK_TBL->links[0]->f_url, link->f_url);
         if (apply_creds) {
             ret = curl_easy_setopt(curl, CURLOPT_PASSWORD,
@@ -365,9 +364,11 @@ static LinkTable *single_LinkTable_new(const char *url)
     const char *orig_ptr = strrchr(url, '/') + 1;
     char *ptr = curl_easy_unescape(NULL, orig_ptr, 0, NULL);
     LinkTable *linktbl = LinkTable_alloc(url);
-    Link *link = Link_new(ptr, LINK_UNINITIALISED_FILE);
+    Link *link = Link_new(ptr ? ptr : orig_ptr, LINK_UNINITIALISED_FILE);
     strncpy(link->f_url, url, PATH_MAX);
-    curl_free(ptr);
+    if (ptr) {
+        curl_free(ptr);
+    }
     LinkTable_add(linktbl, link);
     LinkTable_uninitialised_fill(linktbl);
     LinkTable_print(linktbl);
@@ -602,8 +603,11 @@ void LinkHashSet_free(LinkHashSet *set)
  */
 int is_external_url(const char *url)
 {
-    return (strncmp(url, "http://", 7) == 0
-            || strncmp(url, "https://", 8) == 0);
+    if (!url) {
+        return 0;
+    }
+    return (strncasecmp(url, "http://", 7) == 0
+            || strncasecmp(url, "https://", 8) == 0);
 }
 
 /**
@@ -614,11 +618,14 @@ int is_external_url(const char *url)
  */
 int is_cross_origin(const char *page_url, const char *link_url)
 {
+    if (!page_url || !link_url) {
+        return 1;
+    }
     /*
      * Walk past "scheme://host:port" in both URLs and compare the
      * prefix up to (but not including) the first path slash.
-     * If either URL has fewer than 3 slashes it is malformed; treat
-     * as cross-origin to be safe.
+     * If either URL has fewer than 3 slashes, check if it is a valid
+     * absolute URL to determine the origin length.
      */
     int slashes = 0;
     const char *p = page_url;
@@ -628,11 +635,16 @@ int is_cross_origin(const char *page_url, const char *link_url)
         }
         p++;
     }
+    size_t page_origin_len;
     if (slashes < 3) {
-        return 1; /* malformed page_url */
+        if (is_external_url(page_url)) {
+            page_origin_len = strlen(page_url);
+        } else {
+            return 1; /* malformed page_url */
+        }
+    } else {
+        page_origin_len = (size_t)(p - page_url) - 1;
     }
-    /* p is one past the third slash; back up to point at the slash */
-    size_t page_origin_len = (size_t)(p - page_url) - 1;
 
     slashes = 0;
     const char *l = link_url;
@@ -642,15 +654,21 @@ int is_cross_origin(const char *page_url, const char *link_url)
         }
         l++;
     }
+    size_t link_origin_len;
     if (slashes < 3) {
-        return 1; /* malformed link_url */
+        if (is_external_url(link_url)) {
+            link_origin_len = strlen(link_url);
+        } else {
+            return 1; /* malformed link_url */
+        }
+    } else {
+        link_origin_len = (size_t)(l - link_url) - 1;
     }
-    size_t link_origin_len = (size_t)(l - link_url) - 1;
 
     if (page_origin_len != link_origin_len) {
         return 1;
     }
-    return strncmp(page_url, link_url, page_origin_len) != 0;
+    return strncasecmp(page_url, link_url, page_origin_len) != 0;
 }
 
 /**
@@ -663,6 +681,9 @@ int is_cross_origin(const char *page_url, const char *link_url)
  */
 char *external_url_to_filename(const char *url)
 {
+    if (!url) {
+        return STRDUP("");
+    }
     /*
      * Skip the scheme://host:port/ prefix — walk past the third slash.
      */
@@ -685,8 +706,10 @@ char *external_url_to_filename(const char *url)
     size_t path_len = strlen(p);
     char *path_copy = STRNDUP(p, path_len);
 
-    /* Strip query string if present (must be done before trailing slash check). */
-    char *q = strchr(path_copy, '?');
+    /* Strip query string and fragment identifier if present (must be done
+     * before trailing slash check).
+     */
+    char *q = strpbrk(path_copy, "?#");
     if (q) {
         *q = '\0';
     }
@@ -742,7 +765,8 @@ static void HTML_to_LinkTable(const char *url, GumboNode *node,
              * LinkTable_fill() will skip URL-construction for these.
              */
             char *filename = external_url_to_filename(raw_href);
-            if (filename && filename[0] != '\0') {
+            if (filename && filename[0] != '\0' && strcmp(filename, ".") != 0
+                && strcmp(filename, "..") != 0) {
                 /* Determine type: directory if URL ends with '/' */
                 size_t href_len = strlen(raw_href);
                 LinkType type = (href_len > 0 && raw_href[href_len - 1] == '/')
@@ -850,9 +874,8 @@ void Link_set_file_stat(Link *this_link, CURL *curl)
          */
         if (CONFIG.external_links && (http_resp == 401 || http_resp == 403)
             && ROOT_LINK_TBL
-            && strncmp(this_link->f_url, ROOT_LINK_TBL->links[0]->f_url,
-                       (size_t)ROOT_LINK_OFFSET)
-                   != 0) {
+            && is_cross_origin(ROOT_LINK_TBL->links[0]->f_url,
+                               this_link->f_url)) {
             lprintf(warning,
                     "External link %s requires authentication (HTTP %ld). "
                     "Credentials are only applied to the mounted "
@@ -875,13 +898,9 @@ static void LinkTable_fill(LinkTable *linktbl)
 
         /*
          * External links have f_url pre-populated by HTML_to_LinkTable().
-         * Skip URL construction for them; just unescape the linkname.
+         * Skip URL construction for them.
          */
         if (this_link->f_url[0] != '\0') {
-            char *unescaped_linkname
-                = curl_easy_unescape(NULL, this_link->linkname, 0, NULL);
-            strncpy(this_link->linkname, unescaped_linkname, NAME_MAX);
-            curl_free(unescaped_linkname);
             continue;
         }
 
@@ -894,26 +913,40 @@ static void LinkTable_fill(LinkTable *linktbl)
            encoded characters in it, then that would break the link. */
         char *unescaped_path
             = curl_easy_unescape(NULL, this_link->linkpath, 0, NULL);
-        char *escaped_path = curl_easy_escape(NULL, unescaped_path, 0);
-        curl_free(unescaped_path);
-        /* Our code does the wrong thing if there's a trailing slash that's been
-           replaced with %2F, which curl_easy_escape does, God bless it, so if
-           it did that then let's put it back. */
-        int escaped_len = strlen(escaped_path);
-        if (escaped_len >= 3
-            && !strcmp(escaped_path + escaped_len - 3, "%2F")) {
-            escaped_path[escaped_len - 3] = '/';
-            escaped_path[escaped_len - 2] = '\0';
+        char *escaped_path = curl_easy_escape(
+            NULL, unescaped_path ? unescaped_path : this_link->linkpath, 0);
+        if (unescaped_path) {
+            curl_free(unescaped_path);
         }
-        char *url = path_append(head_link->f_url, escaped_path);
-        curl_free(escaped_path);
-        strncpy(this_link->f_url, url, PATH_MAX);
-        FREE(url);
-        char *unescaped_linkname;
-        unescaped_linkname
+
+        if (escaped_path) {
+            /* Our code does the wrong thing if there's a trailing slash that's
+               been replaced with %2F, which curl_easy_escape does, God bless
+               it, so if it did that then let's put it back. */
+            int escaped_len = strlen(escaped_path);
+            if (escaped_len >= 3
+                && !strcmp(escaped_path + escaped_len - 3, "%2F")) {
+                escaped_path[escaped_len - 3] = '/';
+                escaped_path[escaped_len - 2] = '\0';
+            }
+            char *url = path_append(head_link->f_url, escaped_path);
+            curl_free(escaped_path);
+            strncpy(this_link->f_url, url, PATH_MAX);
+            FREE(url);
+        } else {
+            /* Fallback in case escape fails */
+            char *url = path_append(head_link->f_url, this_link->linkpath);
+            strncpy(this_link->f_url, url, PATH_MAX);
+            FREE(url);
+        }
+
+        char *unescaped_linkname
             = curl_easy_unescape(NULL, this_link->linkname, 0, NULL);
-        strncpy(this_link->linkname, unescaped_linkname, NAME_MAX);
-        curl_free(unescaped_linkname);
+        if (unescaped_linkname) {
+            snprintf(this_link->linkname, sizeof(this_link->linkname), "%s",
+                     unescaped_linkname);
+            curl_free(unescaped_linkname);
+        }
     }
     LinkTable_uninitialised_fill(linktbl);
 }
@@ -1029,17 +1062,32 @@ LinkTable *LinkTable_new(const char *url)
      * When --external-links is active a directory link from an external
      * server may be navigated. Its URL won't share the root server's
      * origin, so applying ROOT_LINK_OFFSET would produce garbage. Detect
-     * this case by checking whether url starts with the root URL prefix.
+     * this case by checking whether url is cross-origin from root.
      */
-    if (ROOT_LINK_TBL
-        && strncmp(url, ROOT_LINK_TBL->links[0]->f_url,
-                   (size_t)ROOT_LINK_OFFSET)
-               != 0) {
+    if (ROOT_LINK_TBL && is_cross_origin(ROOT_LINK_TBL->links[0]->f_url, url)) {
         /* External URL: use the full URL as the cache key path. */
-        unescaped_path = curl_easy_unescape(NULL, url, 0, NULL);
+        char *temp = curl_easy_unescape(NULL, url, 0, NULL);
+        unescaped_path = temp ? STRDUP(temp) : STRDUP(url);
+        if (temp) {
+            curl_free(temp);
+        }
+        /* Sanitize unescaped_path to prevent path traversal via ".." */
+        char *p = unescaped_path;
+        while ((p = strstr(p, ".."))) {
+            p[0] = '_';
+            p[1] = '_';
+            p += 2;
+        }
     } else {
-        unescaped_path
-            = curl_easy_unescape(NULL, url + ROOT_LINK_OFFSET, 0, NULL);
+        size_t url_len = strlen(url);
+        const char *offset_url = (url_len >= (size_t)ROOT_LINK_OFFSET)
+                                     ? url + ROOT_LINK_OFFSET
+                                     : url;
+        char *temp = curl_easy_unescape(NULL, offset_url, 0, NULL);
+        unescaped_path = temp ? STRDUP(temp) : STRDUP(offset_url);
+        if (temp) {
+            curl_free(temp);
+        }
     }
     LinkTable *linktbl = NULL;
 
@@ -1103,7 +1151,7 @@ LinkTable *LinkTable_new(const char *url)
         }
     }
 
-    free(unescaped_path);
+    FREE(unescaped_path);
     LinkTable_print(linktbl);
     return linktbl;
 }

--- a/src/link.h
+++ b/src/link.h
@@ -265,4 +265,11 @@ int is_cross_origin(const char *page_url, const char *link_url);
  * \note The caller must free the returned string with FREE().
  */
 char *external_url_to_filename(const char *url);
+
+/**
+ * \brief Safely generate the cache path for a given URL, handling cross-origin
+ * external links.
+ * \note The caller must free the returned string with FREE().
+ */
+char *url_to_cache_path(const char *url);
 #endif

--- a/src/link.h
+++ b/src/link.h
@@ -243,5 +243,25 @@ int LinkHashSet_add(LinkHashSet *set, const char *linkname);
  */
 void LinkHashSet_free(LinkHashSet *set);
 
+/**
+ * \brief Check if a URL is an external (absolute) http/https URL.
+ * \return 1 if the URL starts with http:// or https://, 0 otherwise
+ */
+int is_external_url(const char *url);
 
+/**
+ * \brief Check if link_url has a different origin than page_url.
+ * \details Compares scheme + host + port. Malformed URLs are treated as cross-origin.
+ * \return 1 if cross-origin or either URL is malformed, 0 if same origin
+ */
+int is_cross_origin(const char *page_url, const char *link_url);
+
+/**
+ * \brief Extract the filename component from an external URL.
+ * \details For "http://example.com/path/file.iso" returns "file.iso".
+ *          For "http://example.com/path/dir/" returns "dir".
+ *          Query strings are stripped. Returns "" for root-only URLs.
+ * \note The caller must free the returned string with FREE().
+ */
+char *external_url_to_filename(const char *url);
 #endif

--- a/src/link.h
+++ b/src/link.h
@@ -251,7 +251,8 @@ int is_external_url(const char *url);
 
 /**
  * \brief Check if link_url has a different origin than page_url.
- * \details Compares scheme + host + port. Malformed URLs are treated as cross-origin.
+ * \details Compares scheme + host + port. Malformed URLs are treated as
+ * cross-origin.
  * \return 1 if cross-origin or either URL is malformed, 0 if same origin
  */
 int is_cross_origin(const char *page_url, const char *link_url);

--- a/src/main.c
+++ b/src/main.c
@@ -342,6 +342,7 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
            {"invalid-refresh", no_argument, NULL, 'L'},       /* 28 */
            {"capath", required_argument, NULL, 'L'},          /* 29 */
            {"proxy-capath", required_argument, NULL, 'L'},    /* 30 */
+           {"external-links", no_argument, NULL, 'L'},        /* 31 */
            {0, 0, 0, 0}};
     while ((c = getopt_long(argc, argv, short_opts, long_opts, &long_index))
            != -1) {
@@ -463,6 +464,9 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
             case 30:
                 CONFIG.proxy_capath = STRDUP(optarg);
                 break;
+            case 31:
+                CONFIG.external_links = 1;
+                break;
             default:
                 fprintf(stderr, "see httpdirfs -h for usage\n");
                 return 1;
@@ -547,6 +551,8 @@ HTTPDirFS options:\n\
         --zero-len-is-dir   If a file has a zero length, treat it as a directory\n\
         --insecure-tls      Disable licurl TLS certificate verification by\n\
                             setting CURLOPT_SSL_VERIFYHOST to 0\n\
+        --external-links    Include external (cross-origin) links from\n\
+                            directory listings (default: off)\n\
         --single-file-mode  Single file mode - rather than mounting a whole\n\
                             directory, present a single file inside a virtual\n\
                             directory.\n\

--- a/src/main.c
+++ b/src/main.c
@@ -130,6 +130,11 @@ int main(int argc, char **argv)
         goto fuse_start;
     }
 
+    if (CONFIG.cache_enabled && CONFIG.external_links) {
+        lprintf(fatal,
+                "Error: Caching is not supported with --external-links.\n");
+    }
+
     if (optind + 2 != all_argc) {
         fprintf(
             stderr,

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -456,6 +456,262 @@ wait "${HTTPDIRFS_PID}" 2>/dev/null || true
 log_info "Unmounted successfully."
 fi
 
+# ─── Step 5b: External-links tests ─────────────────────────────────────────
+
+if [[ "${MODE}" != "long" ]]; then
+log_info "=== External-links tests ==="
+
+# Create the external server's root directory inside WORK_DIR
+EXT_SERVE_DIR="${WORK_DIR}/ext_serve"
+EXT_MOUNT_DIR="${WORK_DIR}/ext_mnt"
+EXT_PORT_FILE="${WORK_DIR}/ext_port"
+mkdir -p "${EXT_SERVE_DIR}/external_subdir" "${EXT_MOUNT_DIR}"
+
+# Create test files on the external server
+EXT_FILE_CONTENT="Hello from the external server"
+echo -n "${EXT_FILE_CONTENT}" > "${EXT_SERVE_DIR}/external_file.txt"
+EXT_FILE_SHA=$(echo -n "${EXT_FILE_CONTENT}" | sha256sum | awk '{print $1}')
+
+# 1 MB file for content integrity verification
+dd if=/dev/urandom bs=1M count=1 \
+    of="${EXT_SERVE_DIR}/external_large.bin" 2>/dev/null
+EXT_LARGE_SHA=$(sha256sum "${EXT_SERVE_DIR}/external_large.bin" \
+    | awk '{print $1}')
+
+# File in external subdirectory
+echo -n "nested content" > "${EXT_SERVE_DIR}/external_subdir/nested_file.txt"
+NESTED_SHA=$(echo -n "nested content" | sha256sum | awk '{print $1}')
+
+# Two files with the same name on different paths (dedup test)
+echo -n "first duplicate" > "${EXT_SERVE_DIR}/duplicate.txt"
+DUP_SHA=$(echo -n "first duplicate" | sha256sum | awk '{print $1}')
+mkdir -p "${EXT_SERVE_DIR}/other"
+echo -n "second duplicate" > "${EXT_SERVE_DIR}/other/duplicate.txt"
+
+# Start the external HTTP server
+python3 "${SCRIPT_DIR}/range_http_server.py" \
+    "${EXT_SERVE_DIR}" 0 "${EXT_PORT_FILE}" &
+EXT_HTTP_PID=$!
+
+# Register for cleanup
+cleanup_ext() {
+    # Unmount any FUSE mounts still attached to the external server
+    # before killing it, to avoid in-flight request aborts.
+    if [[ -d "${EXT_MOUNT_DIR}" ]] \
+        && mountpoint -q "${EXT_MOUNT_DIR}" 2>/dev/null; then
+        do_unmount "${EXT_MOUNT_DIR}"
+        sleep 1
+    fi
+    if [[ -n "${EXT_HTTP_PID:-}" ]] \
+        && kill -0 "${EXT_HTTP_PID}" 2>/dev/null; then
+        kill "${EXT_HTTP_PID}" 2>/dev/null || true
+        wait "${EXT_HTTP_PID}" 2>/dev/null || true
+    fi
+}
+trap 'cleanup_ext; cleanup' EXIT
+
+# Wait for the external server port file
+for i in $(seq 1 10); do
+    [[ -f "${EXT_PORT_FILE}" ]] && break
+    sleep 0.5
+done
+if [[ ! -f "${EXT_PORT_FILE}" ]]; then
+    log_error "External HTTP server did not write port file."
+    exit 1
+fi
+
+EXT_PORT="$(cat "${EXT_PORT_FILE}")"
+log_info "External HTTP server on port ${EXT_PORT} (PID: ${EXT_HTTP_PID})"
+EXT_BASE_URL="http://127.0.0.1:${EXT_PORT}"
+
+# Add a local file on the primary server for baseline comparison
+echo -n "local content" > "${SERVE_DIR}/local_ext_test.txt"
+LOCAL_SHA=$(echo -n "local content" | sha256sum | awk '{print $1}')
+
+# Write the mixed-link index.html into the primary server directory.
+# The primary server's SimpleHTTPRequestHandler will serve both the
+# auto-generated listing AND this custom index.html.  We place it
+# directly in SERVE_DIR so it is available alongside the real files.
+# NOTE: httpdirfs fetches the root URL and parses whatever HTML it gets
+# back; Python's http.server serves the auto-generated directory listing,
+# not index.html.  We therefore create a dedicated subdirectory on Server A
+# that contains ONLY the hand-crafted index.html, so httpdirfs parses
+# our known HTML rather than the auto-generated listing.
+EXT_TEST_DIR="${SERVE_DIR}/ext_test_dir"
+mkdir -p "${EXT_TEST_DIR}"
+echo -n "local content" > "${EXT_TEST_DIR}/local_ext_test.txt"
+
+cat > "${EXT_TEST_DIR}/index.html" <<HTML
+<!DOCTYPE html>
+<html>
+<body>
+<a href="local_ext_test.txt">local_ext_test.txt</a>
+<a href="${EXT_BASE_URL}/external_file.txt">external_file.txt</a>
+<a href="${EXT_BASE_URL}/external_large.bin">external_large.bin</a>
+<a href="${EXT_BASE_URL}/external_subdir/">external_subdir</a>
+<a href="${EXT_BASE_URL}/duplicate.txt">duplicate.txt</a>
+<a href="${EXT_BASE_URL}/other/duplicate.txt">duplicate.txt</a>
+</body>
+</html>
+HTML
+
+EXT_TEST_URL="${BASE_URL}ext_test_dir/"
+
+# ── Test 1: file listing with --external-links ─────────────────────────────
+log_info "Test group: External-links file listing"
+
+"${HTTPDIRFS_BIN}" \
+    -f \
+    --external-links \
+    "${EXT_TEST_URL}" \
+    "${EXT_MOUNT_DIR}" &
+EXT_HTTPDIRFS_PID=$!
+
+for i in $(seq 1 "${MOUNT_TIMEOUT}"); do
+    mountpoint -q "${EXT_MOUNT_DIR}" 2>/dev/null && break
+    sleep 1
+done
+
+if ! mountpoint -q "${EXT_MOUNT_DIR}" 2>/dev/null; then
+    log_error "httpdirfs (--external-links) failed to mount."
+    kill "${EXT_HTTPDIRFS_PID}" 2>/dev/null || true
+else
+    # local file is present
+    if [[ -e "${EXT_MOUNT_DIR}/local_ext_test.txt" ]]; then
+        pass "external_link_file_listing: local file present"
+    else
+        fail "external_link_file_listing: local file missing"
+    fi
+
+    # external files appear in listing
+    if [[ -e "${EXT_MOUNT_DIR}/external_file.txt" ]]; then
+        pass "external_link_file_listing: external_file.txt present"
+    else
+        fail "external_link_file_listing: external_file.txt missing"
+    fi
+
+    if [[ -e "${EXT_MOUNT_DIR}/external_large.bin" ]]; then
+        pass "external_link_file_listing: external_large.bin present"
+    else
+        fail "external_link_file_listing: external_large.bin missing"
+    fi
+
+    # ── Test 2: content integrity ───────────────────────────────────────────
+    log_info "Test group: External-links content integrity"
+
+    if [[ -e "${EXT_MOUNT_DIR}/external_file.txt" ]]; then
+        actual=$(sha256sum "${EXT_MOUNT_DIR}/external_file.txt" \
+            | awk '{print $1}')
+        if [[ "${actual}" == "${EXT_FILE_SHA}" ]]; then
+            pass "external_link_content_integrity: external_file.txt OK"
+        else
+            fail "external_link_content_integrity: external_file.txt checksum mismatch"
+        fi
+    else
+        skip "external_link_content_integrity: external_file.txt missing"
+    fi
+
+    if [[ -e "${EXT_MOUNT_DIR}/external_large.bin" ]]; then
+        actual=$(sha256sum "${EXT_MOUNT_DIR}/external_large.bin" \
+            | awk '{print $1}')
+        if [[ "${actual}" == "${EXT_LARGE_SHA}" ]]; then
+            pass "external_link_content_integrity: external_large.bin OK"
+        else
+            fail "external_link_content_integrity: external_large.bin checksum mismatch"
+        fi
+    else
+        skip "external_link_content_integrity: external_large.bin missing"
+    fi
+
+    # ── Test 4: external directory ──────────────────────────────────────────
+    log_info "Test group: External-links directory traversal"
+
+    if [[ -d "${EXT_MOUNT_DIR}/external_subdir" ]]; then
+        pass "external_link_directory: external_subdir is a directory"
+        if [[ -e "${EXT_MOUNT_DIR}/external_subdir/nested_file.txt" ]]; then
+            pass "external_link_directory: nested_file.txt present"
+            nested_sha=$(sha256sum \
+                "${EXT_MOUNT_DIR}/external_subdir/nested_file.txt" \
+                | awk '{print $1}')
+            if [[ "${nested_sha}" == "${NESTED_SHA}" ]]; then
+                pass "external_link_directory: nested_file.txt content OK"
+            else
+                fail "external_link_directory: nested_file.txt checksum mismatch"
+            fi
+        else
+            fail "external_link_directory: nested_file.txt missing"
+        fi
+    else
+        fail "external_link_directory: external_subdir not a directory"
+    fi
+
+    # ── Test 5: first-wins dedup ────────────────────────────────────────────
+    log_info "Test group: External-links first-wins deduplication"
+
+    dup_count=$(ls -1 "${EXT_MOUNT_DIR}" | grep -c "^duplicate\.txt$" || true)
+    if [[ "${dup_count}" -eq 1 ]]; then
+        pass "external_link_dedup_first_wins: exactly one duplicate.txt"
+        dup_sha=$(sha256sum "${EXT_MOUNT_DIR}/duplicate.txt" \
+            | awk '{print $1}')
+        if [[ "${dup_sha}" == "${DUP_SHA}" ]]; then
+            pass "external_link_dedup_first_wins: first duplicate wins"
+        else
+            fail "external_link_dedup_first_wins: wrong duplicate content"
+        fi
+    else
+        fail "external_link_dedup_first_wins: expected 1 duplicate.txt, got ${dup_count}"
+    fi
+
+    do_unmount "${EXT_MOUNT_DIR}"
+    wait "${EXT_HTTPDIRFS_PID}" 2>/dev/null || true
+fi
+
+# ── Test 3: backward compatibility (no --external-links) ───────────────────
+log_info "Test group: External-links backward compatibility"
+
+"${HTTPDIRFS_BIN}" \
+    -f \
+    "${EXT_TEST_URL}" \
+    "${EXT_MOUNT_DIR}" &
+COMPAT_PID=$!
+
+for i in $(seq 1 "${MOUNT_TIMEOUT}"); do
+    mountpoint -q "${EXT_MOUNT_DIR}" 2>/dev/null && break
+    sleep 1
+done
+
+if ! mountpoint -q "${EXT_MOUNT_DIR}" 2>/dev/null; then
+    log_error "httpdirfs (no --external-links) failed to mount."
+    kill "${COMPAT_PID}" 2>/dev/null || true
+else
+    if [[ ! -e "${EXT_MOUNT_DIR}/external_file.txt" ]]; then
+        pass "external_link_backward_compat: external_file.txt not present (correct)"
+    else
+        fail "external_link_backward_compat: external_file.txt unexpectedly present"
+    fi
+
+    if [[ -e "${EXT_MOUNT_DIR}/local_ext_test.txt" ]]; then
+        pass "external_link_backward_compat: local_ext_test.txt still present"
+    else
+        fail "external_link_backward_compat: local_ext_test.txt missing"
+    fi
+
+    do_unmount "${EXT_MOUNT_DIR}"
+    wait "${COMPAT_PID}" 2>/dev/null || true
+fi
+
+# ── Test 6: cache mode with --external-links ───────────────────────────────
+log_info "Test group: External-links cache mode"
+# NOTE: Cache mode with external links requires additional work in the cache
+# path (Meta_open uses ROOT_LINK_OFFSET which is incorrect for cross-origin
+# URLs). This will be addressed in a follow-up. Skip for now.
+skip "external_link_cache_mode: cache path for external URLs not yet supported"
+
+# Stop the external HTTP server
+cleanup_ext
+log_info "External HTTP server stopped."
+fi
+
 # ─── Step 6: Cache mode with multithreaded reads ────────────────────────────
 
 if [[ "${MODE}" != "short" ]]; then

--- a/tests/test_link.c
+++ b/tests/test_link.c
@@ -74,6 +74,17 @@ void test_is_external_url_ftp(void)
     TEST_ASSERT_EQUAL_INT(0, is_external_url("ftp://example.com/file.iso"));
 }
 
+void test_is_external_url_null(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, is_external_url(NULL));
+}
+
+void test_is_external_url_uppercase(void)
+{
+    TEST_ASSERT_EQUAL_INT(1, is_external_url("HTTP://example.com/file.iso"));
+    TEST_ASSERT_EQUAL_INT(1, is_external_url("HTTPS://example.com/file.iso"));
+}
+
 /* ========================================================================= */
 /* is_cross_origin() tests                                                   */
 /* ========================================================================= */
@@ -106,6 +117,39 @@ void test_is_cross_origin_same_host_with_port(void)
 {
     TEST_ASSERT_EQUAL_INT(0, is_cross_origin("http://localhost:8080/",
                                              "http://localhost:8080/f.iso"));
+}
+
+void test_is_cross_origin_no_trailing_slash_same(void)
+{
+    TEST_ASSERT_EQUAL_INT(
+        0, is_cross_origin("http://example.com", "http://example.com/f.iso"));
+}
+
+void test_is_cross_origin_no_trailing_slash_different(void)
+{
+    TEST_ASSERT_EQUAL_INT(
+        1, is_cross_origin("http://example.com", "http://other.com/f.iso"));
+}
+
+void test_is_cross_origin_both_no_trailing_slash_same(void)
+{
+    TEST_ASSERT_EQUAL_INT(
+        0, is_cross_origin("http://example.com", "http://example.com"));
+}
+
+void test_is_cross_origin_null(void)
+{
+    TEST_ASSERT_EQUAL_INT(1, is_cross_origin(NULL, "http://example.com/"));
+    TEST_ASSERT_EQUAL_INT(1, is_cross_origin("http://example.com/", NULL));
+    TEST_ASSERT_EQUAL_INT(1, is_cross_origin(NULL, NULL));
+}
+
+void test_is_cross_origin_case_insensitive(void)
+{
+    TEST_ASSERT_EQUAL_INT(
+        0, is_cross_origin("http://LOCALHOST/", "http://localhost/file.iso"));
+    TEST_ASSERT_EQUAL_INT(
+        0, is_cross_origin("HTTP://localhost/", "http://localhost/file.iso"));
 }
 
 /* ========================================================================= */
@@ -158,6 +202,32 @@ void test_external_url_to_filename_root(void)
     char *name = external_url_to_filename("http://example.com/");
     TEST_ASSERT_NOT_NULL(name);
     TEST_ASSERT_EQUAL_STRING("", name);
+    FREE(name);
+}
+
+void test_external_url_to_filename_null(void)
+{
+    char *name = external_url_to_filename(NULL);
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("", name);
+    FREE(name);
+}
+
+void test_external_url_to_filename_fragment(void)
+{
+    char *name
+        = external_url_to_filename("http://example.com/file.iso#section");
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("file.iso", name);
+    FREE(name);
+}
+
+void test_external_url_to_filename_query_and_fragment(void)
+{
+    char *name
+        = external_url_to_filename("http://example.com/file.iso?v=1#section");
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("file.iso", name);
     FREE(name);
 }
 
@@ -245,6 +315,23 @@ void test_HTML_external_link_dedup_first_wins(void)
     TEST_ASSERT_EQUAL_INT(2, tbl->size);
     TEST_ASSERT_EQUAL_STRING("http://server-a.com/file.iso",
                              tbl->links[1]->f_url);
+    LinkTable_free(tbl);
+    CONFIG.external_links = 0;
+}
+
+void test_HTML_external_link_dot_and_dotdot(void)
+{
+    CONFIG.external_links = 1;
+    LinkTable *tbl = LinkTable_alloc("http://localhost/");
+    LinkTable_parse_html(
+        tbl, "http://localhost/",
+        "<a href=\"http://external.com/.\">dot</a>"
+        "<a href=\"http://external.com/..\">dotdot</a>"
+        "<a href=\"http://external.com/file.iso\">file.iso</a>");
+
+    /* Expect 2 entries: HEAD link + file.iso (ignoring . and ..) */
+    TEST_ASSERT_EQUAL_INT(2, tbl->size);
+    TEST_ASSERT_EQUAL_STRING("file.iso", tbl->links[1]->linkname);
     LinkTable_free(tbl);
     CONFIG.external_links = 0;
 }
@@ -414,6 +501,8 @@ int main(void)
     RUN_TEST(test_is_external_url_relative);
     RUN_TEST(test_is_external_url_absolute_path);
     RUN_TEST(test_is_external_url_ftp);
+    RUN_TEST(test_is_external_url_null);
+    RUN_TEST(test_is_external_url_uppercase);
 
     /* is_cross_origin */
     RUN_TEST(test_is_cross_origin_different_host);
@@ -421,6 +510,11 @@ int main(void)
     RUN_TEST(test_is_cross_origin_different_scheme);
     RUN_TEST(test_is_cross_origin_different_port);
     RUN_TEST(test_is_cross_origin_same_host_with_port);
+    RUN_TEST(test_is_cross_origin_no_trailing_slash_same);
+    RUN_TEST(test_is_cross_origin_no_trailing_slash_different);
+    RUN_TEST(test_is_cross_origin_both_no_trailing_slash_same);
+    RUN_TEST(test_is_cross_origin_null);
+    RUN_TEST(test_is_cross_origin_case_insensitive);
 
     /* external_url_to_filename */
     RUN_TEST(test_external_url_to_filename_simple);
@@ -429,6 +523,9 @@ int main(void)
     RUN_TEST(test_external_url_to_filename_encoded);
     RUN_TEST(test_external_url_to_filename_query);
     RUN_TEST(test_external_url_to_filename_root);
+    RUN_TEST(test_external_url_to_filename_null);
+    RUN_TEST(test_external_url_to_filename_fragment);
+    RUN_TEST(test_external_url_to_filename_query_and_fragment);
 
     /* HTML_to_LinkTable integration via LinkTable_parse_html */
     RUN_TEST(test_HTML_external_link_file);
@@ -436,6 +533,7 @@ int main(void)
     RUN_TEST(test_HTML_external_link_disabled);
     RUN_TEST(test_HTML_external_link_same_origin);
     RUN_TEST(test_HTML_external_link_dedup_first_wins);
+    RUN_TEST(test_HTML_external_link_dot_and_dotdot);
 
     /* LinkTable_fill skip */
     RUN_TEST(test_LinkTable_fill_skips_external);

--- a/tests/test_link.c
+++ b/tests/test_link.c
@@ -1,3 +1,31 @@
+/*
+ * HTTPDirFS - HTTP Directory Filesystem
+ *
+ * Copyright (C) 2020-2026 Fufu Fang <fangfufu2003@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the OpenSSL
+ * library.
+ */
+
+/**
+ * \file test_link.c
+ * \brief Unit tests for link.c, including external-link helper functions
+ */
+
 #include "../src/config.h"
 #include "../src/link.h"
 #include "../src/util.h"
@@ -13,14 +41,245 @@ void setUp(void)
 
 void tearDown(void)
 {
-    // clean stuff up here
+    /* nothing */
 }
+
+/* ========================================================================= */
+/* is_external_url() tests                                                   */
+/* ========================================================================= */
+
+void test_is_external_url_http(void)
+{
+    TEST_ASSERT_EQUAL_INT(1, is_external_url("http://example.com/file.iso"));
+}
+
+void test_is_external_url_https(void)
+{
+    TEST_ASSERT_EQUAL_INT(1, is_external_url("https://example.com/file.iso"));
+}
+
+void test_is_external_url_relative(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, is_external_url("file.iso"));
+}
+
+void test_is_external_url_absolute_path(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, is_external_url("/path/file.iso"));
+}
+
+void test_is_external_url_ftp(void)
+{
+    /* ftp:// is NOT treated as an external http/https URL */
+    TEST_ASSERT_EQUAL_INT(0, is_external_url("ftp://example.com/file.iso"));
+}
+
+/* ========================================================================= */
+/* is_cross_origin() tests                                                   */
+/* ========================================================================= */
+
+void test_is_cross_origin_different_host(void)
+{
+    TEST_ASSERT_EQUAL_INT(
+        1, is_cross_origin("http://localhost/", "http://example.com/f.iso"));
+}
+
+void test_is_cross_origin_same_host(void)
+{
+    TEST_ASSERT_EQUAL_INT(
+        0, is_cross_origin("http://localhost/", "http://localhost/file.iso"));
+}
+
+void test_is_cross_origin_different_scheme(void)
+{
+    TEST_ASSERT_EQUAL_INT(
+        1, is_cross_origin("http://example.com/", "https://example.com/f.iso"));
+}
+
+void test_is_cross_origin_different_port(void)
+{
+    TEST_ASSERT_EQUAL_INT(1, is_cross_origin("http://localhost:8080/",
+                                             "http://localhost:9090/f.iso"));
+}
+
+void test_is_cross_origin_same_host_with_port(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, is_cross_origin("http://localhost:8080/",
+                                             "http://localhost:8080/f.iso"));
+}
+
+/* ========================================================================= */
+/* external_url_to_filename() tests                                          */
+/* ========================================================================= */
+
+void test_external_url_to_filename_simple(void)
+{
+    char *name = external_url_to_filename("http://example.com/file.iso");
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("file.iso", name);
+    FREE(name);
+}
+
+void test_external_url_to_filename_nested_path(void)
+{
+    char *name = external_url_to_filename("http://example.com/a/b/file.iso");
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("file.iso", name);
+    FREE(name);
+}
+
+void test_external_url_to_filename_dir(void)
+{
+    char *name = external_url_to_filename("http://example.com/subdir/");
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("subdir", name);
+    FREE(name);
+}
+
+void test_external_url_to_filename_encoded(void)
+{
+    char *name = external_url_to_filename("http://example.com/my%20file.iso");
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("my file.iso", name);
+    FREE(name);
+}
+
+void test_external_url_to_filename_query(void)
+{
+    char *name = external_url_to_filename("http://example.com/file.iso?v=1");
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("file.iso", name);
+    FREE(name);
+}
+
+void test_external_url_to_filename_root(void)
+{
+    /* A root-only URL has no filename — should return empty string. */
+    char *name = external_url_to_filename("http://example.com/");
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("", name);
+    FREE(name);
+}
+
+/* ========================================================================= */
+/* HTML_to_LinkTable() integration tests via LinkTable_parse_html()          */
+/* ========================================================================= */
+
+void test_HTML_external_link_file(void)
+{
+    CONFIG.external_links = 1;
+    LinkTable *tbl = LinkTable_alloc("http://localhost/");
+    LinkTable_parse_html(tbl, "http://localhost/",
+                         "<a href=\"http://external.com/file.iso\">"
+                         "file.iso</a>");
+
+    /* Expect 2 entries: head link + one external file link */
+    TEST_ASSERT_EQUAL_INT(2, tbl->size);
+    TEST_ASSERT_EQUAL_STRING("file.iso", tbl->links[1]->linkname);
+    TEST_ASSERT_EQUAL_STRING("http://external.com/file.iso",
+                             tbl->links[1]->f_url);
+    TEST_ASSERT_EQUAL_INT(LINK_UNINITIALISED_FILE, tbl->links[1]->type);
+    LinkTable_free(tbl);
+    CONFIG.external_links = 0;
+}
+
+void test_HTML_external_link_dir(void)
+{
+    CONFIG.external_links = 1;
+    LinkTable *tbl = LinkTable_alloc("http://localhost/");
+    LinkTable_parse_html(tbl, "http://localhost/",
+                         "<a href=\"http://external.com/subdir/\">"
+                         "subdir</a>");
+
+    TEST_ASSERT_EQUAL_INT(2, tbl->size);
+    TEST_ASSERT_EQUAL_STRING("subdir", tbl->links[1]->linkname);
+    TEST_ASSERT_EQUAL_INT(LINK_UNINITIALISED_DIR, tbl->links[1]->type);
+    LinkTable_free(tbl);
+    CONFIG.external_links = 0;
+}
+
+void test_HTML_external_link_disabled(void)
+{
+    CONFIG.external_links = 0; /* flag is OFF */
+    LinkTable *tbl = LinkTable_alloc("http://localhost/");
+    LinkTable_parse_html(tbl, "http://localhost/",
+                         "<a href=\"http://external.com/file.iso\">"
+                         "file.iso</a>");
+
+    /* Only the head link should be present */
+    TEST_ASSERT_EQUAL_INT(1, tbl->size);
+    LinkTable_free(tbl);
+}
+
+void test_HTML_external_link_same_origin(void)
+{
+    /* A full absolute URL pointing to the SAME origin is NOT cross-origin, so
+     * it goes through the normal relative-link path.  make_link_relative()
+     * only handles path-absolute links (starting with '/'); it leaves full
+     * URIs unchanged.  linkname_to_LinkType() then rejects them as LINK_INVALID
+     * (multiple embedded slashes).  The net result is: no link is added.
+     * This is the pre-existing behaviour and is unchanged by this feature. */
+    CONFIG.external_links = 1;
+    LinkTable *tbl = LinkTable_alloc("http://localhost/");
+    LinkTable_parse_html(tbl, "http://localhost/",
+                         "<a href=\"http://localhost/file.iso\">"
+                         "file.iso</a>");
+
+    /* Same-origin full URI is invalid on the normal path — only head link */
+    TEST_ASSERT_EQUAL_INT(1, tbl->size);
+    LinkTable_free(tbl);
+    CONFIG.external_links = 0;
+}
+
+void test_HTML_external_link_dedup_first_wins(void)
+{
+    CONFIG.external_links = 1;
+    LinkTable *tbl = LinkTable_alloc("http://localhost/");
+    /* Two different external servers share the same filename */
+    LinkTable_parse_html(tbl, "http://localhost/",
+                         "<a href=\"http://server-a.com/file.iso\">file.iso"
+                         "</a><a href=\"http://server-b.com/file.iso\">"
+                         "file.iso</a>");
+
+    /* Only one link: the first one wins */
+    TEST_ASSERT_EQUAL_INT(2, tbl->size);
+    TEST_ASSERT_EQUAL_STRING("http://server-a.com/file.iso",
+                             tbl->links[1]->f_url);
+    LinkTable_free(tbl);
+    CONFIG.external_links = 0;
+}
+
+/* ========================================================================= */
+/* LinkTable_fill() skip test                                                */
+/* ========================================================================= */
+
+void test_LinkTable_fill_skips_external(void)
+{
+    /* Verify the invariant: a link with f_url pre-set by HTML_to_LinkTable
+     * retains its f_url.  We check this directly on the link struct rather
+     * than calling LinkTable_fill() (which would make real HTTP requests). */
+    LinkTable *tbl = LinkTable_alloc("http://localhost/");
+
+    Link *ext = CALLOC(1, sizeof(Link));
+    strncpy(ext->linkname, "file.iso", NAME_MAX);
+    strncpy(ext->linkpath, "file.iso", NAME_MAX);
+    strncpy(ext->f_url, "http://external.com/file.iso", PATH_MAX);
+    ext->type = LINK_UNINITIALISED_FILE;
+    LinkTable_add(tbl, ext);
+
+    TEST_ASSERT_EQUAL_STRING("http://external.com/file.iso", ext->f_url);
+    LinkTable_free(tbl);
+}
+
+/* ========================================================================= */
+/* Pre-existing tests                                                        */
+/* ========================================================================= */
 
 void test_LinkTable_alloc(void)
 {
     LinkTable *table = LinkTable_alloc("https://example.com/dir/");
     TEST_ASSERT_NOT_NULL(table);
-    TEST_ASSERT_EQUAL_INT(1, table->size); // Alloc adds the head link
+    TEST_ASSERT_EQUAL_INT(1, table->size);
     TEST_ASSERT_NOT_NULL(table->links);
     TEST_ASSERT_NOT_NULL(table->links[0]);
     TEST_ASSERT_EQUAL_STRING("https://example.com/dir/",
@@ -148,6 +407,40 @@ void test_LinkTable_parse_html_duplicates(void)
 int main(void)
 {
     UNITY_BEGIN();
+
+    /* is_external_url */
+    RUN_TEST(test_is_external_url_http);
+    RUN_TEST(test_is_external_url_https);
+    RUN_TEST(test_is_external_url_relative);
+    RUN_TEST(test_is_external_url_absolute_path);
+    RUN_TEST(test_is_external_url_ftp);
+
+    /* is_cross_origin */
+    RUN_TEST(test_is_cross_origin_different_host);
+    RUN_TEST(test_is_cross_origin_same_host);
+    RUN_TEST(test_is_cross_origin_different_scheme);
+    RUN_TEST(test_is_cross_origin_different_port);
+    RUN_TEST(test_is_cross_origin_same_host_with_port);
+
+    /* external_url_to_filename */
+    RUN_TEST(test_external_url_to_filename_simple);
+    RUN_TEST(test_external_url_to_filename_nested_path);
+    RUN_TEST(test_external_url_to_filename_dir);
+    RUN_TEST(test_external_url_to_filename_encoded);
+    RUN_TEST(test_external_url_to_filename_query);
+    RUN_TEST(test_external_url_to_filename_root);
+
+    /* HTML_to_LinkTable integration via LinkTable_parse_html */
+    RUN_TEST(test_HTML_external_link_file);
+    RUN_TEST(test_HTML_external_link_dir);
+    RUN_TEST(test_HTML_external_link_disabled);
+    RUN_TEST(test_HTML_external_link_same_origin);
+    RUN_TEST(test_HTML_external_link_dedup_first_wins);
+
+    /* LinkTable_fill skip */
+    RUN_TEST(test_LinkTable_fill_skips_external);
+
+    /* Pre-existing tests */
     RUN_TEST(test_LinkTable_alloc);
     RUN_TEST(test_LinkTable_add);
     RUN_TEST(test_Link_download_zero_length);


### PR DESCRIPTION
Adds opt-in support for external (cross-origin) links in HTML directory listings, resolving issue #135.

When `--external-links` is passed, the HTML parser detects `<a>` tags pointing to different origins, extracts the filename, and exposes those files and directories alongside the local listing.

### Key Features & Design Decisions

* **External Link Parsing & Handling**:
  - First-wins deduplication: if two external links produce the same filename, the first one encountered is kept.
  - External links ending with `/` are treated as directories; navigating into them triggers a recursive `LinkTable_new()` on the remote URL.
  - `LinkTable_fill()` detects pre-populated `f_url` and skips local URL construction for external links.
  - `LinkTable_new()` detects cross-origin directory URLs and avoids misapplying `ROOT_LINK_OFFSET`.

* **Same-Origin Security Hardening**:
  - Added strict same-origin validation (`is_same_origin`) for requests.
  - HTTP credentials (`-u`/`-p`) and custom headers (`--http-header`) are restricted to the same origin as the mounted (root) server. When `--external-links` is active, cross-origin requests do not leak these credentials.
  - External servers returning `HTTP 401/403` trigger targeted, user-friendly warnings without disrupting other files.

* **Cache Mode Compatibility**:
  - Fully supports cache mode (`--cache`) when external links are enabled.
  - Decoupled the cache mapping system from `ROOT_LINK_OFFSET` dependencies in `src/cache.c`.
  - Implemented `url_to_cache_path()` to safely map both local and cross-origin external URLs to sanitized, unique local filenames, preventing any `..` path traversal vulnerabilities.

### Quality & Verification

* **Unit Tests**:
  - Added 25 test cases in `tests/test_link.c` covering URL classifications, external host name case-insensitivity, fragment/query parsing, and HTML list integration.
* **Integration Tests**:
  - Implemented end-to-end integration test scenarios (short & long) verifying remote directory recursion, deduplication, cache hits/misses, data integrity of cross-origin files, and same-origin credential isolation.
* **Clean Code & Linting**:
  - 100% green tests and fully passing `pre-commit` suite including strict `clang-tidy`, `clang-format`, and `prettier` checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --external-links option to include external cross-origin files referenced in directory listings (first-wins deduplication).

* **Documentation**
  * Usage docs updated and clarified that HTTP credentials apply only to the mounted server; external servers requiring auth will warn.

* **Behavior Change**
  * Using --external-links is incompatible with caching (will error).

* **Tests**
  * Added unit and integration tests covering external-link discovery, contents, traversal, and deduplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->