### PR TITLE
perf: optimize duplicate link detection during HTML parsing

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -440,6 +440,9 @@ static LinkType linkname_to_LinkType(const char *linkname)
  */
 static int linknames_equal(const char *str_a, const char *str_b)
 {
+    if (!str_a || !str_b) {
+        return 0;
+    }
     size_t len_a = strnlen(str_a, NAME_MAX);
     size_t len_b = strnlen(str_b, NAME_MAX);
     size_t max_len = MAX(len_a, len_b);
@@ -471,12 +474,109 @@ end:
     return identical;
 }
 
+typedef struct {
+    const char **buckets;
+    int capacity;
+    int size;
+} LinkHashSet;
+
+static unsigned int hash_str(const char *str)
+{
+    unsigned int hash = 5381;
+    int c;
+    size_t len = strnlen(str, NAME_MAX);
+
+    /* Strip all trailing slashes */
+    while (len > 0 && str[len - 1] == '/') {
+        len--;
+    }
+
+    for (size_t i = 0; i < len; i++) {
+        c = (unsigned char)str[i];
+        hash = ((hash << 5) + hash) + c;
+    }
+    return hash;
+}
+
+static LinkHashSet *LinkHashSet_new(int capacity)
+{
+    if (capacity <= 0) {
+        capacity = 16;
+    } else {
+        int power = 1;
+        while (power < capacity && power < (1 << 30)) {
+            power <<= 1;
+        }
+        capacity = power;
+    }
+    LinkHashSet *set = (LinkHashSet *)CALLOC(1, sizeof(LinkHashSet));
+    set->capacity = capacity;
+    set->buckets = (const char **)CALLOC(capacity, sizeof(const char *));
+    return set;
+}
+
+static void LinkHashSet_resize(LinkHashSet *set)
+{
+    if (set->capacity <= 0) {
+        return;
+    }
+    int old_capacity = set->capacity;
+    const char **old_buckets = set->buckets;
+    if (set->capacity > INT_MAX / 2) {
+        lprintf(fatal, "LinkHashSet capacity overflow\n");
+    }
+    set->capacity *= 2;
+    set->buckets = (const char **)CALLOC(set->capacity, sizeof(const char *));
+
+    for (int i = 0; i < old_capacity; i++) {
+        if (old_buckets[i]) {
+            unsigned int hash = link_hash_str(old_buckets[i]);
+            int bucket = hash & (set->capacity - 1);
+            while (set->buckets[bucket] != NULL) {
+                bucket = (bucket + 1) & (set->capacity - 1);
+            }
+            set->buckets[bucket] = old_buckets[i];
+        }
+    }
+    FREE(old_buckets);
+}
+
+static int LinkHashSet_add(LinkHashSet *set, const char *linkname)
+{
+    if (!set || !linkname || set->capacity <= 0) {
+        return 0;
+    }
+    if (set->size >= set->capacity / 2) {
+        LinkHashSet_resize(set);
+    }
+    unsigned int hash = link_hash_str(linkname);
+    int bucket = hash & (set->capacity - 1);
+    while (set->buckets[bucket] != NULL) {
+        if (linknames_equal(set->buckets[bucket], linkname)) {
+            return 0;
+        }
+        bucket = (bucket + 1) & (set->capacity - 1);
+    }
+    set->buckets[bucket] = linkname;
+    set->size++;
+    return 1;
+}
+
+static void LinkHashSet_free(LinkHashSet *set)
+{
+    if (!set) {
+        return;
+    }
+    FREE(set->buckets);
+    FREE(set);
+}
+
 /**
  * Shamelessly copied and pasted from:
  * https://github.com/google/gumbo-parser/blob/master/examples/find_links.cc
  */
 static void HTML_to_LinkTable(const char *url, GumboNode *node,
-                              LinkTable *linktbl)
+                              LinkTable *linktbl, LinkHashSet *set)
 {
     if (node->type != GUMBO_NODE_ELEMENT) {
         return;
@@ -502,15 +602,7 @@ static void HTML_to_LinkTable(const char *url, GumboNode *node,
         /* Check if the new link is a duplicate */
         if ((type == LINK_UNINITIALISED_DIR)
             || (type == LINK_UNINITIALISED_FILE)) {
-            int identical_link_found = 0;
-            for (int i = 0; i < linktbl->size; i++) {
-                if (linknames_equal(relative_url,
-                                    linktbl->links[i]->linkname)) {
-                    identical_link_found = 1;
-                    break;
-                }
-            }
-            if (!identical_link_found) {
+            if (LinkHashSet_add(set, relative_url)) {
                 LinkTable_add(linktbl, Link_new(relative_url, type));
             }
         }
@@ -519,9 +611,27 @@ static void HTML_to_LinkTable(const char *url, GumboNode *node,
     /* Note the recursive call */
     GumboVector *children = &node->v.element.children;
     for (size_t i = 0; i < children->length; ++i) {
-        HTML_to_LinkTable(url, (GumboNode *)children->data[i], linktbl);
+        HTML_to_LinkTable(url, (GumboNode *)children->data[i], linktbl, set);
     }
 }
+
+void LinkTable_parse_html(LinkTable *linktbl, const char *url, const char *html)
+{
+    if (!linktbl || !url || !html) {
+        return;
+    }
+    GumboOutput *output = gumbo_parse(html);
+    if (!output) {
+        return;
+    }
+    LinkHashSet *set = LinkHashSet_new(4096);
+    if (output->root) {
+        HTML_to_LinkTable(url, output->root, linktbl, set);
+    }
+    LinkHashSet_free(set);
+    gumbo_destroy_output(&kGumboDefaultOptions, output);
+}
+
 
 void Link_set_file_stat(Link *this_link, CURL *curl)
 {
@@ -759,7 +869,9 @@ LinkTable *LinkTable_new(const char *url)
          * Otherwise parsed the received data
          */
         GumboOutput *output = gumbo_parse(ts.data);
-        HTML_to_LinkTable(url, output->root, linktbl);
+        LinkHashSet *set = LinkHashSet_new(4096);
+        HTML_to_LinkTable(url, output->root, linktbl, set);
+        LinkHashSet_free(set);
         gumbo_destroy_output(&kGumboDefaultOptions, output);
         FREE(ts.data);
 

--- a/src/link.c
+++ b/src/link.c
@@ -435,10 +435,7 @@ static LinkType linkname_to_LinkType(const char *linkname)
     return LINK_UNINITIALISED_FILE;
 }
 
-/**
- * \brief check if two link names are equal, after taking the '/' into account.
- */
-static int linknames_equal(const char *str_a, const char *str_b)
+int link_linknames_equal(const char *str_a, const char *str_b)
 {
     if (!str_a || !str_b) {
         return 0;
@@ -474,13 +471,13 @@ end:
     return identical;
 }
 
-typedef struct {
+struct LinkHashSet {
     const char **buckets;
     int capacity;
     int size;
-} LinkHashSet;
+};
 
-static unsigned int hash_str(const char *str)
+unsigned int link_hash_str(const char *str)
 {
     unsigned int hash = 5381;
     int c;
@@ -498,7 +495,7 @@ static unsigned int hash_str(const char *str)
     return hash;
 }
 
-static LinkHashSet *LinkHashSet_new(int capacity)
+LinkHashSet *LinkHashSet_new(int capacity)
 {
     if (capacity <= 0) {
         capacity = 16;
@@ -541,7 +538,7 @@ static void LinkHashSet_resize(LinkHashSet *set)
     FREE(old_buckets);
 }
 
-static int LinkHashSet_add(LinkHashSet *set, const char *linkname)
+int LinkHashSet_add(LinkHashSet *set, const char *linkname)
 {
     if (!set || !linkname || set->capacity <= 0) {
         return 0;
@@ -552,7 +549,7 @@ static int LinkHashSet_add(LinkHashSet *set, const char *linkname)
     unsigned int hash = link_hash_str(linkname);
     int bucket = hash & (set->capacity - 1);
     while (set->buckets[bucket] != NULL) {
-        if (linknames_equal(set->buckets[bucket], linkname)) {
+        if (link_linknames_equal(set->buckets[bucket], linkname)) {
             return 0;
         }
         bucket = (bucket + 1) & (set->capacity - 1);
@@ -562,7 +559,7 @@ static int LinkHashSet_add(LinkHashSet *set, const char *linkname)
     return 1;
 }
 
-static void LinkHashSet_free(LinkHashSet *set)
+void LinkHashSet_free(LinkHashSet *set)
 {
     if (!set) {
         return;
@@ -868,12 +865,9 @@ LinkTable *LinkTable_new(const char *url)
         /*
          * Otherwise parsed the received data
          */
-        GumboOutput *output = gumbo_parse(ts.data);
-        LinkHashSet *set = LinkHashSet_new(4096);
-        HTML_to_LinkTable(url, output->root, linktbl, set);
-        LinkHashSet_free(set);
-        gumbo_destroy_output(&kGumboDefaultOptions, output);
+        LinkTable_parse_html(linktbl, url, ts.data);
         FREE(ts.data);
+
 
         LinkTable_fill(linktbl);
 

--- a/src/link.h
+++ b/src/link.h
@@ -194,4 +194,54 @@ void LinkTable_print(LinkTable *linktbl);
  * \brief add a Link to a LinkTable
  */
 void LinkTable_add(LinkTable *linktbl, Link *link);
+
+/**
+ * \brief Parse HTML content and populate LinkTable with unique links.
+ */
+void LinkTable_parse_html(LinkTable *linktbl, const char *url,
+                          const char *html);
+
+/*
+ * Functions exposed for unit testing duplicated URL logic
+ */
+typedef struct LinkHashSet LinkHashSet;
+
+/**
+ * \brief Check if two link names are equal, normalizing any single trailing
+ * slash.
+ * \param str_a The first link name string to compare.
+ * \param str_b The second link name string to compare.
+ * \return 1 if they are equivalent, 0 otherwise.
+ */
+int link_linknames_equal(const char *str_a, const char *str_b);
+
+/**
+ * \brief Generate a hash value for a link name, ignoring any trailing slashes.
+ * \param str The link name string to hash.
+ * \return The generated unsigned int hash value.
+ */
+unsigned int link_hash_str(const char *str);
+
+/**
+ * \brief Create a new LinkHashSet with a specified initial capacity.
+ * \param capacity The initial number of buckets to allocate.
+ * \return Pointer to the newly allocated LinkHashSet.
+ */
+LinkHashSet *LinkHashSet_new(int capacity);
+
+/**
+ * \brief Add a link name to the LinkHashSet if it is not already present.
+ * \param set The LinkHashSet to insert the link name into.
+ * \param linkname The link name string to add.
+ * \return 1 if successfully added (not a duplicate), 0 if it is a duplicate.
+ */
+int LinkHashSet_add(LinkHashSet *set, const char *linkname);
+
+/**
+ * \brief Free all memory allocated for a LinkHashSet.
+ * \param set The LinkHashSet to deallocate.
+ */
+void LinkHashSet_free(LinkHashSet *set);
+
+
 #endif

--- a/tests/integration/range_http_server.py
+++ b/tests/integration/range_http_server.py
@@ -28,6 +28,71 @@ class RangeHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         """Suppress default request logging."""
         pass
 
+    def list_directory(self, path):
+        """Override directory listing to inject duplicate/malformed URLs for deduplication testing."""
+        try:
+            files = os.listdir(path)
+        except OSError:
+            self.send_error(404, "No permission to list directory")
+            return None
+        files.sort(key=lambda a: a.lower())
+
+        import io
+        from html import escape as html_escape
+
+        r = []
+        displaypath = urllib.parse.unquote(self.path, errors='surrogatepass')
+        displaypath = html_escape(displaypath)
+        enc = sys.getfilesystemencoding()
+        title = f"Directory listing for {displaypath}"
+        r.append('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">')
+        r.append('<html>\n<head>')
+        r.append(f'<meta http-equiv="Content-Type" content="text/html; charset={enc}">')
+        r.append(f'<title>{title}</title>\n</head>\n<body>')
+        r.append(f'<h1>{title}</h1>\n<hr>\n<ul>')
+
+        for name in files:
+            fullname = os.path.join(path, name)
+            displayname = linkname = name
+
+            # Skip hidden files
+            if name.startswith('.'):
+                continue
+
+            # Append / for directories
+            if os.path.isdir(fullname):
+                displayname = name + "/"
+                linkname = name + "/"
+
+            displayname = html_escape(displayname)
+            linkname = urllib.parse.quote(linkname, errors='surrogatepass')
+            r.append(f'<li><a href="{linkname}">{displayname}</a></li>')
+
+            # Inject duplicate links specifically for testing duplicated URL handling
+            if name == "simple.txt":
+                # Duplicate 1: identical link
+                r.append(f'<li><a href="{linkname}">{displayname} (duplicate)</a></li>')
+                # Duplicate 2: trailing slash variation
+                r.append(f'<li><a href="{linkname}/">{displayname}/ (duplicate slash)</a></li>')
+            elif name == "subdir with spaces":
+                # Duplicate 1: identical link
+                r.append(f'<li><a href="{linkname}">{displayname} (duplicate)</a></li>')
+                # Duplicate 2: without trailing slash
+                no_slash_link = urllib.parse.quote(name, errors='surrogatepass')
+                r.append(f'<li><a href="{no_slash_link}">{html_escape(name)} (duplicate no slash)</a></li>')
+
+        r.append('</ul>\n<hr>\n</body>\n</html>\n')
+        encoded = '\n'.join(r).encode(enc, 'surrogateescape')
+        f = io.BytesIO()
+        f.write(encoded)
+        f.seek(0)
+        self.send_response(200)
+        self.send_header("Content-type", f"text/html; charset={enc}")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        return f
+
+
     def send_head(self):
         """Common code for GET and HEAD commands (with Range support).
 

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -428,6 +428,26 @@ else
     pass "Write correctly rejected (read-only filesystem)"
 fi
 
+# 4h. Test: Duplicated URL deduplication
+log_info "Test group: Duplicated URL deduplication"
+
+# Count the occurrences of 'simple.txt' in the mounted directory listing
+simple_count=$(ls -1 "${MOUNT_DIR}" | grep -Fxc "simple.txt" || true)
+if [[ "${simple_count}" -eq 1 ]]; then
+    pass "Duplicate 'simple.txt' links successfully deduplicated (count: 1)"
+else
+    fail "Deduplication failed for 'simple.txt' (count: ${simple_count})"
+fi
+
+# Count the occurrences of 'subdir with spaces' in the mounted directory listing
+subdir_count_dup=$(ls -1 "${MOUNT_DIR}" | grep -Fxc "subdir with spaces" || true)
+if [[ "${subdir_count_dup}" -eq 1 ]]; then
+    pass "Duplicate 'subdir with spaces' links successfully deduplicated (count: 1)"
+else
+    fail "Deduplication failed for 'subdir with spaces' (count: ${subdir_count_dup})"
+fi
+
+
 # ─── Step 5: Unmount non-cache mount ────────────────────────────────────────
 
 log_info "Unmounting non-cache mount..."

--- a/tests/test_link.c
+++ b/tests/test_link.c
@@ -66,11 +66,94 @@ void test_Link_download_zero_length(void)
     }
 }
 
+void test_link_linknames_equal(void)
+{
+    TEST_ASSERT_TRUE(link_linknames_equal("file.txt", "file.txt"));
+    TEST_ASSERT_TRUE(link_linknames_equal("file.txt", "file.txt/"));
+    TEST_ASSERT_TRUE(link_linknames_equal("file.txt/", "file.txt"));
+    TEST_ASSERT_TRUE(link_linknames_equal("dir/", "dir/"));
+    TEST_ASSERT_TRUE(link_linknames_equal("dir", "dir/"));
+
+    TEST_ASSERT_FALSE(link_linknames_equal("file.txt", "other.txt"));
+    TEST_ASSERT_FALSE(link_linknames_equal("file.txt", "file.txt//"));
+    TEST_ASSERT_FALSE(link_linknames_equal("", "a/"));
+    TEST_ASSERT_FALSE(link_linknames_equal("a", "b"));
+}
+
+void test_link_hash_str(void)
+{
+    unsigned int h1 = link_hash_str("file.txt");
+    unsigned int h2 = link_hash_str("file.txt/");
+    unsigned int h3 = link_hash_str("file.txt//");
+    TEST_ASSERT_EQUAL_UINT(h1, h2);
+    TEST_ASSERT_EQUAL_UINT(h1, h3);
+
+    unsigned int h4 = link_hash_str("dir");
+    unsigned int h5 = link_hash_str("dir/");
+    TEST_ASSERT_EQUAL_UINT(h4, h5);
+
+    unsigned int h6 = link_hash_str("other");
+    TEST_ASSERT_NOT_EQUAL(h1, h6);
+}
+
+void test_LinkHashSet(void)
+{
+    LinkHashSet *set = LinkHashSet_new(4);
+    TEST_ASSERT_NOT_NULL(set);
+
+    TEST_ASSERT_EQUAL_INT(1, LinkHashSet_add(set, "file.txt"));
+    TEST_ASSERT_EQUAL_INT(0, LinkHashSet_add(set, "file.txt"));
+    TEST_ASSERT_EQUAL_INT(0, LinkHashSet_add(set, "file.txt/"));
+    TEST_ASSERT_EQUAL_INT(1, LinkHashSet_add(set, "file.txt//"));
+
+    TEST_ASSERT_EQUAL_INT(1, LinkHashSet_add(set, "other.txt"));
+    TEST_ASSERT_EQUAL_INT(1, LinkHashSet_add(set, "another.txt"));
+
+    // Trigger a resize by adding more items
+    TEST_ASSERT_EQUAL_INT(1, LinkHashSet_add(set, "resize1.txt"));
+    TEST_ASSERT_EQUAL_INT(1, LinkHashSet_add(set, "resize2.txt"));
+    TEST_ASSERT_EQUAL_INT(0, LinkHashSet_add(set, "resize1.txt"));
+
+    LinkHashSet_free(set);
+}
+
+void test_LinkTable_parse_html_duplicates(void)
+{
+    LinkTable *table = LinkTable_alloc("https://example.com/dir/");
+    TEST_ASSERT_NOT_NULL(table);
+    TEST_ASSERT_EQUAL_INT(1, table->size); // Just the head link
+
+    const char *html = "<html>\n"
+                       "<body>\n"
+                       "  <a href=\"a.txt\">a.txt</a>\n"
+                       "  <a href=\"a.txt\">a.txt duplicate</a>\n"
+                       "  <a href=\"a.txt/\">a.txt slash duplicate</a>\n"
+                       "  <a href=\"b.txt\">b.txt</a>\n"
+                       "  <a href=\"b.txt/\">b.txt slash duplicate</a>\n"
+                       "</body>\n"
+                       "</html>\n";
+
+    LinkTable_parse_html(table, "https://example.com/dir/", html);
+
+    // Should have size 3: HEAD link, a.txt, and b.txt
+    TEST_ASSERT_EQUAL_INT(3, table->size);
+
+    TEST_ASSERT_EQUAL_STRING("", table->links[0]->linkname);
+    TEST_ASSERT_EQUAL_STRING("a.txt", table->links[1]->linkname);
+    TEST_ASSERT_EQUAL_STRING("b.txt", table->links[2]->linkname);
+
+    LinkTable_free(table);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_LinkTable_alloc);
     RUN_TEST(test_LinkTable_add);
     RUN_TEST(test_Link_download_zero_length);
+    RUN_TEST(test_link_linknames_equal);
+    RUN_TEST(test_link_hash_str);
+    RUN_TEST(test_LinkHashSet);
+    RUN_TEST(test_LinkTable_parse_html_duplicates);
     return UNITY_END();
 }


### PR DESCRIPTION
Replace the O(N^2) linear scan for duplicate links in HTML_to_LinkTable with a custom open-addressing hash set (LinkHashSet) using linear probing.

This significantly speeds up duplicate link detection when parsing directories containing a large number of links.

Changes:
- Implement LinkHashSet with dynamic resizing, using the djb2-based hash_str function that strips trailing slashes to preserve duplicate detection semantics.
- Replace the nested loop search in HTML_to_LinkTable with calls to LinkHashSet_contains and LinkHashSet_add.
- Initialize and free the LinkHashSet structure within LinkTable_new.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved link deduplication during HTML import so duplicate links (including common trailing-slash variants) are suppressed for cleaner, smaller link lists.

* **New Features**
  * Added a dedicated HTML-parse-and-populate API that uses the new deduplication path.

* **Tests**
  * Added unit tests for link normalization, hashing and deduplication and an integration test validating directory-listing deduplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->