### PR TITLE
Potential fix for code scanning alert no. 100: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
     branches: ["master"]
   pull_request:
     branches: ["master"]
+permissions:
+  contents: read
 jobs:
   build-mac:
     name: Build (macOS, ${{ matrix.buildtype }})

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   push:
     branches: [master]
+permissions:
+  contents: read
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fangfufu/httpdirfs/security/code-scanning/100](https://github.com/fangfufu/httpdirfs/security/code-scanning/100)

Add an explicit top-level `permissions` block in `.github/workflows/build.yml` so all jobs inherit least-privilege token access.  
For this workflow, `contents: read` is the minimal and sufficient permission based on shown steps (checkout, build/test, artifact upload), and it does not change intended functionality.

Best single fix:
- Edit `.github/workflows/build.yml` near the top (after `on:` triggers and before `jobs:`).
- Add:
  - `permissions:`
  - `  contents: read`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to explicitly specify repository content access scopes for enhanced security and proper access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->