### PR TITLE
feat: cache min/max size thresholds

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -6,8 +6,72 @@ configuration and usage flags supported by HTTPDirFS.
 
 ### Command Syntax
 
+Below is the raw help output displaying all available flags:
+
 ```bash
-httpdirfs [options] URL mountpoint
+usage: httpdirfs [options] URL mountpoint
+
+general options:
+        --config            Specify a configuration file
+    -o opt,[opt...]         Mount options
+    -h  --help              Print help
+    -V  --version           Print version
+    -f                      Foreground operation
+    -s                      Disable multi-threaded operation
+    -d  --debug             Enable debug output (implies -f)
+
+HTTPDirFS options:
+    -u  --username          HTTP authentication username
+    -p  --password          HTTP authentication password
+    -P  --proxy             Proxy for libcurl, for more details refer to
+                            https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html
+        --proxy-username    Username for the proxy
+        --proxy-password    Password for the proxy
+        --proxy-cacert      Certificate authority for the proxy
+        --proxy-capath      Certificate authority directory for the proxy
+        --cache             Enable cache (default: off)
+        --cache-location    Set a custom cache location
+                            (default: "${XDG_CACHE_HOME}/httpdirfs")
+        --cache-clear       Delete the cache directory or the custom location
+                            specified with `--cache-location`, if the option is
+                            seen first. Then exit in either case.
+        --cache-min-size    Set minimum file size threshold for caching, in bytes
+                            (default: none)
+        --cache-max-size    Set maximum file size threshold for caching, in bytes
+                            (default: none)
+        --cacert            Certificate authority for the server
+        --capath            Certificate authority directory for the server
+        --dl-seg-size       Set cache download segment size, in MB (default: 8)
+                            Note: this setting is ignored if previously
+                            cached data is found for the requested file.
+        --http-header       Set one or more HTTP headers
+        --max-conns         Set maximum number of network connections that
+                            libcurl is allowed to make. (default: 6)
+        --refresh-timeout   The directories are refreshed after the specified
+                            time, in seconds (default: 3600)
+        --retry-wait        Set delay in seconds before retrying an HTTP request
+                            after encountering an error. (default: 5)
+        --invalid-refresh   Try refreshing invalid links when reading a directory.
+        --user-agent        Set user agent string (default: "HTTPDirFS-1.3.1")
+        --no-range-check    Disable the built-in check for the server's support
+                            for HTTP range requests
+        --zero-len-is-dir   If a file has a zero length, treat it as a directory
+        --insecure-tls      Disable licurl TLS certificate verification by
+                            setting CURLOPT_SSL_VERIFYHOST to 0
+        --external-links    Include external (cross-origin) links from
+                            directory listings (default: off)
+        --single-file-mode  Single file mode - rather than mounting a whole
+                            directory, present a single file inside a virtual
+                            directory.
+
+    For mounting a Airsonic / Subsonic server:
+        --sonic-username    The username for your Airsonic / Subsonic server
+        --sonic-password    The password for your Airsonic / Subsonic server
+        --sonic-id3         Enable ID3 mode - this present the server content in
+                            Artist/Album/Song layout
+        --sonic-insecure    Authenticate against your Airsonic / Subsonic server
+                            using the insecure username / hex encoded password
+                            scheme
 ```
 
 ---
@@ -148,6 +212,20 @@ httpdirfs [options] URL mountpoint
 - **Default:** `8`
 - **Note:** This setting is ignored for files that already have existing cached
   segment data on disk.
+
+#### `--cache-min-size <bytes>`
+
+- **Description:** Sets the minimum file size threshold for caching in bytes.
+  Files with a size smaller than this threshold will bypass the local disk cache
+  and be downloaded directly from the network upon access.
+- **Default:** None (no minimum limit is set).
+
+#### `--cache-max-size <bytes>`
+
+- **Description:** Sets the maximum file size threshold for caching in bytes.
+  Files with a size larger than this threshold will bypass the local disk cache
+  and be downloaded directly from the network upon access.
+- **Default:** None (no maximum limit is set).
 
 ---
 

--- a/src/config.c
+++ b/src/config.c
@@ -86,6 +86,9 @@ void Config_init(void)
 
     CONFIG.data_blksz = DEFAULT_DATA_BLKSZ;
 
+    CONFIG.cache_min_size = -1;
+    CONFIG.cache_max_size = -1;
+
     /*-------------- Sonic related -------------*/
     CONFIG.sonic_username = NULL;
 

--- a/src/config.h
+++ b/src/config.h
@@ -29,6 +29,7 @@
  */
 
 #include <limits.h>
