### PR TITLE
ci: add actions workflow scan to CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,20 +9,18 @@ on:
     - cron: '18 19 * * 1'
 
 jobs:
-  analyze:
-    name: Analyze
+  analyze-c:
+    name: Analyze C
     runs-on: 'ubuntu-latest'
     timeout-minutes: 360
     permissions:
       security-events: write
-
       actions: read
       contents: read
 
     strategy:
       fail-fast: true
       matrix:
-        language: [ 'c-cpp' ]
         buildtype: [ 'debug', 'release' ]
 
     steps:
@@ -39,7 +37,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
-        languages: ${{ matrix.language }}
+        languages: c
 
     - name: Setup Meson
       run: meson setup builddir -Dbuildtype=${{ matrix.buildtype }}
@@ -50,4 +48,27 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
       with:
-        category: "/language:${{matrix.language}}/buildtype:${{matrix.buildtype}}"
+        category: "/language:c/buildtype:${{matrix.buildtype}}"
+
+  analyze-actions:
+    name: Analyze Actions
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: actions
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:actions"


### PR DESCRIPTION
This PR adds a dedicated job to scan GitHub Actions workflow files with CodeQL, while keeping the main C scan streamlined and target-specific.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CodeQL analysis workflow organization by restructuring the GitHub Actions pipeline to run separate analysis jobs for different language types, enhancing maintainability and clarity of the continuous integration process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fangfufu/httpdirfs/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->