### PR TITLE
test: update unity subproject to latest master commit

### DIFF
--- a/subprojects/unity.wrap
+++ b/subprojects/unity.wrap
@@ -1,4 +1,5 @@
 [wrap-git]
 directory = unity
 url = https://github.com/ThrowTheSwitch/Unity.git
-revision = 860062d51b2e8a75d150337b63ca2a472840d13c
+# master branch latest commit (2026-05-29)
+revision = bbf8f3728a937c7627b8094de7ae13559d220ed5


### PR DESCRIPTION
Updates the unity test framework wrap file to point to the latest commit on the master branch (bbf8f37) from 2026-05-29.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated subproject to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->