+#include <sys/types.h>
 
 /**
  * \brief the default user agent string
@@ -126,6 +127,10 @@ typedef struct {
     int data_blksz;
     /** \brief The maximum segment count for a single cache file */
     int max_segbc;
+    /** \brief The minimum file size threshold for caching */
+    off_t cache_min_size;
+    /** \brief The maximum file size threshold for caching */
+    off_t cache_max_size;
     /*-------------- Sonic related -------------*/
     /** \brief The Sonic server username */
     char *sonic_username;

--- a/src/fuse_local.c
+++ b/src/fuse_local.c
@@ -29,6 +29,7 @@
 #include "fuse_local.h"
 
 #include "cache.h"
+#include "config.h"
 #include "link.h"
 #include "log.h"
 
@@ -122,8 +123,17 @@ static int fs_read(const char *path, char *buf, size_t size, off_t offset,
         if (fi->fh) {
             received = Cache_read((Cache *)fi->fh, buf, size, offset);
         } else {
-            /* zero-length file: fi->fh was set to 0 in fs_open; return EOF */
-            received = 0;
+            Link *link = path_to_Link(path);
+            if (link) {
+                if (link->content_length == 0) {
+                    received = 0;
+                } else {
+                    received = path_download(path, buf, size, offset);
+                }
+                LinkTable_unref(link->parent_table);
+            } else {
+                received = -ENOENT;
+            }
         }
     } else {
         received = path_download(path, buf, size, offset);
@@ -146,6 +156,30 @@ static int fs_open(const char *path, struct fuse_file_info *fi)
     if (CACHE_SYSTEM_INIT) {
         if (link->content_length == 0) {
             fi->fh = 0; /* valid empty file: bypass cache creation */
+            LinkTable_unref(link->parent_table);
+            return 0;
+        }
+        int bypass_cache = 0;
+        /* Portable overflow guard: compare against the maximum value
+         * that off_t can represent. If content_length exceeds this,
+         * it cannot be safely cast to off_t, so we skip cache for
+         * abnormally large files (if a max threshold is configured).
+         */
+        const size_t off_t_max
+            = (sizeof(off_t) >= 8) ? (size_t)LLONG_MAX : (size_t)INT_MAX;
+        if (link->content_length > off_t_max) {
+            bypass_cache = 1;
+        } else {
+            off_t file_size = (off_t)link->content_length;
+            if ((CONFIG.cache_min_size >= 0
+                 && file_size < CONFIG.cache_min_size)
+                || (CONFIG.cache_max_size >= 0
+                    && file_size > CONFIG.cache_max_size)) {
+                bypass_cache = 1;
+            }
+        }
+        if (bypass_cache) {
+            fi->fh = 0; /* bypass cache creation due to size thresholds */
             LinkTable_unref(link->parent_table);
             return 0;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -353,6 +353,8 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
            {"capath", required_argument, NULL, 'L'},          /* 29 */
            {"proxy-capath", required_argument, NULL, 'L'},    /* 30 */
            {"external-links", no_argument, NULL, 'L'},        /* 31 */
+           {"cache-min-size", required_argument, NULL, 'L'},  /* 32 */
+           {"cache-max-size", required_argument, NULL, 'L'},  /* 33 */
            {0, 0, 0, 0}};
     while ((c = getopt_long(argc, argv, short_opts, long_opts, &long_index))
            != -1) {
@@ -469,6 +471,32 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
             case 31:
                 CONFIG.external_links = 1;
                 break;
+            case 32: {
+                char *endptr;
+                errno = 0;
+                long long val = strtoll(optarg, &endptr, 10);
+                if (errno != 0 || endptr == optarg || *endptr != '\0' || val < 0
+                    || (long long)(off_t)val != val) {
+                    fprintf(stderr,
+                            "Error: --cache-min-size requires a "
+                            "non-negative integer within off_t range\n");
+                    return 1;
+                }
+                CONFIG.cache_min_size = (off_t)val;
+            } break;
+            case 33: {
+                char *endptr;
+                errno = 0;
+                long long val = strtoll(optarg, &endptr, 10);
+                if (errno != 0 || endptr == optarg || *endptr != '\0' || val < 0
+                    || (long long)(off_t)val != val) {
+                    fprintf(stderr,
+                            "Error: --cache-max-size requires a "
+                            "non-negative integer within off_t range\n");
+                    return 1;
+                }
+                CONFIG.cache_max_size = (off_t)val;
+            } break;
             default:
                 fprintf(stderr, "see httpdirfs -h for usage\n");
                 return 1;
@@ -487,6 +515,12 @@ static int parse_arg_list(int argc, char **argv, char ***fuse_argv,
             add_arg(fuse_argv, fuse_argc, arg_buf);
         }
     };
+    if (CONFIG.cache_min_size >= 0 && CONFIG.cache_max_size >= 0
+        && CONFIG.cache_min_size > CONFIG.cache_max_size) {
+        fprintf(stderr, "Error: --cache-min-size cannot be greater than "
+                        "--cache-max-size\n");
+        return 1;
+    }
     return 0;
 }
 
@@ -532,6 +566,10 @@ HTTPDirFS options:\n\
         --cache-clear       Delete the cache directory or the custom location\n\
                             specified with `--cache-location`, if the option is\n\
                             seen first. Then exit in either case.\n\
+        --cache-min-size    Set minimum file size threshold for caching, in bytes\n\
+                            (default: none)\n\
+        --cache-max-size    Set maximum file size threshold for caching, in bytes\n\
+                            (default: none)\n\
         --cacert            Certificate authority for the server\n\
         --capath            Certificate authority directory for the server\n\
         --dl-seg-size       Set cache download segment size, in MB (default: " XSTR(

--- a/tests/integration/run_integration_test.sh
+++ b/tests/integration/run_integration_test.sh
@@ -761,6 +761,148 @@ fi
 # Stop the external HTTP server
 cleanup_ext
 log_info "External HTTP server stopped."
+
+    # ── Test 7: Cache size thresholds ───────────────────────────────────────────
+    log_info "Test group: Cache size thresholds"
+
+    # --- Test 7a: cache-min-size threshold ---
+    log_info "Subgroup: Cache minimum size threshold"
+    rm -rf "${CACHE_DIR:?}"
+    mkdir -p "${CACHE_DIR}"
+
+    "${HTTPDIRFS_BIN}" \
+        -f \
+        --cache \
+        --cache-location "${CACHE_DIR}" \
+        --cache-min-size 1024 \
+        "${BASE_URL}" \
+        "${CACHE_MOUNT_DIR}" &
+    THRESH_PID=$!
+
+    # Wait for mount
+    for i in $(seq 1 "${MOUNT_TIMEOUT}"); do
+        if mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+
+    if ! mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
+        fail "httpdirfs (cache-min-size) failed to mount."
+        kill "${THRESH_PID}" 2>/dev/null || true
+    else
+        # Read tiny.txt (1 byte, should not be cached)
+        tiny_content=$(cat "${CACHE_MOUNT_DIR}/tiny.txt")
+        if [[ -n "${tiny_content}" ]]; then
+            pass "cache-min-size: tiny.txt read successfully"
+        else
+            fail "cache-min-size: tiny.txt read failed"
+        fi
+
+        # Read simple.txt (should be cached as it is > 1024 bytes)
+        cat "${CACHE_MOUNT_DIR}/simple.txt" > /dev/null
+
+        # Check cache directory
+        # tiny.txt should NOT have a cache file
+        tiny_cache_file=$(find "${CACHE_DIR}/meta" -type f -name "*tiny.txt" 2>/dev/null)
+        if [[ -z "${tiny_cache_file}" ]]; then
+            pass "cache-min-size: tiny.txt (1 byte) was NOT cached (correct)"
+        else
+            fail "cache-min-size: tiny.txt (1 byte) was unexpectedly cached"
+        fi
+
+        # simple.txt should have a cache file
+        simple_cache_file=$(find "${CACHE_DIR}/meta" -type f -name "*simple.txt" 2>/dev/null)
+        if [[ -n "${simple_cache_file}" ]]; then
+            pass "cache-min-size: simple.txt was cached (correct)"
+        else
+            fail "cache-min-size: simple.txt was NOT cached"
+        fi
+
+        do_unmount "${CACHE_MOUNT_DIR}"
+        wait "${THRESH_PID}" 2>/dev/null || true
+    fi
+
+    # --- Test 7b: cache-max-size threshold ---
+    log_info "Subgroup: Cache maximum size threshold"
+    rm -rf "${CACHE_DIR:?}"
+    mkdir -p "${CACHE_DIR}"
+
+    # We set max size to 100 bytes. tiny.txt (1 byte) is cached, simple.txt (> 1024 bytes) is not.
+    "${HTTPDIRFS_BIN}" \
+        -f \
+        --cache \
+        --cache-location "${CACHE_DIR}" \
+        --cache-max-size 100 \
+        "${BASE_URL}" \
+        "${CACHE_MOUNT_DIR}" &
+    THRESH_PID=$!
+
+    # Wait for mount
+    for i in $(seq 1 "${MOUNT_TIMEOUT}"); do
+        if mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+
+    if ! mountpoint -q "${CACHE_MOUNT_DIR}" 2>/dev/null; then
+        fail "httpdirfs (cache-max-size) failed to mount."
+        kill "${THRESH_PID}" 2>/dev/null || true
+    else
+        # Read tiny.txt (should be cached)
+        cat "${CACHE_MOUNT_DIR}/tiny.txt" > /dev/null
+
+        # Read simple.txt (should not be cached)
+        cat "${CACHE_MOUNT_DIR}/simple.txt" > /dev/null
+
+        # Check cache directory
+        # tiny.txt should have a cache file
+        tiny_cache_file=$(find "${CACHE_DIR}/meta" -type f -name "*tiny.txt" 2>/dev/null)
+        if [[ -n "${tiny_cache_file}" ]]; then
+            pass "cache-max-size: tiny.txt (1 byte) was cached (correct)"
+        else
+            fail "cache-max-size: tiny.txt (1 byte) was NOT cached"
+        fi
+
+        # simple.txt should NOT have a cache file
+        simple_cache_file=$(find "${CACHE_DIR}/meta" -type f -name "*simple.txt" 2>/dev/null)
+        if [[ -z "${simple_cache_file}" ]]; then
+            pass "cache-max-size: simple.txt (>100 bytes) was NOT cached (correct)"
+        else
+            fail "cache-max-size: simple.txt (>100 bytes) was unexpectedly cached"
+        fi
+
+        do_unmount "${CACHE_MOUNT_DIR}"
+        wait "${THRESH_PID}" 2>/dev/null || true
+    fi
+
+    # --- Test 7c: cache size invalid and inconsistent parameter checks ---
+    log_info "Subgroup: Cache size threshold invalid parameter validation"
+
+    # Test negative cache-min-size
+    err_out=$("${HTTPDIRFS_BIN}" --cache --cache-min-size -50 "${BASE_URL}" "${CACHE_MOUNT_DIR}" 2>&1 || true)
+    if [[ "${err_out}" == *"Error: --cache-min-size requires a non-negative integer"* ]]; then
+        pass "cache size validation: negative --cache-min-size rejected (correct)"
+    else
+        fail "cache size validation: negative --cache-min-size not rejected correctly: ${err_out}"
+    fi
+
+    # Test non-numeric cache-max-size
+    err_out=$("${HTTPDIRFS_BIN}" --cache --cache-max-size abc "${BASE_URL}" "${CACHE_MOUNT_DIR}" 2>&1 || true)
+    if [[ "${err_out}" == *"Error: --cache-max-size requires a non-negative integer"* ]]; then
+        pass "cache size validation: non-numeric --cache-max-size rejected (correct)"
+    else
+        fail "cache size validation: non-numeric --cache-max-size not rejected correctly: ${err_out}"
+    fi
+
+    # Test min-size > max-size inconsistency
+    err_out=$("${HTTPDIRFS_BIN}" --cache --cache-min-size 1000 --cache-max-size 500 "${BASE_URL}" "${CACHE_MOUNT_DIR}" 2>&1 || true)
+    if [[ "${err_out}" == *"Error: --cache-min-size cannot be greater than --cache-max-size"* ]]; then
+        pass "cache size validation: min > max consistency check rejected (correct)"
+    else
+        fail "cache size validation: min > max inconsistency not rejected correctly: ${err_out}"
+    fi
 fi
 
 # ─── Step 6: Cache mode with multithreaded reads ────────────────────────────

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -26,6 +26,8 @@ void test_Config_init(void)
     TEST_ASSERT_EQUAL_INT(0, CONFIG.cache_enabled);
     TEST_ASSERT_EQUAL_STRING(DEFAULT_USER_AGENT, CONFIG.user_agent);
     TEST_ASSERT_NULL(CONFIG.http_username);
+    TEST_ASSERT_EQUAL_INT64(-1, (int64_t)CONFIG.cache_min_size);
+    TEST_ASSERT_EQUAL_INT64(-1, (int64_t)CONFIG.cache_max_size);
 }
 
 int main(void)


### PR DESCRIPTION
This pull request adds two new command line options to httpdirfs:
- `--cache-min-size <bytes>`: files smaller than this size will bypass caching and download directly from the network.
- `--cache-max-size <bytes>`: files larger than this size will bypass caching and download directly from the network.

By default, these thresholds are unset.

Includes:
- Command-line parsing of the new options.
- Cache bypass integration in the FUSE layer.
- Unit tests verifying configuration defaults.
- Integration tests validating the cache size limits.
- Complete documentation in `USAGE.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --cache-min-size and --cache-max-size to control which files bypass the local disk cache (files smaller than min or larger than max are fetched from the network).

* **Documentation**
  * Usage guide and CLI help updated to document both options and their “(default: none)” behavior.

* **Validation**
  * Startup defaults set; CLI rejects negative/malformed values and enforces min ≤ max.

* **Tests**
  * Integration and unit tests added for threshold behavior and input validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->